### PR TITLE
Speed up MCP bootstrap by deferring parser construction

### DIFF
--- a/chunkhound/registry/__init__.py
+++ b/chunkhound/registry/__init__.py
@@ -8,8 +8,10 @@ Simplified from 540 lines to ~250 lines by:
 """
 
 import os
+from collections.abc import MutableMapping
 from pathlib import Path
-from typing import Any
+from threading import Lock
+from typing import Any, Callable
 
 from loguru import logger
 
@@ -25,6 +27,73 @@ from chunkhound.core.types.common import Language
 # Import new unified parser system
 from chunkhound.parsers.parser_factory import get_parser_factory
 
+
+class LazyLanguageParsers(MutableMapping[Language, Any]):
+    """Mapping that lazily materializes language parsers on first access."""
+
+    def __init__(self):
+        self._factories: dict[Language, Callable[[], Any]] = {}
+        self._instances: dict[Language, Any] = {}
+        self._lock = Lock()
+
+    def register_factory(
+        self, language: Language, factory: Callable[[], Any]
+    ) -> None:
+        """Register a factory used to materialize a parser lazily."""
+        self._factories[language] = factory
+
+    def materialized_copy(self) -> dict[Language, Any]:
+        """Return copy of parsers that have already been instantiated."""
+        with self._lock:
+            return dict(self._instances)
+
+    def __getitem__(self, key: Language) -> Any:
+        with self._lock:
+            if key in self._instances:
+                return self._instances[key]
+
+        factory = self._factories.get(key)
+        if factory is None:
+            raise KeyError(key)
+
+        parser = factory()
+        with self._lock:
+            existing = self._instances.get(key)
+            if existing is not None:
+                return existing
+            self._instances[key] = parser
+            return parser
+
+    def __setitem__(self, key: Language, value: Any) -> None:
+        with self._lock:
+            self._instances[key] = value
+            self._factories.pop(key, None)
+
+    def __delitem__(self, key: Language) -> None:
+        with self._lock:
+            self._instances.pop(key, None)
+            self._factories.pop(key, None)
+
+    def __iter__(self):
+        with self._lock:
+            combined = set(self._instances.keys()) | set(self._factories.keys())
+        return iter(combined)
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(set(self._instances.keys()) | set(self._factories.keys()))
+
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, Language):
+            return False
+        with self._lock:
+            return key in self._instances or key in self._factories
+
+    def clear(self) -> None:
+        with self._lock:
+            self._instances.clear()
+            self._factories.clear()
+
 # Import services
 from chunkhound.services.embedding_service import EmbeddingService
 from chunkhound.services.indexing_coordinator import IndexingCoordinator
@@ -37,7 +106,7 @@ class ProviderRegistry:
     def __init__(self):
         """Initialize the provider registry."""
         self._providers: dict[str, Any] = {}
-        self._language_parsers: dict[Language, Any] = {}
+        self._language_parsers: LazyLanguageParsers = LazyLanguageParsers()
         self._config: Config | None = None
 
     def configure(self, config: Config) -> None:
@@ -90,11 +159,14 @@ class ProviderRegistry:
 
     def get_language_parser(self, language: Language) -> Any | None:
         """Get parser for specified programming language."""
-        return self._language_parsers.get(language)
+        try:
+            return self._language_parsers[language]
+        except KeyError:
+            return None
 
     def get_all_language_parsers(self) -> dict[Language, Any]:
         """Get all registered language parsers."""
-        return self._language_parsers.copy()
+        return self._language_parsers.materialized_copy()
 
     def create_indexing_coordinator(self) -> IndexingCoordinator:
         """Create an IndexingCoordinator with all dependencies."""
@@ -280,11 +352,14 @@ class ProviderRegistry:
         for language, is_available in available_languages.items():
             if is_available:
                 try:
-                    parser = parser_factory.create_parser(language)
-                    self._language_parsers[language] = parser
-
+                    self._language_parsers.register_factory(
+                        language,
+                        lambda lang=language: parser_factory.create_parser(lang),
+                    )
                     if not os.environ.get("CHUNKHOUND_MCP_MODE"):
-                        logger.debug(f"Registered parser for {language.value}")
+                        logger.debug(
+                            f"Registered parser factory for {language.value}"
+                        )
                 except Exception as e:
                     if not os.environ.get("CHUNKHOUND_MCP_MODE"):
                         logger.warning(

--- a/tests/test_registry_lazy_parsers.py
+++ b/tests/test_registry_lazy_parsers.py
@@ -1,0 +1,48 @@
+"""Tests for lazy language parser instantiation in the registry."""
+
+from collections import defaultdict
+
+from chunkhound.core.types.common import Language
+from chunkhound.registry import ProviderRegistry
+
+
+def test_registry_lazily_instantiates_language_parsers(monkeypatch):
+    """Ensure parser factories are only invoked when a language is requested."""
+
+    class FakeParserFactory:
+        def __init__(self):
+            self.calls = defaultdict(int)
+
+        def get_available_languages(self):
+            return {Language.PYTHON: True, Language.JAVA: True}
+
+        def create_parser(self, language, cast_config=None):
+            self.calls[language] += 1
+            return f"parser-{language.value}"
+
+    fake_factory = FakeParserFactory()
+    monkeypatch.setattr(
+        "chunkhound.registry.get_parser_factory", lambda: fake_factory
+    )
+
+    registry = ProviderRegistry()
+    registry._language_parsers.clear()
+
+    # Register factories without instantiating parsers.
+    registry._setup_language_parsers()
+    assert fake_factory.calls == {}
+
+    # First access materializes parser exactly once.
+    parser_python = registry.get_language_parser(Language.PYTHON)
+    assert parser_python == "parser-python"
+    assert fake_factory.calls[Language.PYTHON] == 1
+
+    # Second access reuses cached parser.
+    parser_python_again = registry.get_language_parser(Language.PYTHON)
+    assert parser_python_again == parser_python
+    assert fake_factory.calls[Language.PYTHON] == 1
+
+    # Another language materializes independently.
+    parser_java = registry.get_language_parser(Language.JAVA)
+    assert parser_java == "parser-java"
+    assert fake_factory.calls[Language.JAVA] == 1


### PR DESCRIPTION
## Summary
    - introduce a LazyLanguageParsers helper and wire ProviderRegistry to use it so
      tree-sitter parsers are created on demand instead of during configure()
    - add a regression test that patches the parser factory to prove we only build
      a parser when the corresponding language is requested

## Testing
  - uv run pytest tests/test_registry_lazy_parsers.py
  - uv run pytest tests/test_smoke.py -v