### PR TITLE
Increase verbosity of the mcp server in the stdio mode

### DIFF
--- a/chunkhound/mcp/base.py
+++ b/chunkhound/mcp/base.py
@@ -156,7 +156,9 @@ class MCPServerBase(ABC):
 
             # Start real-time indexing service
             self.debug_log("Starting real-time indexing service")
-            self.realtime_indexing = RealtimeIndexingService(self.services, self.config)
+            self.realtime_indexing = RealtimeIndexingService(
+                self.services, self.config, debug_sink=self.debug_log
+            )
 
             # Start monitoring and wait for it to be ready
             monitoring_task = asyncio.create_task(


### PR DESCRIPTION
Title
  Increase MCP stdio verbosity; forward realtime indexing debug to MCP log

  Summary
  Improves observability when running the MCP server in stdio mode by routing realtime indexing lifecycle and event details into the MCP debug log.
  This makes it easier to diagnose indexing behavior without interfering with JSON-RPC.

  Key Changes

  - Add optional debug_sink to RealtimeIndexingService to emit detailed RT traces.
  - Wire MCPServerBase.debug_log into the realtime service so events land in /tmp/chunkhound_mcp_debug.log when CHUNKHOUND_DEBUG is enabled.
  - Log monitoring readiness, watchdog fallback decisions, queue/debounce actions, event types, and per-file processing summaries (chunks/embeddings).
  - Minor constructor update while keeping backward compatibility (new arg is optional).

  Files Changed

  - chunkhound/mcp/base.py (+3/−1): pass debug_sink=self.debug_log to realtime service.
  - chunkhound/services/realtime_indexing_service.py (+56/−4): add debug_sink, _debug() helper, and detailed event/processing traces.

  Totals: 2 files, 59 insertions, 5 deletions.

  How To Test

  - Enable debug mode: set CHUNKHOUND_DEBUG=1 (optionally CHUNKHOUND_DEBUG_FILE=/tmp/chunkhound_mcp_debug.log).
  - Start stdio server against a project directory:
      - uv run chunkhound mcp --stdio <path-to-project>
  - Create/modify/delete files under the watched path.
  - Verify rich RT logs in /tmp/chunkhound_mcp_debug.log showing:
      - startup: “RT: start watch …”, “monitoring ready” or polling fallback
      - event flow: queued/debounced items, event types, processing summaries with chunk/embedding counts

  Risks & Rollback

  - Low risk; change is additive and controlled by CHUNKHOUND_DEBUG.
  - Constructor signature remains compatible (new parameter is optional).
  - Rollback by reverting this PR.

  Notes For Reviewers

  - Focus on signal-to-noise: message prefixes use “RT:” to keep MCP logs scannable.
  - Confirm no stderr noise is introduced (stdio JSON-RPC remains clean).