### PR TITLE
Add Haskell parsing support (tree-sitter), incl. binds and pattern synonyms

### DIFF
--- a/chunkhound/core/types/common.py
+++ b/chunkhound/core/types/common.py
@@ -139,6 +139,7 @@ class Language(Enum):
     GROOVY = "groovy"
     KOTLIN = "kotlin"
     GO = "go"
+    HASKELL = "haskell"
     RUST = "rust"
     BASH = "bash"
     MAKEFILE = "makefile"
@@ -191,6 +192,7 @@ class Language(Enum):
             ".kt": cls.KOTLIN,
             ".kts": cls.KOTLIN,
             ".go": cls.GO,
+            ".hs": cls.HASKELL,
             ".sh": cls.BASH,
             ".bash": cls.BASH,
             ".zsh": cls.BASH,
@@ -240,6 +242,7 @@ class Language(Enum):
             Language.GROOVY,
             Language.KOTLIN,
             Language.GO,
+            Language.HASKELL,
             Language.RUST,
             Language.BASH,
             Language.MAKEFILE,
@@ -294,6 +297,7 @@ class Language(Enum):
             ".kt",
             ".kts",
             ".go",
+            ".hs",
             ".sh",
             ".bash",
             ".zsh",

--- a/chunkhound/parsers/mappings/__init__.py
+++ b/chunkhound/parsers/mappings/__init__.py
@@ -11,6 +11,7 @@ from .cpp import CppMapping
 from .csharp import CSharpMapping
 from .go import GoMapping
 from .groovy import GroovyMapping
+from .haskell import HaskellMapping
 from .java import JavaMapping
 from .javascript import JavaScriptMapping
 from .json import JsonMapping
@@ -36,6 +37,7 @@ __all__ = [
     "CSharpMapping",
     "GoMapping",
     "GroovyMapping",
+    "HaskellMapping",
     "JavaMapping",
     "JavaScriptMapping",
     "JsonMapping",

--- a/chunkhound/parsers/mappings/haskell.py
+++ b/chunkhound/parsers/mappings/haskell.py
@@ -1,0 +1,163 @@
+"""Haskell language mapping for the unified parser architecture.
+
+This mapping extracts semantic concepts from Haskell source using the
+Tree-sitter grammar. It leverages the base mapping adapter so function
+definitions, data/newtype declarations, type synonyms, and type classes can be
+fed into the universal ConceptExtractor.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from chunkhound.core.types.common import Language
+from chunkhound.parsers.mappings.base import BaseMapping
+
+if TYPE_CHECKING:
+    from tree_sitter import Node as TSNode
+
+try:
+    from tree_sitter import Node as TSNode
+
+    TREE_SITTER_AVAILABLE = True
+except ImportError:  # pragma: no cover - handled in runtime environments
+    TREE_SITTER_AVAILABLE = False
+    TSNode = Any  # type: ignore
+
+
+class HaskellMapping(BaseMapping):
+    """Haskell-specific mapping implementation."""
+
+    def __init__(self) -> None:
+        super().__init__(Language.HASKELL)
+
+    # BaseMapping abstract methods -------------------------------------------------
+    def get_function_query(self) -> str:
+        """Capture top-level function bindings."""
+        return """
+            (function
+                name: (_) @function_name
+            ) @function_def
+
+            (bind
+                name: (_) @function_name
+            ) @function_def
+
+            (pattern_synonym
+                (signature
+                    synonym: (_) @function_name
+                )
+            ) @function_def
+
+            (pattern_synonym
+                (equation
+                    synonym: (_) @function_name
+                )
+            ) @function_def
+        """
+
+    def get_class_query(self) -> str:
+        """Capture algebraic data types, newtypes, type synonyms, and type classes."""
+        return """
+            (data_type
+                name: (_) @class_name
+            ) @class_def
+
+            (newtype
+                name: (_) @class_name
+            ) @class_def
+
+            (type_synomym
+                name: (_) @class_name
+            ) @class_def
+
+            (type_family
+                name: (_) @class_name
+            ) @class_def
+
+            (data_family
+                name: (_) @class_name
+            ) @class_def
+
+            (instance
+                name: (_) @class_name
+            ) @class_def
+
+            (class
+                name: (_) @class_name
+            ) @class_def
+        """
+
+    def get_method_query(self) -> str:
+        """Capture methods defined inside type classes."""
+        return """
+            (class
+                declarations: (class_declarations
+                    (function
+                        name: (_) @method_name
+                    ) @method_def
+                )
+            )
+        """
+
+    def get_comment_query(self) -> str:
+        """Capture line, block, and Haddock comments."""
+        return """
+            (comment) @comment
+            (haddock) @comment
+        """
+
+    def extract_function_name(self, node: TSNode | None, source: str) -> str:
+        """Extract the bound function name, falling back when necessary."""
+        if not TREE_SITTER_AVAILABLE or node is None:
+            return self.get_fallback_name(node, "function")
+
+        # Functions and binds expose 'name'; pattern synonyms expose 'synonym'
+        name_node = node.child_by_field_name("name")
+        if name_node is None and node.type == "pattern_synonym":
+            name_node = node.child_by_field_name("synonym")
+        if name_node is None and node.child_count > 0:
+            name_node = node.child(0)
+
+        if name_node is not None:
+            text = self.get_node_text(name_node, source).strip()
+            if text:
+                return text
+
+        return self.get_fallback_name(node, "function")
+
+    def extract_class_name(self, node: TSNode | None, source: str) -> str:
+        """Extract the declared type name for data/newtype/class/type synonym."""
+        if not TREE_SITTER_AVAILABLE or node is None:
+            return self.get_fallback_name(node, "type")
+
+        name_node = node.child_by_field_name("name")
+        if name_node is None and node.child_count > 0:
+            name_node = node.child(0)
+
+        text = ""
+        if name_node is not None:
+            text = self.get_node_text(name_node, source).strip()
+
+        if node.type == "instance":
+            type_patterns = node.child_by_field_name("type_patterns")
+            if type_patterns is not None:
+                patterns_text = self.get_node_text(type_patterns, source).strip()
+                if patterns_text:
+                    text = f"{text} {patterns_text}".strip()
+        else:
+            param_field = node.child_by_field_name("type_params") or node.child_by_field_name(
+                "patterns"
+            )
+            if param_field is not None:
+                params_text = self.get_node_text(param_field, source).strip()
+                if params_text:
+                    text = f"{text} {params_text}".strip()
+
+        if text:
+            return text
+
+        return self.get_fallback_name(node, "type")
+
+    # Optional overrides -----------------------------------------------------------
+    # Uses BaseMapping default filtering behaviour.

--- a/chunkhound/parsers/parser_factory.py
+++ b/chunkhound/parsers/parser_factory.py
@@ -25,6 +25,7 @@ from chunkhound.parsers.mappings import (
     CSharpMapping,
     GoMapping,
     GroovyMapping,
+    HaskellMapping,
     JavaMapping,
     JavaScriptMapping,
     JsonMapping,
@@ -117,6 +118,14 @@ except ImportError:
     GO_AVAILABLE = False
 
 try:
+    import tree_sitter_haskell as ts_haskell
+
+    HASKELL_AVAILABLE = True
+except ImportError:
+    ts_haskell = None
+    HASKELL_AVAILABLE = False
+
+try:
     import tree_sitter_rust as ts_rust
 
     RUST_AVAILABLE = True
@@ -166,6 +175,21 @@ try:
 except ImportError:
     ts_matlab = None
     MATLAB_AVAILABLE = False
+
+if not HASKELL_AVAILABLE:
+    try:
+        from tree_sitter_language_pack import get_language as _get_language_haskell
+
+        _haskell_lang = _get_language_haskell("haskell")
+        if _haskell_lang:
+            class _HaskellLanguageWrapper:
+                def language(self):
+                    return _haskell_lang
+
+            ts_haskell = _HaskellLanguageWrapper()
+            HASKELL_AVAILABLE = True
+    except ImportError:
+        pass
 
 # Markup and config languages
 try:
@@ -315,6 +339,9 @@ LANGUAGE_CONFIGS: dict[Language, LanguageConfig] = {
         ts_csharp, CSharpMapping, CSHARP_AVAILABLE, "c_sharp"
     ),
     Language.GO: LanguageConfig(ts_go, GoMapping, GO_AVAILABLE, "go"),
+    Language.HASKELL: LanguageConfig(
+        ts_haskell, HaskellMapping, HASKELL_AVAILABLE, "haskell"
+    ),
     Language.RUST: LanguageConfig(ts_rust, RustMapping, RUST_AVAILABLE, "rust"),
     Language.BASH: LanguageConfig(ts_bash, BashMapping, BASH_AVAILABLE, "bash"),
     Language.KOTLIN: LanguageConfig(
@@ -388,6 +415,7 @@ EXTENSION_TO_LANGUAGE: dict[str, Language] = {
     ".csx": Language.CSHARP,
     # Other languages
     ".go": Language.GO,
+    ".hs": Language.HASKELL,
     ".rs": Language.RUST,
     ".sh": Language.BASH,
     ".bash": Language.BASH,

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -21,6 +21,7 @@ LANGUAGE_SAMPLES = {
     Language.GROOVY: "def hello() { }",
     Language.KOTLIN: "fun hello() { }",
     Language.GO: "package main\nfunc main() { }",
+    Language.HASKELL: "add x y = x + y",
     Language.RUST: "fn main() { }",
     Language.BASH: "echo hello",
     Language.MAKEFILE: "all:\n\techo hello",


### PR DESCRIPTION
- Add Language.HASKELL and  extension mapping
  - core/types/common.py: add enum, extension detection, include in programming languages and get_all_extensions

- Wire Haskell into parser factory
  - parsers/parser_factory.py:
    - Try tree_sitter_haskell, fallback to tree_sitter_language_pack.get_language('haskell')
    - Register Language.HASKELL in LANGUAGE_CONFIGS
    - Map .hs in EXTENSION_TO_LANGUAGE

- Implement HaskellMapping
  - parsers/mappings/haskell.py:
    - Definitions: functions, binds, pattern synonyms (signature + equation), data/newtype, type/data families, classes, instances
    - Methods: class methods via declarations: (class_declarations (function …))
    - Comments: (comment) and (haddock)
    - Name extraction: handles pattern_synonym nested synonym field, includes instance type_patterns, appends type params where present
    - Grammar quirk handled: type_synomym spelling used by upstream grammar

- Export mapping
  - parsers/mappings/__init__.py: export HaskellMapping

- Tests
  - tests/test_parsers.py: add minimal Haskell snippet to parameterized samples

Rationale
- Extend multi-language coverage with Haskell, normalizing key constructs to universal concepts for consistent chunking and RAG.
- Include binds and pattern synonyms to improve recall for common Haskell code patterns.

Test Plan
- Haskell minimal path validated via parameterized parser tests.
- Parser loading smoke pass; CLI/MCP smoke needs non-sandboxed uv cache + sockets to pass locally.