### PR TITLE
Fix pattern matching engine not resolving **/ properly

### DIFF
--- a/chunkhound/utils/file_patterns.py
+++ b/chunkhound/utils/file_patterns.py
@@ -70,10 +70,14 @@ def should_exclude_path(
             if target_dir in rel_path.parts or target_dir in path.parts:
                 return True
         elif exclude_pattern.startswith("**/"):
-            # Pattern like **/*.db - check suffix against relative path and filename
-            suffix = exclude_pattern[3:]
-            compiled_suffix = compile_pattern(suffix, cache)
-            if compiled_suffix.match(rel_path_str) or compiled_suffix.match(path_name):
+            # Treat "**/..." like include logic: try full and simple variants
+            compiled_full = compile_pattern(exclude_pattern, cache)
+            compiled_simple = compile_pattern(exclude_pattern[3:], cache)
+            if (
+                compiled_full.match(rel_path_str)
+                or compiled_simple.match(rel_path_str)
+                or compiled_simple.match(path_name)
+            ):
                 return True
         else:
             # Regular pattern - use compiled regex for faster matching

--- a/tests/test_file_patterns_exclude.py
+++ b/tests/test_file_patterns_exclude.py
@@ -1,0 +1,31 @@
+import pytest
+from pathlib import Path
+
+from chunkhound.utils.file_patterns import should_exclude_path
+
+
+@pytest.mark.unit
+def test_exclude_pattern_with_double_star_prefix_matches_anywhere_in_tree():
+    base = Path('.')
+    # Simulate repo path
+    target = Path('monorepo/workflows-engine/camunda-cockpit-plugins/instance-route-history.js')
+
+    # User-specified exclude; should match regardless of leading segments
+    patterns = ["**/workflows-engine/camunda-cockpit-plugins/instance-route-history.js"]
+
+    assert should_exclude_path(target, base, patterns, {}) is True
+
+
+@pytest.mark.unit
+def test_exclude_pattern_without_double_star_needs_exact_prefix():
+    base = Path('.')
+    target = Path('monorepo/workflows-engine/camunda-cockpit-plugins/instance-route-history.js')
+
+    patterns = ["workflows-engine/camunda-cockpit-plugins/instance-route-history.js"]
+
+    # Depending on implementation, this may or may not match. This test
+    # documents that the double-star form is the portable one for matching
+    # the file at any depth, while the bare relative form should not match
+    # when there's a leading segment like 'monorepo/'.
+    assert should_exclude_path(target, base, patterns, {}) is False
+


### PR DESCRIPTION
## Testing  
- Add tests/test_file_patterns_exclude.py with two unit tests
      - Verifies “**/workflows-engine/camunda-cockpit-plugins/instance-route-history.js” excludes a deep path (expected True)
      - Control: bare relative pattern without “**/” does not match when leading segments exist (expected False)
  - Reproduces current bug where “**/” excludes are effectively anchored at path start
  - Repro: pytest -q tests/test_file_patterns_exclude.py
  - Will pass after making exclude “**/” handling mirror include logic (match full and simplified patterns against relpath/filename)

## Fix

Apply fix