### PR TITLE
feat(anthropic): add native structured outputs with Pydantic support

### DIFF
--- a/chunkhound/interfaces/llm_provider.py
+++ b/chunkhound/interfaces/llm_provider.py
@@ -1,8 +1,81 @@
 """LLM Provider Interface for ChunkHound deep research."""
 
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def _normalize_schema_for_structured_outputs(schema: dict[str, Any]) -> dict[str, Any]:
+    """Recursively normalize a JSON schema for structured outputs.
+
+    Forces 'additionalProperties: false' on all object types in the schema,
+    including nested objects and $defs. This is required by Anthropic's
+    structured outputs API - any other value will cause a 400 error.
+
+    Args:
+        schema: JSON schema dictionary to normalize
+
+    Returns:
+        Normalized schema with additionalProperties: false on all objects
+    """
+    if not isinstance(schema, dict):
+        return schema  # type: ignore[unreachable]  # Defensive guard for runtime
+
+    result = schema.copy()
+
+    # Force additionalProperties: false on all object types
+    # Anthropic's structured outputs API does not support any other value
+    if result.get("type") == "object":
+        existing = result.get("additionalProperties")
+        if existing is not None and existing is not False:
+            logger.warning(
+                "additionalProperties=%r not supported by structured outputs API, "
+                "forcing to false",
+                existing,
+            )
+        result["additionalProperties"] = False
+
+    # Recursively process $defs (Pydantic's way of defining nested models)
+    if "$defs" in result:
+        result["$defs"] = {
+            name: _normalize_schema_for_structured_outputs(def_schema)
+            for name, def_schema in result["$defs"].items()
+        }
+
+    # Recursively process properties
+    if "properties" in result:
+        result["properties"] = {
+            name: _normalize_schema_for_structured_outputs(prop_schema)
+            for name, prop_schema in result["properties"].items()
+        }
+
+    # Process array items
+    if "items" in result:
+        result["items"] = _normalize_schema_for_structured_outputs(result["items"])
+
+    # Process prefixItems (Pydantic tuples generate this)
+    if "prefixItems" in result:
+        result["prefixItems"] = [
+            _normalize_schema_for_structured_outputs(item_schema)
+            for item_schema in result["prefixItems"]
+        ]
+
+    # Process anyOf/oneOf/allOf
+    for key in ("anyOf", "oneOf", "allOf"):
+        if key in result:
+            result[key] = [
+                _normalize_schema_for_structured_outputs(sub_schema)
+                for sub_schema in result[key]
+            ]
+
+    return result
 
 
 @dataclass
@@ -60,8 +133,8 @@ class LLMProvider(ABC):
         """
         Generate a structured JSON completion conforming to the given schema.
 
-        Best practice for GPT-5-Nano and modern LLMs: Use response_format with
-        json_schema and strict: true to guarantee valid, parseable output.
+        Uses native structured outputs with constrained decoding for guaranteed
+        valid, parseable output.
 
         Args:
             prompt: User prompt
@@ -78,6 +151,53 @@ class LLMProvider(ABC):
         raise NotImplementedError(
             f"{self.name} provider does not support structured outputs"
         )
+
+    async def complete_structured_typed(
+        self,
+        prompt: str,
+        response_model: type[T],
+        system: str | None = None,
+        max_completion_tokens: int = 4096,
+    ) -> T:
+        """
+        Generate a typed structured completion using a Pydantic model.
+
+        This is the recommended way to use structured outputs - provides type
+        safety, IDE autocomplete, and automatic schema generation.
+
+        Automatically normalizes the schema by adding 'additionalProperties: false'
+        to all object types, as required by Anthropic's structured outputs API.
+
+        Args:
+            prompt: User prompt
+            response_model: Pydantic model class defining the response schema
+            system: Optional system message
+            max_completion_tokens: Maximum completion tokens to generate
+
+        Returns:
+            Validated Pydantic model instance
+
+        Raises:
+            NotImplementedError: If provider doesn't support structured outputs
+            ValidationError: If response doesn't match the schema
+        """
+        # Generate JSON schema from Pydantic model
+        schema = response_model.model_json_schema()
+
+        # Normalize schema: recursively add additionalProperties: false to all objects
+        # This is required by Anthropic's structured outputs API for strict validation
+        schema = _normalize_schema_for_structured_outputs(schema)
+
+        # Call the dict-based method
+        result = await self.complete_structured(
+            prompt=prompt,
+            json_schema=schema,
+            system=system,
+            max_completion_tokens=max_completion_tokens,
+        )
+
+        # Validate and return typed model
+        return response_model.model_validate(result)
 
     @abstractmethod
     async def batch_complete(

--- a/chunkhound/services/deep_research_service.py
+++ b/chunkhound/services/deep_research_service.py
@@ -20,6 +20,7 @@ from chunkhound.services.research.context_manager import ContextManager
 from chunkhound.services.research.file_reader import FileReader
 from chunkhound.services.research.quality_validator import QualityValidator
 from chunkhound.services.research.query_expander import QueryExpander
+from chunkhound.services.research.schemas import QueryExpansionResponse
 from chunkhound.services.research.question_generator import QuestionGenerator
 from chunkhound.services.research.synthesis_engine import SynthesisEngine
 from chunkhound.services.research.unified_search import UnifiedSearch
@@ -798,20 +799,6 @@ class DeepResearchService:
         """
         llm = self._llm_manager.get_utility_provider()
 
-        # Define JSON schema for structured output
-        schema = {
-            "type": "object",
-            "properties": {
-                "queries": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                    "description": f"Array of exactly {NUM_LLM_EXPANDED_QUERIES} expanded search queries (semantically complete sentences)",
-                }
-            },
-            "required": ["queries"],
-            "additionalProperties": False,
-        }
-
         # Simplified system prompt per GPT-5-Nano best practices
         system = prompts.QUERY_EXPANSION_SYSTEM
 
@@ -834,14 +821,15 @@ class DeepResearchService:
         )
 
         try:
-            result = await llm.complete_structured(
+            # Use typed structured output with Pydantic model
+            result = await llm.complete_structured_typed(
                 prompt=prompt,
-                json_schema=schema,
+                response_model=QueryExpansionResponse,
                 system=system,
                 max_completion_tokens=QUERY_EXPANSION_TOKENS,
             )
 
-            expanded = result.get("queries", [])
+            expanded = result.queries  # Type-safe access
 
             # Validation: expect exactly 2 queries from LLM
             if not expanded or len(expanded) < NUM_LLM_EXPANDED_QUERIES:

--- a/chunkhound/services/research/schemas.py
+++ b/chunkhound/services/research/schemas.py
@@ -1,0 +1,38 @@
+"""Pydantic models for structured LLM outputs in research services.
+
+These models define the expected response schemas for structured completions,
+providing type safety and automatic JSON Schema generation for the API.
+"""
+
+from pydantic import BaseModel, Field
+
+
+class QueryExpansionResponse(BaseModel):
+    """Response schema for query expansion."""
+
+    queries: list[str] = Field(
+        description="Expanded search queries (semantically complete sentences)"
+    )
+
+    model_config = {"extra": "forbid"}
+
+
+class FollowupQuestionsResponse(BaseModel):
+    """Response schema for follow-up question generation."""
+
+    questions: list[str] = Field(description="Follow-up research questions")
+
+    model_config = {"extra": "forbid"}
+
+
+class QuestionSynthesisResponse(BaseModel):
+    """Response schema for question synthesis with reasoning."""
+
+    reasoning: str = Field(
+        description="Brief explanation of synthesis strategy and why these questions explore different unexplored aspects"
+    )
+    questions: list[str] = Field(
+        description="Synthesized research questions, each exploring a distinct aspect"
+    )
+
+    model_config = {"extra": "forbid"}

--- a/tests/unit/test_llm_provider_interface.py
+++ b/tests/unit/test_llm_provider_interface.py
@@ -1,0 +1,275 @@
+"""Tests for LLM Provider interface utilities."""
+
+import pytest
+
+from chunkhound.interfaces.llm_provider import _normalize_schema_for_structured_outputs
+
+
+class TestNormalizeSchemaForStructuredOutputs:
+    """Tests for the schema normalization helper function."""
+
+    def test_adds_additional_properties_to_top_level(self):
+        """Test that additionalProperties is added to top-level objects."""
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "required": ["name"],
+        }
+
+        result = _normalize_schema_for_structured_outputs(schema)
+
+        assert result["additionalProperties"] is False
+
+    def test_forces_additional_properties_false_with_warning(self, caplog):
+        """Test that invalid additionalProperties is forced to false with warning.
+
+        Anthropic's structured outputs API only supports additionalProperties: false.
+        Any other value should be forced to false with a warning log.
+        """
+        import logging
+
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+            "additionalProperties": True,  # Invalid - will be forced to false
+        }
+
+        with caplog.at_level(logging.WARNING):
+            result = _normalize_schema_for_structured_outputs(schema)
+
+        # Should force to false, not preserve
+        assert result["additionalProperties"] is False
+
+        # Should log a warning
+        assert "additionalProperties=True not supported" in caplog.text
+        assert "forcing to false" in caplog.text
+
+    def test_adds_additional_properties_to_defs(self):
+        """Test that additionalProperties is added to nested $defs."""
+        schema = {
+            "$defs": {
+                "Address": {
+                    "type": "object",
+                    "properties": {
+                        "street": {"type": "string"},
+                        "city": {"type": "string"},
+                    },
+                    "required": ["street", "city"],
+                }
+            },
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "address": {"$ref": "#/$defs/Address"},
+            },
+            "required": ["name", "address"],
+        }
+
+        result = _normalize_schema_for_structured_outputs(schema)
+
+        # Top level should have additionalProperties
+        assert result["additionalProperties"] is False
+
+        # Nested $defs should also have additionalProperties
+        assert result["$defs"]["Address"]["additionalProperties"] is False
+
+    def test_adds_additional_properties_to_array_items(self):
+        """Test that additionalProperties is added to array items."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {"id": {"type": "integer"}},
+                    },
+                }
+            },
+        }
+
+        result = _normalize_schema_for_structured_outputs(schema)
+
+        # Top level
+        assert result["additionalProperties"] is False
+
+        # Array items
+        assert result["properties"]["items"]["items"]["additionalProperties"] is False
+
+    def test_adds_additional_properties_to_prefix_items(self):
+        """Test that additionalProperties is added to prefixItems (Pydantic tuples)."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "endpoints": {
+                    "type": "array",
+                    "prefixItems": [
+                        {"type": "object", "properties": {"x": {"type": "integer"}}},
+                        {"type": "object", "properties": {"y": {"type": "integer"}}},
+                    ],
+                }
+            },
+        }
+
+        result = _normalize_schema_for_structured_outputs(schema)
+
+        # Top level
+        assert result["additionalProperties"] is False
+
+        # prefixItems objects should have additionalProperties
+        prefix_items = result["properties"]["endpoints"]["prefixItems"]
+        assert prefix_items[0]["additionalProperties"] is False
+        assert prefix_items[1]["additionalProperties"] is False
+
+    def test_handles_any_of(self):
+        """Test that additionalProperties is added to anyOf schemas."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {
+                            "type": "object",
+                            "properties": {"x": {"type": "number"}},
+                        },
+                    ]
+                }
+            },
+        }
+
+        result = _normalize_schema_for_structured_outputs(schema)
+
+        # The object in anyOf should have additionalProperties
+        any_of_schemas = result["properties"]["value"]["anyOf"]
+        object_schema = next(s for s in any_of_schemas if s.get("type") == "object")
+        assert object_schema["additionalProperties"] is False
+
+    def test_handles_one_of(self):
+        """Test that additionalProperties is added to oneOf schemas."""
+        schema = {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {"type": {"type": "string"}},
+                }
+            ]
+        }
+
+        result = _normalize_schema_for_structured_outputs(schema)
+
+        assert result["oneOf"][0]["additionalProperties"] is False
+
+    def test_handles_all_of(self):
+        """Test that additionalProperties is added to allOf schemas."""
+        schema = {
+            "allOf": [
+                {
+                    "type": "object",
+                    "properties": {"base": {"type": "string"}},
+                },
+                {
+                    "type": "object",
+                    "properties": {"extra": {"type": "string"}},
+                },
+            ]
+        }
+
+        result = _normalize_schema_for_structured_outputs(schema)
+
+        assert result["allOf"][0]["additionalProperties"] is False
+        assert result["allOf"][1]["additionalProperties"] is False
+
+    def test_handles_non_object_types(self):
+        """Test that non-object types are passed through unchanged."""
+        schema = {"type": "string"}
+
+        result = _normalize_schema_for_structured_outputs(schema)
+
+        assert result == {"type": "string"}
+        assert "additionalProperties" not in result
+
+    def test_handles_non_dict_input(self):
+        """Test that non-dict input is returned unchanged."""
+        result = _normalize_schema_for_structured_outputs("not a dict")  # type: ignore
+
+        assert result == "not a dict"
+
+    def test_does_not_mutate_original(self):
+        """Test that the original schema is not modified."""
+        original = {
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+        }
+        original_copy = original.copy()
+
+        _normalize_schema_for_structured_outputs(original)
+
+        # Original should be unchanged
+        assert original == original_copy
+        assert "additionalProperties" not in original
+
+    def test_deeply_nested_objects(self):
+        """Test normalization of deeply nested object structures."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "level1": {
+                    "type": "object",
+                    "properties": {
+                        "level2": {
+                            "type": "object",
+                            "properties": {
+                                "level3": {
+                                    "type": "object",
+                                    "properties": {"value": {"type": "string"}},
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+        }
+
+        result = _normalize_schema_for_structured_outputs(schema)
+
+        # All levels should have additionalProperties
+        assert result["additionalProperties"] is False
+        assert result["properties"]["level1"]["additionalProperties"] is False
+        assert result["properties"]["level1"]["properties"]["level2"]["additionalProperties"] is False
+        assert result["properties"]["level1"]["properties"]["level2"]["properties"]["level3"]["additionalProperties"] is False
+
+    def test_pydantic_model_schema_format(self):
+        """Test with a typical Pydantic model schema format."""
+        # This simulates what Pydantic generates for nested models
+        schema = {
+            "$defs": {
+                "Item": {
+                    "properties": {
+                        "id": {"title": "Id", "type": "integer"},
+                        "name": {"title": "Name", "type": "string"},
+                    },
+                    "required": ["id", "name"],
+                    "title": "Item",
+                    "type": "object",
+                }
+            },
+            "properties": {
+                "items": {
+                    "items": {"$ref": "#/$defs/Item"},
+                    "title": "Items",
+                    "type": "array",
+                }
+            },
+            "required": ["items"],
+            "title": "Response",
+            "type": "object",
+        }
+
+        result = _normalize_schema_for_structured_outputs(schema)
+
+        # Top level should have additionalProperties
+        assert result["additionalProperties"] is False
+
+        # $defs/Item should have additionalProperties
+        assert result["$defs"]["Item"]["additionalProperties"] is False


### PR DESCRIPTION
## Summary

Implements Anthropic's native structured outputs feature using constrained decoding for guaranteed schema-compliant JSON.

**References:**
- [Anthropic Structured Outputs Docs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs)
- [Beta Header: `structured-outputs-2025-11-13`](https://platform.claude.com/docs/en/api/beta-headers)

## Changes

### Core Implementation
- `AnthropicLLMProvider.complete_structured()` - Native structured outputs via `output_format` parameter
- `complete_structured_typed()` - Type-safe Pydantic model responses with automatic schema generation
- `_normalize_schema_for_structured_outputs()` - Recursive schema normalization

### Schema Normalization ([API requirement](https://platform.claude.com/docs/en/build-with-claude/structured-outputs#json-schema-limitations))
- Forces `additionalProperties: false` on all objects (logs warning if overriding)
- Handles `$defs`, `properties`, `items`, `prefixItems`, `anyOf/oneOf/allOf`

### Strict Tool Use Integration
- Adds beta header when any tool has `strict: true` for guaranteed tool input validation

### Extended Thinking Compatibility
- Grammar resets between thinking sections, allowing structured output with reasoning

### Error Handling
- `stop_reason: refusal` - RuntimeError for safety refusals
- `stop_reason: max_tokens` - RuntimeError with usage info for truncation
- JSON decode errors wrapped with context

## Test plan

- [x] Unit tests for schema normalization (13 tests)
- [x] Anthropic provider tests (56 tests)  
- [x] mypy type checking passes
- [x] Manual test with code_research MCP tool