### PR TITLE
fix: use stdin for OpenCodeCLIProvider prompts to bypass Windows CLI limits

### DIFF
--- a/chunkhound/providers/llm/opencode_cli_provider.py
+++ b/chunkhound/providers/llm/opencode_cli_provider.py
@@ -114,7 +114,7 @@ class OpenCodeCLIProvider(BaseCLIProvider):
         # Combine system prompt and user prompt
         full_prompt = f"{system}\n{prompt}" if system else prompt
 
-        # Write prompt to temp file and pass via stdin to avoid Windows command line
+        # Encode prompt to bytes and pass via stdin to avoid Windows command line
         # length limits (~8191 chars). opencode-cli run reads from stdin when no
         # positional args are provided.
         prompt_bytes = full_prompt.encode("utf-8")


### PR DESCRIPTION
## Summary
- Switches `OpenCodeCLIProvider` to pass prompts via `stdin` instead of command-line arguments.
- Resolves Windows command-line length limitations (~8191 characters) that occur when sending large prompts/files.
- Adds support for `CHUNKHOUND_OPENCODE_BIN` environment variable to configure the CLI binary path.
- Updates unit tests to verify `stdin` usage and combined prompt handling.