### PR TITLE
fix(mcp): prevent server hanging on shutdown during background operations

### DIFF
--- a/chunkhound/mcp_server/stdio.py
+++ b/chunkhound/mcp_server/stdio.py
@@ -10,9 +10,9 @@ ARCHITECTURE: Global state required for stdio communication model
 from __future__ import annotations
 
 import asyncio
-import sys
-import os
 import logging
+import os
+import sys
 import warnings
 
 # CRITICAL: Suppress SWIG warnings that break JSON-RPC protocol in CI
@@ -23,9 +23,7 @@ warnings.filterwarnings(
 )
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any
-
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 # Try to import the official MCP SDK; if unavailable, we'll fall back to a
 # minimal stdio JSON-RPC loop sufficient for tests that only exercise the
@@ -105,7 +103,9 @@ class StdioMCPServer(MCPServerBase):
                         CodexCLIProvider,
                     )
 
-                    async def _stub_run_exec(self, text, cwd=None, max_tokens=1024, timeout=None, model=None):  # type: ignore[override]
+                    async def _stub_run_exec(
+                        self, text, cwd=None, max_tokens=1024, timeout=None, model=None
+                    ):  # type: ignore[override]
                         mark = os.getenv("CH_TEST_CODEX_MARK_FILE")
                         if mark:
                             try:
@@ -126,12 +126,23 @@ class StdioMCPServer(MCPServerBase):
                 # And if asked, force deep_research to call synthesis directly
                 if os.getenv("CH_TEST_FORCE_SYNTHESIS") == "1":
                     try:
-                        from chunkhound.mcp_server import tools as tools_mod  # noqa: WPS433
+                        from chunkhound.mcp_server import (
+                            tools as tools_mod,  # noqa: WPS433
+                        )
 
-                        async def _stub_deep_research_impl(*, services, embedding_manager, llm_manager, query, progress=None):
+                        async def _stub_deep_research_impl(
+                            *,
+                            services,
+                            embedding_manager,
+                            llm_manager,
+                            query,
+                            progress=None,
+                        ):
                             if llm_manager is None:
                                 try:
-                                    from chunkhound.llm_manager import LLMManager  # noqa: WPS433
+                                    from chunkhound.llm_manager import (
+                                        LLMManager,  # noqa: WPS433
+                                    )
 
                                     llm_manager = LLMManager(
                                         {"provider": "codex-cli", "model": "codex"},
@@ -145,7 +156,9 @@ class StdioMCPServer(MCPServerBase):
 
                         tools_mod.deep_research_impl = _stub_deep_research_impl  # type: ignore[assignment]
                         if "code_research" in tools_mod.TOOL_REGISTRY:
-                            tools_mod.TOOL_REGISTRY["code_research"].implementation = _stub_deep_research_impl  # type: ignore[index]
+                            tools_mod.TOOL_REGISTRY[
+                                "code_research"
+                            ].implementation = _stub_deep_research_impl  # type: ignore[index]
                     except Exception:
                         pass
         except Exception:
@@ -158,6 +171,7 @@ class StdioMCPServer(MCPServerBase):
             self.server = None  # type: ignore
         else:
             from mcp.server import Server  # noqa: WPS433
+
             self.server: Server = Server("ChunkHound Code Search")
 
         # Event to signal initialization completion
@@ -267,6 +281,7 @@ class StdioMCPServer(MCPServerBase):
                 async with self.server_lifespan():
                     # Run the stdio server
                     import mcp.server.stdio  # noqa: WPS433
+
                     async with mcp.server.stdio.stdio_server() as (
                         read_stream,
                         write_stream,
@@ -280,13 +295,18 @@ class StdioMCPServer(MCPServerBase):
             else:
                 # Minimal fallback stdio: immediately emit a valid initialize response
                 # so tests can proceed without the official MCP SDK.
-                import json, os as _os
+                import json
+                import os as _os
+
                 resp = {
                     "jsonrpc": "2.0",
                     "id": 1,
                     "result": {
                         "protocolVersion": "2024-11-05",
-                        "serverInfo": {"name": "ChunkHound Code Search", "version": __version__},
+                        "serverInfo": {
+                            "name": "ChunkHound Code Search",
+                            "version": __version__,
+                        },
                         "capabilities": {},
                     },
                 }
@@ -303,6 +323,7 @@ class StdioMCPServer(MCPServerBase):
             self.debug_log(f"Server error: {e}")
             if self.debug_mode:
                 import traceback
+
                 traceback.print_exc(file=sys.stderr)
 
 


### PR DESCRIPTION
## Problem
MCP server hangs indefinitely when terminated during background operations (initial scan, file monitoring). Background tasks were never tracked or cancelled.

## Solution
- Track all background tasks with automatic cleanup
- Add cancellation checkpoints for responsive shutdown  
- Cancel tasks with 10s timeout before closing database

## Changes
- `base.py`: Added `_background_tasks` set and `_track_task()` helper
- `base.py`: Enhanced `cleanup()` to cancel all tracked tasks with timeout
- `base.py`: Added `CancelledError` handlers for graceful task termination

## Testing
- Small repo: <1s shutdown
- Large repo (100 files mid-scan): <10s shutdown
- Clean exit codes, no zombie processes