### PR TITLE
Fix | Lancedb search pagination

### DIFF
--- a/chunkhound/api/cli/commands/search.py
+++ b/chunkhound/api/cli/commands/search.py
@@ -173,6 +173,7 @@ def _format_search_results(
 
     # Display header
     total = pagination.get("total", len(results))
+    total_is_estimate = bool(pagination.get("total_is_estimate"))
     offset = pagination.get("offset", 0)
     page_size = pagination.get("page_size", len(results))
 
@@ -180,8 +181,14 @@ def _format_search_results(
     formatter.info(f"Query: '{query}'")
     start_idx = offset + 1
     end_idx = offset + len(results)
+    if total is None:
+        total_display = "unknown"
+    elif total_is_estimate:
+        total_display = f"≈{total}"
+    else:
+        total_display = str(total)
     formatter.info(
-        f"Results: {len(results)} of {total} (showing {start_idx}-{end_idx})"
+        f"Results: {len(results)} of {total_display} (showing {start_idx}-{end_idx})"
     )
 
     # Display each result
@@ -225,7 +232,9 @@ def _format_search_results(
     # Display pagination info
     has_more = pagination.get("has_more", False)
     if has_more:
-        next_offset = pagination.get("next_offset", offset + page_size)
+        next_offset = pagination.get("next_offset")
+        if next_offset is None:
+            next_offset = offset + len(results)
         formatter.info(
             f"\nMore results available. Use --offset {next_offset} to see next page."
         )

--- a/chunkhound/interfaces/database_provider.py
+++ b/chunkhound/interfaces/database_provider.py
@@ -193,7 +193,21 @@ class DatabaseProvider(Protocol):
             path_filter: Optional relative path to limit search scope (e.g., 'src/', 'tests/')
 
         Returns:
-            Tuple of (results, pagination_metadata)
+            Tuple of (results, pagination_metadata).
+
+            Pagination metadata is a dict that commonly contains:
+            - offset: int
+            - page_size: int (actual returned page size)
+            - has_more: bool
+            - total: int | None (may be missing for some strategies)
+            - next_offset: int | None (optional)
+            - total_is_estimate: bool (optional; when True, total is a best-effort
+              lower bound)
+
+            Provider notes:
+            - DuckDB providers generally return exact total counts and next_offset.
+            - LanceDB providers may return an estimated total; when present they set
+              total_is_estimate=True.
         """
         ...
 
@@ -261,7 +275,9 @@ class DatabaseProvider(Protocol):
             path_filter: Optional relative path to limit search scope (e.g., 'src/', 'tests/')
 
         Returns:
-            Tuple of (results, pagination_metadata)
+            Tuple of (results, pagination_metadata).
+
+            See search_semantic() for pagination metadata conventions.
         """
         ...
 
@@ -271,7 +287,9 @@ class DatabaseProvider(Protocol):
         """Perform full-text search on code content.
 
         Returns:
-            Tuple of (results, pagination_metadata)
+            Tuple of (results, pagination_metadata).
+
+            See search_semantic() for pagination metadata conventions.
         """
         ...
 

--- a/chunkhound/mcp_server/tools.py
+++ b/chunkhound/mcp_server/tools.py
@@ -273,6 +273,7 @@ class PaginationInfo(TypedDict):
     has_more: bool
     total: NotRequired[int | None]
     next_offset: NotRequired[int | None]
+    total_is_estimate: NotRequired[bool]
 
 
 class SearchResponse(TypedDict):
@@ -338,6 +339,7 @@ def limit_response_size(
         limited_results = limited_results[:-reduction_size]
 
     # If even empty results exceed token limit, return minimal response
+    total_is_estimate = response_data["pagination"].get("total_is_estimate")
     return {
         "results": [],
         "pagination": {
@@ -346,6 +348,7 @@ def limit_response_size(
             "has_more": len(response_data["results"]) > 0,
             "total": response_data["pagination"].get("total", 0),
             "next_offset": None,
+            **({"total_is_estimate": total_is_estimate} if total_is_estimate is not None else {}),
         },
     }
 

--- a/chunkhound/providers/database/duckdb_provider.py
+++ b/chunkhound/providers/database/duckdb_provider.py
@@ -1900,6 +1900,7 @@ class DuckDBProvider(SerialDatabaseProvider):
                     "offset": offset,
                     "page_size": page_size,
                     "has_more": False,
+                    "next_offset": None,
                     "total": 0,
                 }
 
@@ -2000,6 +2001,7 @@ class DuckDBProvider(SerialDatabaseProvider):
                 "offset": offset,
                 "page_size": page_size,
                 "has_more": False,
+                "next_offset": None,
                 "total": 0,
             }
 
@@ -2114,6 +2116,7 @@ class DuckDBProvider(SerialDatabaseProvider):
                 "offset": offset,
                 "page_size": page_size,
                 "has_more": False,
+                "next_offset": None,
                 "total": 0,
             }
 

--- a/chunkhound/providers/database/lancedb_provider.py
+++ b/chunkhound/providers/database/lancedb_provider.py
@@ -174,6 +174,11 @@ class LanceDBProvider(SerialDatabaseProvider):
         like = f"{escaped}%"
         return f"path LIKE '{like}' ESCAPE '\\\\'"
 
+    def _build_path_contains_clause(self, segment: str) -> str:
+        escaped = _escape_like_pattern(segment)
+        like = f"%{escaped}%"
+        return f"path LIKE '{like}' ESCAPE '\\\\'"
+
     def _fetch_file_paths_by_ids(self, file_ids: list[int]) -> dict[int, str]:
         if not self._files_table or not file_ids:
             return {}
@@ -1568,16 +1573,20 @@ class LanceDBProvider(SerialDatabaseProvider):
                     "offset": offset,
                     "page_size": 0,
                     "has_more": False,
+                    "next_offset": None,
                     "total": 0,
                 }
 
             # Check if any chunks have embeddings for this provider/model
             try:
-                sample_chunks = self._chunks_table.head(
-                    min(100, chunks_count)
-                ).to_pandas()
-                # Handle embeddings that are lists - also exclude zero vectors
-                embeddings_mask = sample_chunks["embedding"].apply(_has_valid_embedding)
+                sample_head = self._chunks_table.head(min(100, chunks_count))
+                try:
+                    sample_rows = sample_head.to_list()
+                except Exception:
+                    # Best-effort fallback for environments where LanceDB returns a
+                    # DataFrame-like wrapper.
+                    sample_df = sample_head.to_pandas()
+                    sample_rows = sample_df.to_dict(orient="records")
             except Exception as data_error:
                 logger.error(
                     f"LanceDB data corruption detected during semantic search: {data_error}"
@@ -1586,13 +1595,17 @@ class LanceDBProvider(SerialDatabaseProvider):
                     "offset": offset,
                     "page_size": 0,
                     "has_more": False,
+                    "next_offset": None,
                     "total": 0,
                 }
-            embeddings_exist = (
-                embeddings_mask
-                & (sample_chunks["provider"] == provider)
-                & (sample_chunks["model"] == model)
-            ).any()
+
+            embeddings_exist = any(
+                _has_valid_embedding(row.get("embedding"))
+                and str(row.get("provider", "")) == provider
+                and str(row.get("model", "")) == model
+                for row in sample_rows
+                if isinstance(row, dict)
+            )
 
             if not embeddings_exist:
                 logger.warning(
@@ -1602,6 +1615,7 @@ class LanceDBProvider(SerialDatabaseProvider):
                     "offset": offset,
                     "page_size": 0,
                     "has_more": False,
+                    "next_offset": None,
                     "total": 0,
                 }
 
@@ -1609,19 +1623,70 @@ class LanceDBProvider(SerialDatabaseProvider):
             query = self._chunks_table.search(
                 query_embedding, vector_column_name="embedding"
             )
-            query = query.where(
-                f"provider = '{provider}' AND model = '{model}' AND embedding IS NOT NULL"
-            )
-            query = query.limit(page_size + offset)
+            where_parts = [
+                f"provider = '{provider}'",
+                f"model = '{model}'",
+                "embedding IS NOT NULL",
+            ]
 
-            if threshold:
-                query = query.where(f"_distance <= {threshold}")
+            # threshold is similarity (match DuckDB): similarity >= threshold
+            # LanceDB exposes distance; for cosine similarity distance ~= 1 - similarity.
+            if threshold is not None:
+                if threshold > 1.0:
+                    return [], {
+                        "offset": offset,
+                        "page_size": 0,
+                        "has_more": False,
+                        "next_offset": None,
+                        "total": 0,
+                    }
+                if threshold > 0.0:
+                    max_distance = 1.0 - float(threshold)
+                    where_parts.append(f"_distance <= {max_distance}")
 
+            valid_file_ids: set[int] | None = None
             if path_filter:
-                # Join with files table to filter by path
-                pass  # Would need more complex query joining with files table
+                if not self._files_table:
+                    logger.warning(
+                        "LanceDB semantic search: path_filter ignored (files table not initialized)."
+                    )
+                else:
+                    normalized_path = path_filter.replace("\\", "/")
+                    clause = self._build_path_contains_clause(normalized_path)
+                    file_results = self._files_table.search().where(clause).to_list()
+                    try:
+                        valid_file_ids = {
+                            int(r["id"]) for r in file_results if "id" in r
+                        }
+                    except Exception:
+                        valid_file_ids = None
+                    if valid_file_ids is not None and not valid_file_ids:
+                        return [], {
+                            "offset": offset,
+                            "page_size": 0,
+                            "has_more": False,
+                            "next_offset": None,
+                            "total": 0,
+                        }
+                    if valid_file_ids is not None:
+                        ids_str = ",".join(map(str, sorted(valid_file_ids)))
+                        where_parts.append(f"file_id IN ({ids_str})")
 
-            results = query.to_list()
+            where_clause = " AND ".join(where_parts)
+
+            # Overfetch by 1 so has_more works even without OFFSET support.
+            fetch_limit = offset + page_size + 1
+            results = (
+                query.where(where_clause)
+                .limit(fetch_limit)
+                .to_list()
+            )
+
+            # Safety net: enforce path_filter even if LanceDB query pushdown fails.
+            if valid_file_ids is not None:
+                results = [
+                    r for r in results if int(r.get("file_id", -1)) in valid_file_ids
+                ]
 
             # Deduplicate across fragments (safety net for fragment-induced duplicates)
             results = _deduplicate_by_id(results)
@@ -1657,11 +1722,14 @@ class LanceDBProvider(SerialDatabaseProvider):
                 }
                 formatted_results.append(formatted_result)
 
+            has_more = len(results) > offset + page_size
             pagination = {
                 "offset": offset,
                 "page_size": len(paginated_results),
-                "has_more": len(results) > offset + page_size,
-                "total": len(results),
+                "has_more": has_more,
+                "total": offset + len(paginated_results) + (1 if has_more else 0),
+                "total_is_estimate": True,
+                "next_offset": (offset + page_size) if has_more else None,
             }
 
             return formatted_results, pagination
@@ -1832,7 +1900,13 @@ class LanceDBProvider(SerialDatabaseProvider):
     ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
         """Executor method for search_regex - runs in DB thread."""
         if not self._chunks_table or not self._files_table:
-            return [], {"offset": offset, "page_size": 0, "has_more": False, "total": 0}
+            return [], {
+                "offset": offset,
+                "page_size": 0,
+                "has_more": False,
+                "next_offset": None,
+                "total": 0,
+            }
 
         try:
             # Build WHERE clause using regexp_match (DataFusion SQL function)
@@ -1851,10 +1925,15 @@ class LanceDBProvider(SerialDatabaseProvider):
             if path_filter:
                 # Get file IDs matching path filter
                 normalized_path = path_filter.replace("\\", "/")
-                clause = self._build_path_like_clause(normalized_path)
-                file_results = self._files_table.search().where(clause).to_list()
-                valid_file_ids = {r["id"] for r in file_results}
-                results = [r for r in results if r["file_id"] in valid_file_ids]
+                if not self._files_table:
+                    logger.warning(
+                        "LanceDB regex search: path_filter ignored (files table not initialized)."
+                    )
+                else:
+                    clause = self._build_path_contains_clause(normalized_path)
+                    file_results = self._files_table.search().where(clause).to_list()
+                    valid_file_ids = {r["id"] for r in file_results if "id" in r}
+                    results = [r for r in results if r["file_id"] in valid_file_ids]
 
             total_count = len(results)
 
@@ -1885,6 +1964,7 @@ class LanceDBProvider(SerialDatabaseProvider):
                 "page_size": len(paginated),
                 "has_more": total_count > offset + page_size,
                 "total": total_count,
+                "next_offset": (offset + page_size) if total_count > offset + page_size else None,
             }
 
             return formatted, pagination
@@ -1916,18 +1996,62 @@ class LanceDBProvider(SerialDatabaseProvider):
     ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
         """Executor method for search_fuzzy - runs in DB thread."""
         if not self._chunks_table:
-            return [], {"offset": offset, "page_size": 0, "has_more": False, "total": 0}
+            return [], {
+                "offset": offset,
+                "page_size": 0,
+                "has_more": False,
+                "next_offset": None,
+                "total": 0,
+            }
 
         try:
+            valid_file_ids: set[int] | None = None
+            if path_filter and self._files_table:
+                normalized_path = path_filter.replace("\\", "/")
+                clause = self._build_path_contains_clause(normalized_path)
+                file_results = self._files_table.search().where(clause).to_list()
+                try:
+                    valid_file_ids = {int(r["id"]) for r in file_results if "id" in r}
+                except Exception:
+                    valid_file_ids = None
+
+                if valid_file_ids is not None and not valid_file_ids:
+                    return [], {
+                        "offset": offset,
+                        "page_size": 0,
+                        "has_more": False,
+                        "next_offset": None,
+                        "total": 0,
+                    }
+            elif path_filter and not self._files_table:
+                logger.warning(
+                    "LanceDB fuzzy search: path_filter ignored (files table not initialized)."
+                )
+
             # Use LanceDB's full-text search capabilities
             escaped_query = _escape_like_pattern(query)
             where_clause = f"content LIKE '%{escaped_query}%' ESCAPE '\\\\'"
+            if valid_file_ids is not None:
+                ids_str = ",".join(map(str, sorted(valid_file_ids)))
+                where_clause = f"{where_clause} AND file_id IN ({ids_str})"
+
+            # Overfetch by 1 so has_more works even without OFFSET support.
+            fetch_limit = offset + page_size + 1
             results = (
                 self._chunks_table.search()
                 .where(where_clause)
-                .limit(page_size + offset)
+                .limit(fetch_limit)
                 .to_list()
             )
+
+            # Safety net: enforce path_filter even if LanceDB query pushdown fails.
+            if valid_file_ids is not None:
+                results = [
+                    r for r in results if int(r.get("file_id", -1)) in valid_file_ids
+                ]
+
+            # Deduplicate across fragments (safety net for fragment-induced duplicates)
+            results = _deduplicate_by_id(results)
 
             # Apply offset manually
             paginated_results = results[offset : offset + page_size]
@@ -1954,18 +2078,29 @@ class LanceDBProvider(SerialDatabaseProvider):
                 }
                 formatted_results.append(formatted_result)
 
+            has_more = len(results) > offset + page_size
             pagination = {
                 "offset": offset,
                 "page_size": len(paginated_results),
-                "has_more": len(results) > offset + page_size,
-                "total": len(results),
+                "has_more": has_more,
+                # total is an estimate (lower bound): enough for clients to
+                # progress via offset while avoiding expensive full counts.
+                "total": offset + len(paginated_results) + (1 if has_more else 0),
+                "total_is_estimate": True,
+                "next_offset": (offset + page_size) if has_more else None,
             }
 
             return formatted_results, pagination
 
         except Exception as e:
             logger.error(f"Error in fuzzy search: {e}")
-            return [], {"offset": offset, "page_size": 0, "has_more": False, "total": 0}
+            return [], {
+                "offset": offset,
+                "page_size": 0,
+                "has_more": False,
+                "next_offset": None,
+                "total": 0,
+            }
 
     def _executor_search_text(
         self,

--- a/tests/integration/test_lancedb_regex.py
+++ b/tests/integration/test_lancedb_regex.py
@@ -114,16 +114,19 @@ def test_regex_pagination(lancedb_provider, tmp_path):
     assert len(results1) == 2, "First page should have 2 results"
     assert pagination1["has_more"] is True
     assert pagination1["total"] == 5
+    assert pagination1["next_offset"] == 2
 
     # Second page
     results2, pagination2 = lancedb_provider.search_regex("common_pattern", page_size=2, offset=2)
     assert len(results2) == 2, "Second page should have 2 results"
     assert pagination2["has_more"] is True
+    assert pagination2["next_offset"] == 4
 
     # Third page (partial)
     results3, pagination3 = lancedb_provider.search_regex("common_pattern", page_size=2, offset=4)
     assert len(results3) == 1, "Third page should have 1 result"
     assert pagination3["has_more"] is False
+    assert pagination3["next_offset"] is None
 
 
 def test_regex_invalid_pattern_raises(lancedb_provider, tmp_path):

--- a/tests/unit/test_duckdb_pagination_contract.py
+++ b/tests/unit/test_duckdb_pagination_contract.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from chunkhound.providers.database.duckdb_provider import DuckDBProvider
+
+
+class _UnusedConn:
+    pass
+
+
+def test_duckdb_semantic_early_return_includes_next_offset() -> None:
+    provider = DuckDBProvider.__new__(DuckDBProvider)
+
+    # Avoid relying on instance initialization for this early-return path.
+    provider._validate_and_normalize_path_filter = (  # type: ignore[method-assign]
+        lambda self, path: path
+    )
+    provider._executor_table_exists = (  # type: ignore[method-assign]
+        lambda self, conn, state, table_name: False
+    )
+
+    results, pagination = provider._executor_search_semantic(  # type: ignore[arg-type]
+        _UnusedConn(),
+        {},
+        [0.1],
+        "provider",
+        "model",
+        page_size=10,
+        offset=0,
+        threshold=None,
+        path_filter=None,
+    )
+
+    assert results == []
+    assert pagination["has_more"] is False
+    assert pagination["next_offset"] is None

--- a/tests/unit/test_lancedb_provider_helpers.py
+++ b/tests/unit/test_lancedb_provider_helpers.py
@@ -10,13 +10,60 @@ from chunkhound.providers.database.like_utils import escape_like_pattern
 class _FakeSearch:
     def __init__(self, table) -> None:
         self._table = table
+        self._where_clauses: list[str] = []
 
     def where(self, clause: str):  # noqa: ANN001 - test stub
         self._table.where_clauses.append(clause)
+        self._where_clauses.append(clause)
         return self
 
     def to_list(self) -> list[dict[str, object]]:
-        return self._table.rows
+        rows = list(self._table.rows)
+        for clause in self._where_clauses:
+            clause = clause.strip()
+            if clause.startswith("id IN (") and clause.endswith(")"):
+                ids = clause.partition("IN (")[2].rstrip(")")
+                allowed = {
+                    int(item.strip())
+                    for item in ids.split(",")
+                    if item.strip() and item.strip().lstrip("-").isdigit()
+                }
+                rows = [row for row in rows if int(row.get("id", -1)) in allowed]
+                continue
+
+            if clause.startswith("path LIKE '") and "ESCAPE" in clause:
+                # Format: path LIKE 'prefix%' ESCAPE '\\'
+                pattern = clause.partition("path LIKE '")[2].partition("'")[0]
+                if pattern.startswith("%") and pattern.endswith("%") and len(pattern) >= 2:
+                    needle = pattern.strip("%")
+                    rows = [
+                        row
+                        for row in rows
+                        if needle in str(row.get("path", ""))
+                    ]
+                elif pattern.startswith("%"):
+                    needle = pattern[1:]
+                    rows = [
+                        row
+                        for row in rows
+                        if str(row.get("path", "")).endswith(needle)
+                    ]
+                elif pattern.endswith("%"):
+                    prefix = pattern[:-1]
+                    rows = [
+                        row
+                        for row in rows
+                        if str(row.get("path", "")).startswith(prefix)
+                    ]
+                else:
+                    rows = [
+                        row
+                        for row in rows
+                        if str(row.get("path", "")) == pattern
+                    ]
+                continue
+
+        return rows
 
 
 class _FakeFilesTable:
@@ -54,9 +101,11 @@ class _FakeChunksTable:
 class _FakeFuzzySearch:
     def __init__(self, table) -> None:
         self._table = table
+        self._where_clauses: list[str] = []
 
     def where(self, clause: str):  # noqa: ANN001 - test stub
         self._table.where_clauses.append(clause)
+        self._where_clauses.append(clause)
         return self
 
     def limit(self, limit: int):  # noqa: ANN001 - test stub
@@ -64,7 +113,11 @@ class _FakeFuzzySearch:
         return self
 
     def to_list(self) -> list[dict[str, object]]:
-        return self._table.rows
+        rows = list(self._table.rows)
+        last_limit = self._table.limits[-1] if self._table.limits else None
+        if isinstance(last_limit, int) and last_limit >= 0:
+            rows = rows[:last_limit]
+        return rows
 
 
 class _FakeChunksTableForFuzzy:
@@ -155,3 +208,312 @@ def test_search_fuzzy_escapes_like_and_quotes() -> None:
     assert provider._chunks_table.where_clauses, "Expected a WHERE clause to be used"
     clause = provider._chunks_table.where_clauses[0]
     assert clause == f"content LIKE '%{expected}%' ESCAPE '\\\\'"
+
+
+def test_search_fuzzy_empty_returns_next_offset() -> None:
+    provider = LanceDBProvider.__new__(LanceDBProvider)
+    provider._chunks_table = None
+
+    _results, pagination = provider._executor_search_fuzzy(
+        object(), {}, "needle", page_size=10, offset=0, path_filter=None
+    )
+
+    assert pagination["has_more"] is False
+    assert pagination["next_offset"] is None
+
+
+def test_search_fuzzy_applies_path_filter() -> None:
+    provider = LanceDBProvider.__new__(LanceDBProvider)
+    provider._chunks_table = _FakeChunksTableForFuzzy(
+        [
+            {
+                "id": 1,
+                "file_id": 1,
+                "content": "needle",
+                "start_line": 1,
+                "end_line": 1,
+                "chunk_type": "text",
+                "language": "python",
+                "name": "",
+            },
+            {
+                "id": 2,
+                "file_id": 2,
+                "content": "needle",
+                "start_line": 1,
+                "end_line": 1,
+                "chunk_type": "text",
+                "language": "python",
+                "name": "",
+            },
+        ]
+    )
+    provider._files_table = _FakeFilesTable(
+        [
+            {"id": 1, "path": "src/a.py"},
+            {"id": 2, "path": "tests/b.py"},
+        ]
+    )
+
+    results, _pagination = provider._executor_search_fuzzy(
+        object(), {}, "needle", page_size=10, offset=0, path_filter="src/"
+    )
+
+    assert results
+    assert all("src/" in row["file_path"] for row in results)
+    assert provider._files_table.where_clauses, "Expected files-table filtering"
+
+
+def test_search_fuzzy_has_more_works_with_offset() -> None:
+    provider = LanceDBProvider.__new__(LanceDBProvider)
+    provider._chunks_table = _FakeChunksTableForFuzzy(
+        [
+            {
+                "id": idx,
+                "file_id": 1,
+                "content": "needle",
+                "start_line": 1,
+                "end_line": 1,
+                "chunk_type": "text",
+                "language": "python",
+                "name": "",
+            }
+            for idx in range(1, 6)
+        ]
+    )
+    provider._files_table = _FakeFilesTable([{"id": 1, "path": "src/a.py"}])
+
+    results, pagination = provider._executor_search_fuzzy(
+        object(), {}, "needle", page_size=2, offset=0, path_filter=None
+    )
+
+    assert len(results) == 2
+    assert pagination["offset"] == 0
+    assert pagination["page_size"] == 2
+    assert pagination["has_more"] is True
+    assert pagination["total_is_estimate"] is True
+    assert pagination["next_offset"] == 2
+    # total is estimated; it should at least cover the returned page.
+    assert pagination["total"] >= 2
+
+
+class _FakeHead:
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self._rows = rows
+
+    def to_list(self) -> list[dict[str, object]]:
+        return list(self._rows)
+
+
+class _FakeVectorSearch:
+    def __init__(self, table) -> None:
+        self._table = table
+        self._limit: int | None = None
+        self._where_clauses: list[str] = []
+
+    def where(self, clause: str):  # noqa: ANN001 - test stub
+        self._where_clauses.append(clause)
+        return self
+
+    def limit(self, limit: int):  # noqa: ANN001 - test stub
+        self._limit = limit
+        return self
+
+    def to_list(self) -> list[dict[str, object]]:
+        rows = list(self._table.rows)
+        last_clause = self._where_clauses[-1] if self._where_clauses else ""
+        if "file_id IN (" in last_clause:
+            ids_tail = last_clause.partition("file_id IN (")[2]
+            ids = ids_tail.split(")")[0]
+            allowed = {
+                int(item.strip())
+                for item in ids.split(",")
+                if item.strip() and item.strip().lstrip("-").isdigit()
+            }
+            rows = [row for row in rows if int(row.get("file_id", -1)) in allowed]
+
+        if "_distance <=" in last_clause:
+            raw = last_clause.partition("_distance <=")[2].strip().split()[0]
+            try:
+                max_distance = float(raw)
+            except ValueError:
+                max_distance = None
+            if max_distance is not None:
+                rows = [
+                    row
+                    for row in rows
+                    if float(row.get("_distance", 0.0)) <= max_distance
+                ]
+
+        if isinstance(self._limit, int) and self._limit >= 0:
+            rows = rows[: self._limit]
+        return rows
+
+
+class _FakeChunksTableForSemantic:
+    def __init__(self, rows: list[dict[str, object]], sample_rows: list[dict[str, object]]) -> None:
+        self.rows = rows
+        self._sample_rows = sample_rows
+
+    def count_rows(self) -> int:
+        return len(self.rows)
+
+    def head(self, n: int):  # noqa: ANN001 - test stub
+        return _FakeHead(self._sample_rows[:n])
+
+    def search(self, *args, **kwargs) -> _FakeVectorSearch:  # noqa: ANN001 - test stub
+        return _FakeVectorSearch(self)
+
+
+def test_search_semantic_threshold_is_similarity_and_has_more_works() -> None:
+    provider = LanceDBProvider.__new__(LanceDBProvider)
+    rows = [
+        {
+            "id": 1,
+            "file_id": 1,
+            "_distance": 0.05,  # sim 0.95
+            "content": "a",
+            "start_line": 1,
+            "end_line": 1,
+            "chunk_type": "text",
+            "language": "python",
+            "name": "",
+            "provider": "p",
+            "model": "m",
+            "embedding": [0.1],
+        },
+        {
+            "id": 2,
+            "file_id": 1,
+            "_distance": 0.25,  # sim 0.75
+            "content": "b",
+            "start_line": 1,
+            "end_line": 1,
+            "chunk_type": "text",
+            "language": "python",
+            "name": "",
+            "provider": "p",
+            "model": "m",
+            "embedding": [0.1],
+        },
+        {
+            "id": 3,
+            "file_id": 1,
+            "_distance": 0.10,  # sim 0.90
+            "content": "c",
+            "start_line": 1,
+            "end_line": 1,
+            "chunk_type": "text",
+            "language": "python",
+            "name": "",
+            "provider": "p",
+            "model": "m",
+            "embedding": [0.1],
+        },
+        {
+            "id": 4,
+            "file_id": 1,
+            "_distance": 0.15,  # sim 0.85
+            "content": "d",
+            "start_line": 1,
+            "end_line": 1,
+            "chunk_type": "text",
+            "language": "python",
+            "name": "",
+            "provider": "p",
+            "model": "m",
+            "embedding": [0.1],
+        },
+        {
+            "id": 5,
+            "file_id": 1,
+            "_distance": 0.20,  # sim 0.80
+            "content": "e",
+            "start_line": 1,
+            "end_line": 1,
+            "chunk_type": "text",
+            "language": "python",
+            "name": "",
+            "provider": "p",
+            "model": "m",
+            "embedding": [0.1],
+        },
+    ]
+    provider._chunks_table = _FakeChunksTableForSemantic(rows=rows, sample_rows=rows)
+    provider._files_table = _FakeFilesTable([{"id": 1, "path": "src/a.py"}])
+
+    results, pagination = provider._executor_search_semantic(
+        object(),
+        {},
+        [0.1],
+        "p",
+        "m",
+        page_size=2,
+        offset=0,
+        threshold=0.8,
+        path_filter=None,
+    )
+
+    assert len(results) == 2
+    assert pagination["has_more"] is True
+    assert pagination["total_is_estimate"] is True
+    assert pagination["next_offset"] == 2
+    # Similarity threshold >= 0.8 should exclude id=2 (sim 0.75).
+    returned_ids = {r["chunk_id"] for r in results}
+    assert 2 not in returned_ids
+
+
+def test_search_semantic_applies_path_filter_like_duckdb() -> None:
+    provider = LanceDBProvider.__new__(LanceDBProvider)
+    rows = [
+        {
+            "id": 1,
+            "file_id": 1,
+            "_distance": 0.05,
+            "content": "a",
+            "start_line": 1,
+            "end_line": 1,
+            "chunk_type": "text",
+            "language": "python",
+            "name": "",
+            "provider": "p",
+            "model": "m",
+            "embedding": [0.1],
+        },
+        {
+            "id": 2,
+            "file_id": 2,
+            "_distance": 0.05,
+            "content": "b",
+            "start_line": 1,
+            "end_line": 1,
+            "chunk_type": "text",
+            "language": "python",
+            "name": "",
+            "provider": "p",
+            "model": "m",
+            "embedding": [0.1],
+        },
+    ]
+    provider._chunks_table = _FakeChunksTableForSemantic(rows=rows, sample_rows=rows)
+    provider._files_table = _FakeFilesTable(
+        [
+            {"id": 1, "path": "src/a.py"},
+            {"id": 2, "path": "tests/b.py"},
+        ]
+    )
+
+    results, _pagination = provider._executor_search_semantic(
+        object(),
+        {},
+        [0.1],
+        "p",
+        "m",
+        page_size=10,
+        offset=0,
+        threshold=None,
+        path_filter="src/",
+    )
+
+    assert results
+    assert all("src/" in r["file_path"] for r in results)

--- a/tests/unit/test_mcp_limit_response_size.py
+++ b/tests/unit/test_mcp_limit_response_size.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from chunkhound.mcp_server.tools import limit_response_size
+
+
+def test_limit_response_size_preserves_total_is_estimate_and_sets_next_offset() -> None:
+    response = {
+        "results": [
+            {"file_path": "a.py", "content": "x" * 1000},
+            {"file_path": "b.py", "content": "x" * 1000},
+            {"file_path": "c.py", "content": "x" * 1000},
+        ],
+        "pagination": {
+            "offset": 5,
+            "page_size": 3,
+            "has_more": False,
+            "next_offset": None,
+            "total": 9,
+            "total_is_estimate": True,
+        },
+    }
+
+    # Ensure the full response is too large, but at least one result fits.
+    limited = limit_response_size(response, max_tokens=450)
+
+    assert limited["results"], "Expected at least one result to survive truncation"
+    assert limited["pagination"]["total_is_estimate"] is True
+    assert limited["pagination"]["has_more"] is True
+    assert limited["pagination"]["next_offset"] == 5 + len(limited["results"])
+
+
+def test_limit_response_size_minimal_response_preserves_total_is_estimate() -> None:
+    response = {
+        "results": [{"file_path": "a.py", "content": "x" * 50000}],
+        "pagination": {
+            "offset": 0,
+            "page_size": 1,
+            "has_more": False,
+            "next_offset": None,
+            "total": 1,
+            "total_is_estimate": True,
+        },
+    }
+
+    limited = limit_response_size(response, max_tokens=1)
+
+    assert limited["results"] == []
+    assert limited["pagination"]["page_size"] == 0
+    assert limited["pagination"]["next_offset"] is None
+    assert limited["pagination"]["total_is_estimate"] is True

--- a/tests/unit/test_search_cli_formatting.py
+++ b/tests/unit/test_search_cli_formatting.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any
+
+from chunkhound.api.cli.commands.search import _format_search_results
+
+
+class _StubFormatter:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def section_header(self, message: str) -> None:
+        self.messages.append(message)
+
+    def info(self, message: str) -> None:
+        self.messages.append(message)
+
+
+def test_search_cli_renders_estimated_total_with_marker() -> None:
+    formatter = _StubFormatter()
+    result: dict[str, Any] = {
+        "results": [
+            {
+                "file_path": "src/a.py",
+                "content": "",
+            }
+        ],
+        "pagination": {
+            "offset": 0,
+            "page_size": 1,
+            "has_more": True,
+            "total": 10,
+            "total_is_estimate": True,
+        },
+    }
+
+    _format_search_results(formatter, result, query="needle", is_regex=False)
+
+    assert any("Results:" in msg for msg in formatter.messages)
+    assert any("of ≈10" in msg for msg in formatter.messages)
+
+
+def test_search_cli_renders_exact_total_without_marker() -> None:
+    formatter = _StubFormatter()
+    result: dict[str, Any] = {
+        "results": [
+            {
+                "file_path": "src/a.py",
+                "content": "",
+            }
+        ],
+        "pagination": {
+            "offset": 0,
+            "page_size": 1,
+            "has_more": True,
+            "total": 10,
+        },
+    }
+
+    _format_search_results(formatter, result, query="needle", is_regex=False)
+
+    assert any("of 10" in msg for msg in formatter.messages)
+    assert not any("of ≈10" in msg for msg in formatter.messages)
+


### PR DESCRIPTION
**Note**: This summary was generated by an AI agent.
If you'd like to discuss with humans, drop by our [Discord](https://discord.gg/BAepHEXXnX)!
---

This branch is a single commit that tightens the **pagination contract** across providers and surfaces (CLI + MCP): pagination dictionaries consistently include `next_offset` where relevant, and LanceDB can explicitly mark totals as *estimated* via `total_is_estimate=True`. The CLI now renders estimated totals with an `≈` marker and handles cases where totals are unknown (`total=None`) or when `next_offset` is missing (e.g., after response truncation).

The biggest behavioral fix is on **LanceDB semantic/fuzzy search**: pagination becomes reliable by overfetching one extra row (`offset + page_size + 1`) to compute `has_more`, adding a stable `next_offset`, and returning a conservative lower-bound `total` with `total_is_estimate=True`. It also brings LanceDB semantic `threshold` semantics in line with DuckDB (treat threshold as *similarity*, not distance), and implements `path_filter` for semantic/fuzzy/regex by resolving matching `file_id`s from the files table and filtering via `file_id IN (...)` (with a safety-net re-filter when pushdown fails).

Potential breaking change: if anyone was passing LanceDB **distance** values as `threshold`, results will change because `threshold` is now interpreted as similarity. Net value is fewer pagination inconsistencies, fewer “missing next page” UX bugs, and better feature parity across providers; tests were added/expanded to lock in the new pagination fields and truncation behavior.

[fix-lancedb-search-pagination-2_AGENT_SUMMARY.md](https://github.com/user-attachments/files/24392728/fix-lancedb-search-pagination-2_AGENT_SUMMARY.md)
