### PR TITLE
fix: Display an error message when attempting to index a repo without a config file and embeddings are enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,26 @@ uv tool install chunkhound
 
 ## Quick Start
 
+### Option 1: With Embeddings (Recommended)
+
+
+1. Create `.chunkhound.json` in project root file
+```json
+{
+  "embedding": {
+    "provider": "openai",
+    "api_key": "your-api-key-here"
+  }
+}
+```
+2. Index your codebase
 ```bash
-# Index your codebase
 chunkhound index
+```
+
+### Option 2: Without embeddings (regex search only)
+```bash
+chunkhound index --no-embeddings
 ```
 
 **For configuration, IDE setup, and advanced usage, see the [documentation](https://ofriw.github.io/chunkhound).**

--- a/chunkhound/api/cli/commands/run.py
+++ b/chunkhound/api/cli/commands/run.py
@@ -143,7 +143,7 @@ def _validate_run_arguments(
     # Validate provider arguments
     if not args.no_embeddings:
         # Use unified config values if available, fall back to CLI args
-        if config:
+        if config and config.embedding:
             provider = config.embedding.provider
             api_key = (
                 config.embedding.api_key.get_secret_value()
@@ -153,10 +153,19 @@ def _validate_run_arguments(
             base_url = config.embedding.base_url
             model = config.embedding.model
         else:
-            provider = args.provider
-            api_key = args.api_key
-            base_url = args.base_url
-            model = args.model
+            # Check if CLI args have provider info
+            provider = getattr(args, 'provider', None)
+            api_key = getattr(args, 'api_key', None)
+            base_url = getattr(args, 'base_url', None)
+            model = getattr(args, 'model', None)
+            
+            # If no provider info found, provide helpful error
+            if not provider:
+                formatter.error("No embedding provider configured.")
+                formatter.info("To fix this, you can:")
+                formatter.info("  1. Create a .chunkhound.json config file with embedding settings")
+                formatter.info("  2. Use --no-embeddings to skip embeddings")
+                return False
 
         if not validate_provider_args(provider, api_key, base_url, model):
             return False

--- a/tests/test_config_missing_behavior.py
+++ b/tests/test_config_missing_behavior.py
@@ -1,0 +1,59 @@
+"""Test behavior when config file is missing."""
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+class TestConfigMissingBehavior:
+    """Test behavior when config file is missing or incomplete."""
+
+    def test_index_without_config_shows_helpful_error(self):
+        """Test that running index without config shows a helpful error message."""
+        with tempfile.TemporaryDirectory() as test_dir:
+            # Run chunkhound index without any config
+            # Copy env and clear provider
+            env = os.environ.copy()
+            env.pop("CHUNKHOUND_EMBEDDING_PROVIDER", None)
+            env.pop("CHUNKHOUND_EMBEDDING__PROVIDER", None)
+            
+            result = subprocess.run(
+                ["uv", "run", "chunkhound", "index", test_dir],
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=30,
+            )
+            
+            # Should exit with error
+            assert result.returncode == 1, f"Expected exit code 1, got {result.returncode}"
+            
+            # Should show helpful error message
+            assert "No embedding provider configured" in result.stderr, f"Error message not found in stderr: {result.stderr}"
+            assert "Create a .chunkhound.json config file" in result.stdout, f"Config file suggestion not found in stdout: {result.stdout}"
+            assert "--no-embeddings" in result.stdout, f"--no-embeddings option not found in stdout: {result.stdout}"
+
+    def test_no_attribute_error_crash(self):
+        """Test that we don't get AttributeError when no config exists (the main bug fix)."""
+        with tempfile.TemporaryDirectory() as test_dir:
+            # Clear all embedding environment variables
+            env = os.environ.copy()
+            env.pop("CHUNKHOUND_EMBEDDING_PROVIDER", None)
+            env.pop("CHUNKHOUND_EMBEDDING__PROVIDER", None)
+            env.pop("CHUNKHOUND_EMBEDDING_API_KEY", None)
+            env.pop("CHUNKHOUND_EMBEDDING__API_KEY", None)
+            
+            result = subprocess.run(
+                ["uv", "run", "chunkhound", "index", test_dir],
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=30,
+            )
+            
+            # The critical fix: should not crash with AttributeError
+            assert "'NoneType' object has no attribute 'provider'" not in result.stderr, f"AttributeError crash found: {result.stderr}"
+            assert "AttributeError: 'Namespace' object has no attribute 'provider'" not in result.stderr, f"CLI AttributeError found: {result.stderr}"


### PR DESCRIPTION
  Fixes crash when running chunkhound index without configuration

  - Add null checks to prevent AttributeError when config.embedding is None
  - Show error message with setup instructions instead of crashing
  - Update README Quick Start with step-by-step configuration options
  - Add tests for missing config behavior

