### PR TITLE
fix(config): load reranking env vars in EmbeddingConfig.load_from_env()

### DIFF
--- a/chunkhound/core/config/embedding_config.py
+++ b/chunkhound/core/config/embedding_config.py
@@ -323,6 +323,19 @@ class EmbeddingConfig(BaseSettings):
         if model := os.getenv("CHUNKHOUND_EMBEDDING__MODEL"):
             config["model"] = model
 
+        # Reranking configuration
+        if rerank_model := os.getenv("CHUNKHOUND_EMBEDDING__RERANK_MODEL"):
+            config["rerank_model"] = rerank_model
+        if rerank_url := os.getenv("CHUNKHOUND_EMBEDDING__RERANK_URL"):
+            config["rerank_url"] = rerank_url
+        if rerank_format := os.getenv("CHUNKHOUND_EMBEDDING__RERANK_FORMAT"):
+            config["rerank_format"] = rerank_format
+        if rerank_batch_size := os.getenv("CHUNKHOUND_EMBEDDING__RERANK_BATCH_SIZE"):
+            try:
+                config["rerank_batch_size"] = int(rerank_batch_size)
+            except ValueError:
+                pass
+
         return config
 
     @classmethod


### PR DESCRIPTION
## Problem

`EmbeddingConfig.load_from_env()` was not loading reranking-related environment variables, causing providers to be created with `rerank_model=None` even when `CHUNKHOUND_EMBEDDING__RERANK_MODEL` was set.

This broke multi-hop semantic search when using environment-based configuration.

## Root Cause

`EmbeddingConfig` extends Pydantic's `BaseSettings` with `env_prefix="CHUNKHOUND_EMBEDDING__"`, but has a custom `load_from_env()` classmethod that manually loads only specific fields. This method was incomplete - it only loaded 4 fields (api_key, base_url, provider, model) and was missing all the reranking fields.

## Solution

Added loading for reranking environment variables:
- `CHUNKHOUND_EMBEDDING__RERANK_MODEL`
- `CHUNKHOUND_EMBEDDING__RERANK_URL`
- `CHUNKHOUND_EMBEDDING__RERANK_FORMAT`
- `CHUNKHOUND_EMBEDDING__RERANK_BATCH_SIZE`

## Testing

These environment variables were already documented in `tests/RERANKING_TEST_SETUP.md` and intended to work - this fix completes the existing API.

**Before:**
```
Creating VoyageAI provider: ... rerank_model=None
```

**After:**
```
Creating VoyageAI provider: ... rerank_model=rerank-2.5
VoyageAI reranking 90 documents with model rerank-2.5
```