### PR TITLE
Fix Claude Code CLI provider to use cross-platform temp directory

### DIFF
--- a/chunkhound/providers/llm/claude_code_cli_provider.py
+++ b/chunkhound/providers/llm/claude_code_cli_provider.py
@@ -6,7 +6,7 @@ using the user's existing Claude subscription instead of API credits.
 Note: This provider is configured for vanilla LLM behavior:
 - All tools disabled (Write, Edit, Bash, WebFetch, etc.)
 - MCP servers disabled via --strict-mcp-config
-- Workspace isolation (runs from /tmp to prevent context gathering)
+- Workspace isolation (runs from temp directory to prevent context gathering)
 - Clean API access without workspace overhead
 """
 
@@ -14,6 +14,7 @@ import asyncio
 import json
 import os
 import subprocess
+import tempfile
 from typing import Any
 
 from loguru import logger
@@ -141,11 +142,11 @@ class ClaudeCodeCLIProvider(LLMProvider):
                 # Create subprocess with neutral CWD to prevent workspace scanning
                 process = await asyncio.create_subprocess_exec(
                     *cmd,
-                    stdin=subprocess.DEVNULL,  # Prevent stdin inheritance (fixes MCP server freeze)
+                    stdin=subprocess.DEVNULL,  # Prevent stdin inheritance
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     env=env,
-                    cwd="/tmp",  # Run from neutral directory to avoid Claude CLI workspace context gathering
+                    cwd=tempfile.gettempdir(),  # Cross-platform temp directory
                 )
 
                 # Wrap communicate() with timeout (this is the long-running part)


### PR DESCRIPTION
Fixed a platform compatibility bug where the Claude Code CLI LLM provider used hardcoded `/tmp` as the working directory when spawning subprocesses. This directory doesn't exist on Windows, causing the provider to fail on Windows systems.

The fix replaces the Unix-specific `/tmp` path with Python's `tempfile.gettempdir()`, which returns the appropriate temp directory for the current platform (`C:\Users\<user>\AppData\Local\Temp` on Windows, `/tmp` on Unix-like systems). This maintains the existing workspace isolation behavior while ensuring cross-platform compatibility.

[PR_REVIEW_AGENT.md](https://github.com/user-attachments/files/23540130/PR_REVIEW_AGENT.md)
