### PR TITLE
feat: add dotenv support for configuration loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,7 +149,7 @@
 # ==============================================================================
 
 # Custom OpenCode binary path (for codex-cli LLM provider)
-# CHUNKHOUND_OPENCODE_BIN=opencode
+# CHUNKHOUND_CODEX_BIN=opencode
 
 # MCP mode flag (automatically set by MCP server - don't set manually)
 # CHUNKHOUND_MCP_MODE=1

--- a/.env.example
+++ b/.env.example
@@ -104,10 +104,6 @@
 # Modification time epsilon (seconds) - files changed within this window may be skipped
 # CHUNKHOUND_INDEXING__MTIME_EPSILON_SECONDS=2.0
 
-# Batch processing settings
-# CHUNKHOUND_INDEXING__BATCH_SIZE=100
-# CHUNKHOUND_INDEXING__WORKERS=4
-
 # ==============================================================================
 # RESEARCH CONFIGURATION (for semantic code search)
 # ==============================================================================

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,162 @@
+# ChunkHound Environment Configuration
+# 
+# This file contains all environment variables that ChunkHound supports.
+# Copy this file to .env in your project directory and uncomment/set the values you need.
+# 
+# Configuration Precedence (highest to lowest):
+# 1. CLI arguments
+# 2. Environment variables (set in your shell)
+# 3. .env file (this file)
+# 4. Config files (.chunkhound.json, --config)
+# 5. Default values
+
+# ==============================================================================
+# EMBEDDING CONFIGURATION
+# ==============================================================================
+
+# Provider: openai, voyage, mistral, or custom endpoint
+# CHUNKHOUND_EMBEDDING__PROVIDER=openai
+
+# API Key for embedding provider
+# CHUNKHOUND_EMBEDDING__API_KEY=sk-your-api-key-here
+
+# Model name to use for embeddings
+# CHUNKHOUND_EMBEDDING__MODEL=text-embedding-3-small
+
+# Base URL for custom embedding endpoints
+# CHUNKHOUND_EMBEDDING__BASE_URL=http://localhost:8001
+
+# Reranking Configuration (optional)
+# CHUNKHOUND_EMBEDDING__RERANK_MODEL=rerank-v2
+# CHUNKHOUND_EMBEDDING__RERANK_URL=http://localhost:8002/rerank
+# CHUNKHOUND_EMBEDDING__RERANK_FORMAT=auto  # auto, cohere, or tei
+# CHUNKHOUND_EMBEDDING__RERANK_BATCH_SIZE=100
+
+# ==============================================================================
+# LLM CONFIGURATION (for research/map/autodoc features)
+# ==============================================================================
+
+# Primary LLM Provider: openai, anthropic, openai-compatible, gemini, mistral, or codex-cli
+# CHUNKHOUND_LLM_PROVIDER=openai
+
+# LLM API Key
+# CHUNKHOUND_LLM_API_KEY=sk-your-llm-api-key
+
+# Base URL for custom LLM endpoints
+# CHUNKHOUND_LLM_BASE_URL=http://localhost:11434/v1
+
+# Per-Role Provider Configuration (optional - override default provider for specific roles)
+# CHUNKHOUND_LLM_UTILITY_PROVIDER=openai
+# CHUNKHOUND_LLM_SYNTHESIS_PROVIDER=anthropic
+
+# Per-Role Model Configuration
+# CHUNKHOUND_LLM_UTILITY_MODEL=gpt-4o-mini
+# CHUNKHOUND_LLM_SYNTHESIS_MODEL=claude-3-5-sonnet-20241022
+
+# Reasoning Effort (for providers that support it: low, medium, high)
+# CHUNKHOUND_LLM_CODEX_REASONING_EFFORT=medium
+# CHUNKHOUND_LLM_CODEX_REASONING_EFFORT_UTILITY=low
+# CHUNKHOUND_LLM_CODEX_REASONING_EFFORT_SYNTHESIS=high
+
+# Map/HyDE Configuration (for semantic code mapping)
+# CHUNKHOUND_LLM_MAP_HYDE_PROVIDER=openai
+# CHUNKHOUND_LLM_MAP_HYDE_MODEL=gpt-4o-mini
+# CHUNKHOUND_LLM_MAP_HYDE_REASONING_EFFORT=low
+
+# Autodoc Cleanup Configuration
+# CHUNKHOUND_LLM_AUTODOC_CLEANUP_PROVIDER=openai
+# CHUNKHOUND_LLM_AUTODOC_CLEANUP_MODEL=gpt-4o-mini
+# CHUNKHOUND_LLM_AUTODOC_CLEANUP_REASONING_EFFORT=low
+
+# ==============================================================================
+# DATABASE CONFIGURATION
+# ==============================================================================
+
+# Database provider: duckdb or lancedb
+# CHUNKHOUND_DATABASE__PROVIDER=duckdb
+
+# Database path (defaults to ~/.chunkhound/db)
+# CHUNKHOUND_DATABASE__PATH=/path/to/database
+
+# Read-only mode (prevents any writes to database)
+# CHUNKHOUND_DATABASE__READ_ONLY=false
+
+# Maximum database size in GB before indexing stops
+# CHUNKHOUND_DATABASE__MAX_DISK_USAGE_GB=50
+
+# LanceDB-specific settings
+# CHUNKHOUND_DATABASE__LANCEDB_INDEX_TYPE=IVF_PQ
+# CHUNKHOUND_DATABASE__LANCEDB_OPTIMIZE_FRAGMENT_THRESHOLD=100
+
+# ==============================================================================
+# INDEXING CONFIGURATION
+# ==============================================================================
+
+# Force reindex of all files (ignore modification timestamps)
+# CHUNKHOUND_INDEXING__FORCE_REINDEX=false
+
+# File patterns to include (comma-separated)
+# CHUNKHOUND_INDEXING__INCLUDE=*.py,*.js,*.ts
+
+# File patterns to exclude (comma-separated)
+# CHUNKHOUND_INDEXING__EXCLUDE=*.test.js,*.spec.ts
+
+# Per-file timeout settings
+# CHUNKHOUND_INDEXING__PER_FILE_TIMEOUT_SECONDS=30.0
+# CHUNKHOUND_INDEXING__PER_FILE_TIMEOUT_MIN_SIZE_KB=100
+
+# Modification time epsilon (seconds) - files changed within this window may be skipped
+# CHUNKHOUND_INDEXING__MTIME_EPSILON_SECONDS=2.0
+
+# Batch processing settings
+# CHUNKHOUND_INDEXING__BATCH_SIZE=100
+# CHUNKHOUND_INDEXING__WORKERS=4
+
+# ==============================================================================
+# RESEARCH CONFIGURATION (for semantic code search)
+# ==============================================================================
+
+# Research algorithm: v3_parallel (default)
+# CHUNKHOUND_RESEARCH_ALGORITHM=v3_parallel
+
+# Query expansion settings
+# CHUNKHOUND_RESEARCH_QUERY_EXPANSION_ENABLED=true
+# CHUNKHOUND_RESEARCH_NUM_EXPANDED_QUERIES=3
+
+# Search parameters
+# CHUNKHOUND_RESEARCH_INITIAL_PAGE_SIZE=20
+# CHUNKHOUND_RESEARCH_RELEVANCE_THRESHOLD=0.5
+# CHUNKHOUND_RESEARCH_MAX_SYMBOLS=100
+
+# Regex augmentation (combine semantic + regex search)
+# CHUNKHOUND_RESEARCH_REGEX_AUGMENTATION_RATIO=0.3
+# CHUNKHOUND_RESEARCH_REGEX_MIN_RESULTS=5
+# CHUNKHOUND_RESEARCH_REGEX_SCAN_PAGE_SIZE=1000
+
+# Multi-hop exploration
+# CHUNKHOUND_RESEARCH_MULTI_HOP_TIME_LIMIT=30.0
+# CHUNKHOUND_RESEARCH_MULTI_HOP_MAX_ITERATIONS=3
+# CHUNKHOUND_RESEARCH_MULTI_HOP_MAX_CHUNKS=500
+
+# ==============================================================================
+# GENERAL CONFIGURATION
+# ==============================================================================
+
+# Enable debug logging
+# CHUNKHOUND_DEBUG=false
+
+# Config file path (alternative to --config CLI argument)
+# CHUNKHOUND_CONFIG_FILE=/path/to/config.json
+
+# ==============================================================================
+# SPECIAL USE CASES
+# ==============================================================================
+
+# Custom OpenCode binary path (for codex-cli LLM provider)
+# CHUNKHOUND_OPENCODE_BIN=opencode
+
+# MCP mode flag (automatically set by MCP server - don't set manually)
+# CHUNKHOUND_MCP_MODE=1
+
+# YAML parser engine (tree or default) - for debugging
+# CHUNKHOUND_YAML_ENGINE=default

--- a/.env.example
+++ b/.env.example
@@ -75,12 +75,8 @@
 # Database provider: duckdb or lancedb
 # CHUNKHOUND_DATABASE__PROVIDER=duckdb
 
-# Database path (defaults to ~/.chunkhound/db)
+# Database path (defaults to <project_root>/.chunkhound/db)
 # CHUNKHOUND_DATABASE__PATH=/path/to/database
-
-# Read-only mode (prevents any writes to database)
-# CHUNKHOUND_DATABASE__READ_ONLY=false
-
 # Maximum database size in GB before indexing stops
 # CHUNKHOUND_DATABASE__MAX_DISK_USAGE_GB=50
 

--- a/.env.example
+++ b/.env.example
@@ -81,7 +81,7 @@
 # CHUNKHOUND_DATABASE__MAX_DISK_USAGE_GB=50
 
 # LanceDB-specific settings
-# CHUNKHOUND_DATABASE__LANCEDB_INDEX_TYPE=IVF_PQ
+# CHUNKHOUND_DATABASE__LANCEDB_INDEX_TYPE=auto
 # CHUNKHOUND_DATABASE__LANCEDB_OPTIMIZE_FRAGMENT_THRESHOLD=100
 
 # ==============================================================================

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -480,7 +480,7 @@ class TestConfigurationSmoke:
         )
         assert config_auto.rerank_format == "auto"
 
-    def test_dotenv_file_loading(self):
+    def test_dotenv_file_loading(self, clean_environment):
         """Verify .env file loading doesn't break config initialization.
 
         This test ensures that dotenv support is properly integrated and

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -20,7 +20,10 @@ import pytest
 from pathlib import Path
 
 # Import Windows-safe subprocess utilities
-from tests.utils.windows_subprocess import create_subprocess_exec_safe, get_safe_subprocess_env
+from tests.utils.windows_subprocess import (
+    create_subprocess_exec_safe,
+    get_safe_subprocess_env,
+)
 from tests.utils.windows_compat import windows_safe_tempdir
 from tests.utils import SubprocessJsonRpcClient
 
@@ -118,6 +121,7 @@ class TestCLICommands:
             f"Command {' '.join(command)} produced no output"
         )
 
+
 class TestServerStartup:
     """Test that servers can at least start without immediate crashes."""
 
@@ -152,23 +156,24 @@ class TestServerStartup:
         # Create a temporary directory to avoid indexing the current directory
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
-            
+
             # Create minimal config file (required for Config() creation)
             config_path = temp_path / ".chunkhound.json"
             db_path = temp_path / ".chunkhound" / "test.db"
             db_path.parent.mkdir(exist_ok=True)
-            
+
             config = {
                 "database": {"path": str(db_path), "provider": "duckdb"},
-                "indexing": {"include": ["*.py"]}
+                "indexing": {"include": ["*.py"]},
             }
             config_path.write_text(json.dumps(config))
-            
+
             # Test that the server starts without crashing
             proc = await create_subprocess_exec_safe(
                 "uv",
                 "run",
-                "python", "-c",
+                "python",
+                "-c",
                 f'''
 import sys
 import os
@@ -204,17 +209,21 @@ sys.exit(asyncio.run(test()))
             )
 
             try:
-                stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=10.0)
-                
+                stdout, stderr = await asyncio.wait_for(
+                    proc.communicate(), timeout=10.0
+                )
+
                 if proc.returncode != 0:
                     pytest.fail(
                         f"MCP stdio server initialization failed with code {proc.returncode}\n"
                         f"stdout: {stdout.decode()}\n"
                         f"stderr: {stderr.decode()}"
                     )
-                
+
                 # Check for success message
-                assert "SUCCESS:" in stdout.decode(), f"Expected success message, got: {stdout.decode()}"
+                assert "SUCCESS:" in stdout.decode(), (
+                    f"Expected success message, got: {stdout.decode()}"
+                )
 
             except asyncio.TimeoutError:
                 proc.kill()
@@ -225,21 +234,20 @@ sys.exit(asyncio.run(test()))
     async def test_mcp_stdio_protocol_handshake(self):
         """Test MCP stdio server completes full protocol handshake with tool discovery."""
         import json
-        
+
         with windows_safe_tempdir() as temp_path:
-            
             # Create minimal test content (server will auto-index on startup)
             test_file = temp_path / "test.py"
             test_file.write_text("def hello(): return 'world'")
-            
+
             # Create minimal config
             config_path = temp_path / ".chunkhound.json"
             db_path = temp_path / ".chunkhound" / "test.db"
             db_path.parent.mkdir(exist_ok=True)
-            
+
             config = {
                 "database": {"path": str(db_path), "provider": "duckdb"},
-                "indexing": {"include": ["*.py"]}
+                "indexing": {"include": ["*.py"]},
             }
 
             # Add embedding config if API key available
@@ -248,7 +256,7 @@ sys.exit(asyncio.run(test()))
             if api_key:
                 config["embedding"] = {
                     "provider": "openai",
-                    "model": "text-embedding-3-small"
+                    "model": "text-embedding-3-small",
                 }
 
             config_path.write_text(json.dumps(config))
@@ -256,16 +264,20 @@ sys.exit(asyncio.run(test()))
             # Start MCP server (it will auto-index on startup)
             mcp_env = get_safe_subprocess_env(os.environ)
             mcp_env["CHUNKHOUND_MCP_MODE"] = "1"
-            
+
             proc = await create_subprocess_exec_safe(
-                "uv", "run", "chunkhound", "mcp", str(temp_path),
+                "uv",
+                "run",
+                "chunkhound",
+                "mcp",
+                str(temp_path),
                 cwd=str(temp_path),
                 env=mcp_env,
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
+                stderr=asyncio.subprocess.PIPE,
             )
-            
+
             client = SubprocessJsonRpcClient(proc)
             await client.start()
 
@@ -276,13 +288,15 @@ sys.exit(asyncio.run(test()))
                     {
                         "protocolVersion": "2024-11-05",
                         "capabilities": {},
-                        "clientInfo": {"name": "test", "version": "1.0"}
+                        "clientInfo": {"name": "test", "version": "1.0"},
                     },
-                    timeout=10.0
+                    timeout=10.0,
                 )
 
                 # Verify response structure
-                assert "serverInfo" in init_result, f"No serverInfo in result: {init_result}"
+                assert "serverInfo" in init_result, (
+                    f"No serverInfo in result: {init_result}"
+                )
                 assert init_result["serverInfo"]["name"] == "ChunkHound Code Search"
 
                 # 2. Send initialized notification
@@ -305,6 +319,7 @@ sys.exit(asyncio.run(test()))
                 pytest.fail("MCP stdio protocol handshake timed out")
             finally:
                 await client.close()
+
 
 class TestParserLoading:
     """Test that all parsers can be loaded and created."""
@@ -358,8 +373,12 @@ class TestParserLoading:
                 # Actually test parsing to trigger tree-sitter Language initialization
                 sample_code = language_samples.get(language, "")
                 if sample_code:
-                    chunks = parser.parse_content(sample_code, f"test.{language.value}", FileId(1))
-                    assert isinstance(chunks, list), f"Parser for {language.value} didn't return a list"
+                    chunks = parser.parse_content(
+                        sample_code, f"test.{language.value}", FileId(1)
+                    )
+                    assert isinstance(chunks, list), (
+                        f"Parser for {language.value} didn't return a list"
+                    )
 
             except SetupError as e:
                 # SetupError indicates critical issues like version incompatibility
@@ -460,6 +479,41 @@ class TestConfigurationSmoke:
             base_url="http://localhost:8001",
         )
         assert config_auto.rerank_format == "auto"
+
+    def test_dotenv_file_loading(self):
+        """Verify .env file loading doesn't break config initialization.
+
+        This test ensures that dotenv support is properly integrated and
+        doesn't cause import or initialization errors.
+        """
+        import tempfile
+        from chunkhound.core.config.config import Config
+
+        # Create temp directory with .env file
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            dotenv_path = tmppath / ".env"
+
+            # Write a simple .env file
+            dotenv_path.write_text(
+                "CHUNKHOUND_EMBEDDING__PROVIDER=openai\n"
+                "CHUNKHOUND_EMBEDDING__API_KEY=sk-test-from-dotenv\n"
+            )
+
+            # Should not raise during config initialization
+            config = Config(target_dir=tmppath)
+
+            # Verify .env was loaded
+            assert config.embedding is not None
+            assert config.embedding.provider == "openai"
+            assert config.embedding.api_key.get_secret_value() == "sk-test-from-dotenv"
+
+        # Test that missing .env doesn't break anything
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            # No .env file - should work fine
+            config = Config(target_dir=tmppath)
+            assert config is not None
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_dotenv_loading.py
+++ b/tests/unit/test_dotenv_loading.py
@@ -1,0 +1,338 @@
+"""Unit tests for dotenv file loading in configuration system.
+
+Tests verify that .env files are loaded correctly and that the precedence
+chain works as expected: CLI > env vars > .env file > config file > defaults
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from chunkhound.core.config.config import Config
+
+
+@pytest.fixture
+def temp_project_dir():
+    """Create a temporary directory for testing."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+@pytest.fixture
+def clean_env():
+    """Clean up environment variables before and after test."""
+    # Store original env vars
+    original_env = os.environ.copy()
+
+    # Clean CHUNKHOUND env vars
+    keys_to_remove = [k for k in os.environ.keys() if k.startswith("CHUNKHOUND_")]
+    for key in keys_to_remove:
+        os.environ.pop(key, None)
+
+    yield
+
+    # Restore original environment
+    os.environ.clear()
+    os.environ.update(original_env)
+
+
+def test_dotenv_file_loads_embedding_config(
+    temp_project_dir: Path, clean_env: None
+) -> None:
+    """Test that .env file is loaded and embedding config is populated."""
+    # Create .env file with embedding configuration
+    dotenv_path = temp_project_dir / ".env"
+    dotenv_path.write_text(
+        "CHUNKHOUND_EMBEDDING__PROVIDER=openai\n"
+        "CHUNKHOUND_EMBEDDING__API_KEY=sk-test-from-dotenv\n"
+        "CHUNKHOUND_EMBEDDING__MODEL=text-embedding-3-small\n"
+    )
+
+    # Create config with target_dir pointing to temp directory
+    config = Config(target_dir=temp_project_dir)
+
+    # Verify embedding config was loaded from .env
+    assert config.embedding is not None
+    assert config.embedding.provider == "openai"
+    assert config.embedding.api_key.get_secret_value() == "sk-test-from-dotenv"
+    assert config.embedding.model == "text-embedding-3-small"
+
+
+def test_dotenv_file_loads_llm_config(temp_project_dir: Path, clean_env: None) -> None:
+    """Test that .env file loads LLM configuration."""
+    # Create .env file with LLM configuration
+    dotenv_path = temp_project_dir / ".env"
+    dotenv_path.write_text(
+        "CHUNKHOUND_LLM_PROVIDER=anthropic\n"
+        "CHUNKHOUND_LLM_API_KEY=sk-ant-test\n"
+        "CHUNKHOUND_LLM_UTILITY_MODEL=claude-3-5-haiku-20241022\n"
+    )
+
+    # Create config
+    config = Config(target_dir=temp_project_dir)
+
+    # Verify LLM config was loaded from .env
+    assert config.llm is not None
+    assert config.llm.provider == "anthropic"
+    assert config.llm.api_key.get_secret_value() == "sk-ant-test"
+    assert config.llm.utility_model == "claude-3-5-haiku-20241022"
+
+
+def test_dotenv_file_loads_database_config(
+    temp_project_dir: Path, clean_env: None
+) -> None:
+    """Test that .env file loads database configuration."""
+    # Create .env file with database configuration
+    dotenv_path = temp_project_dir / ".env"
+    db_path = temp_project_dir / "custom_db"
+    dotenv_path.write_text(
+        f"CHUNKHOUND_DATABASE__PATH={db_path}\nCHUNKHOUND_DATABASE__PROVIDER=lancedb\n"
+    )
+
+    # Create config
+    config = Config(target_dir=temp_project_dir)
+
+    # Verify database config was loaded from .env
+    assert config.database.path == db_path
+    assert config.database.provider == "lancedb"
+
+
+def test_env_vars_override_dotenv(temp_project_dir: Path, clean_env: None) -> None:
+    """Test that system environment variables override .env file values."""
+    # Create .env file
+    dotenv_path = temp_project_dir / ".env"
+    dotenv_path.write_text(
+        "CHUNKHOUND_EMBEDDING__PROVIDER=openai\n"
+        "CHUNKHOUND_EMBEDDING__API_KEY=sk-test-from-dotenv\n"
+    )
+
+    # Set environment variable (should override .env)
+    os.environ["CHUNKHOUND_EMBEDDING__API_KEY"] = "sk-test-from-env-var"
+
+    # Create config
+    config = Config(target_dir=temp_project_dir)
+
+    # Verify env var took precedence over .env file
+    assert config.embedding is not None
+    assert config.embedding.provider == "openai"  # from .env
+    assert (
+        config.embedding.api_key.get_secret_value() == "sk-test-from-env-var"
+    )  # from env var (overridden)
+
+
+def test_cli_args_override_dotenv_and_env_vars(
+    temp_project_dir: Path, clean_env: None
+) -> None:
+    """Test that CLI arguments override both .env and environment variables."""
+    # Create .env file
+    dotenv_path = temp_project_dir / ".env"
+    dotenv_path.write_text(
+        "CHUNKHOUND_EMBEDDING__PROVIDER=openai\n"
+        "CHUNKHOUND_EMBEDDING__API_KEY=sk-test-from-dotenv\n"
+    )
+
+    # Set environment variable
+    os.environ["CHUNKHOUND_EMBEDDING__API_KEY"] = "sk-test-from-env-var"
+
+    # Create mock CLI args
+    from argparse import Namespace
+
+    args = Namespace(
+        command="index",
+        path=str(temp_project_dir),
+        config=None,
+        debug=False,
+    )
+
+    # Override via kwargs (simulating CLI args for embedding config)
+    config = Config(args=args, embedding={"api_key": "sk-test-from-cli"})
+
+    # Verify CLI took precedence
+    assert config.embedding is not None
+    assert config.embedding.api_key.get_secret_value() == "sk-test-from-cli"
+
+
+def test_dotenv_file_missing_does_not_break(
+    temp_project_dir: Path, clean_env: None
+) -> None:
+    """Test that missing .env file doesn't cause errors."""
+    # Don't create .env file - should work fine
+    config = Config(target_dir=temp_project_dir)
+
+    # Config should be created successfully with defaults
+    assert config is not None
+    assert config.database is not None
+
+
+def test_dotenv_overrides_config_file(temp_project_dir: Path, clean_env: None) -> None:
+    """Test that .env file values override JSON config file values."""
+    # Create JSON config file
+    config_file = temp_project_dir / "config.json"
+    config_file.write_text(
+        '{"embedding": {"provider": "openai", "api_key": "sk-from-json"}}'
+    )
+
+    # Create .env file (should override JSON)
+    dotenv_path = temp_project_dir / ".env"
+    dotenv_path.write_text("CHUNKHOUND_EMBEDDING__API_KEY=sk-from-dotenv\n")
+
+    # Create mock CLI args pointing to config file
+    from argparse import Namespace
+
+    args = Namespace(
+        command="index",
+        path=str(temp_project_dir),
+        config=str(config_file),
+        debug=False,
+    )
+
+    # Create config
+    config = Config(args=args)
+
+    # Verify .env overrode JSON config
+    assert config.embedding is not None
+    assert config.embedding.provider == "openai"  # from JSON
+    assert (
+        config.embedding.api_key.get_secret_value() == "sk-from-dotenv"
+    )  # from .env (overridden)
+
+
+def test_dotenv_with_local_chunkhound_json(
+    temp_project_dir: Path, clean_env: None
+) -> None:
+    """Test .env interaction with local .chunkhound.json file."""
+    # Create local .chunkhound.json
+    local_config = temp_project_dir / ".chunkhound.json"
+    local_config.write_text(
+        '{"embedding": {"provider": "openai", "model": "text-embedding-3-small"}}'
+    )
+
+    # Create .env file
+    dotenv_path = temp_project_dir / ".env"
+    dotenv_path.write_text("CHUNKHOUND_EMBEDDING__API_KEY=sk-from-dotenv\n")
+
+    # Create config
+    config = Config(target_dir=temp_project_dir)
+
+    # Verify both sources were merged correctly
+    assert config.embedding is not None
+    assert config.embedding.provider == "openai"  # from .chunkhound.json
+    assert config.embedding.model == "text-embedding-3-small"  # from .chunkhound.json
+    assert config.embedding.api_key.get_secret_value() == "sk-from-dotenv"  # from .env
+
+
+def test_dotenv_loads_multiple_config_sections(
+    temp_project_dir: Path, clean_env: None
+) -> None:
+    """Test that .env can configure multiple config sections at once."""
+    # Create .env with various settings
+    dotenv_path = temp_project_dir / ".env"
+    dotenv_path.write_text(
+        "CHUNKHOUND_EMBEDDING__PROVIDER=openai\n"
+        "CHUNKHOUND_EMBEDDING__API_KEY=sk-test\n"
+        "CHUNKHOUND_LLM_PROVIDER=anthropic\n"
+        "CHUNKHOUND_LLM_API_KEY=sk-ant-test\n"
+        "CHUNKHOUND_DATABASE__PROVIDER=lancedb\n"
+        "CHUNKHOUND_DEBUG=true\n"
+    )
+
+    # Create config
+    config = Config(target_dir=temp_project_dir)
+
+    # Verify all sections loaded
+    assert config.embedding is not None
+    assert config.embedding.provider == "openai"
+    assert config.embedding.api_key.get_secret_value() == "sk-test"
+
+    assert config.llm is not None
+    assert config.llm.provider == "anthropic"
+    assert config.llm.api_key.get_secret_value() == "sk-ant-test"
+
+    assert config.database.provider == "lancedb"
+    assert config.debug is True
+
+
+def test_dotenv_with_comments_and_blank_lines(
+    temp_project_dir: Path, clean_env: None
+) -> None:
+    """Test that .env file handles comments and blank lines correctly."""
+    # Create .env with comments and blank lines
+    dotenv_path = temp_project_dir / ".env"
+    dotenv_path.write_text(
+        "# Embedding configuration\n"
+        "CHUNKHOUND_EMBEDDING__PROVIDER=openai\n"
+        "\n"
+        "# API key\n"
+        "CHUNKHOUND_EMBEDDING__API_KEY=sk-test\n"
+        "\n"
+        "# End of file\n"
+    )
+
+    # Create config
+    config = Config(target_dir=temp_project_dir)
+
+    # Verify it loaded correctly despite comments
+    assert config.embedding is not None
+    assert config.embedding.provider == "openai"
+    assert config.embedding.api_key.get_secret_value() == "sk-test"
+
+
+def test_dotenv_not_loaded_from_other_directories(
+    temp_project_dir: Path, clean_env: None
+) -> None:
+    """Test that .env is only loaded from target directory, not cwd."""
+    # Create .env in a subdirectory
+    subdir = temp_project_dir / "subdir"
+    subdir.mkdir()
+    dotenv_path = subdir / ".env"
+    dotenv_path.write_text("CHUNKHOUND_EMBEDDING__API_KEY=sk-should-not-load\n")
+
+    # Create config with target_dir as parent (not subdir)
+    config = Config(target_dir=temp_project_dir)
+
+    # Verify .env from subdirectory was NOT loaded
+    if config.embedding:
+        assert config.embedding.api_key != "sk-should-not-load"
+
+
+def test_dotenv_rerank_config(temp_project_dir: Path, clean_env: None) -> None:
+    """Test that .env file loads reranking configuration."""
+    # Create .env file with reranking config (needs base_url for rerank)
+    dotenv_path = temp_project_dir / ".env"
+    dotenv_path.write_text(
+        "CHUNKHOUND_EMBEDDING__PROVIDER=openai\n"
+        "CHUNKHOUND_EMBEDDING__API_KEY=sk-test\n"
+        "CHUNKHOUND_EMBEDDING__BASE_URL=http://localhost:8001\n"
+        "CHUNKHOUND_EMBEDDING__RERANK_MODEL=rerank-v2\n"
+        "CHUNKHOUND_EMBEDDING__RERANK_BATCH_SIZE=50\n"
+    )
+
+    # Create config
+    config = Config(target_dir=temp_project_dir)
+
+    # Verify rerank config was loaded
+    assert config.embedding is not None
+    assert config.embedding.rerank_model == "rerank-v2"
+    assert config.embedding.rerank_batch_size == 50
+
+
+def test_dotenv_indexing_config(temp_project_dir: Path, clean_env: None) -> None:
+    """Test that .env file loads indexing configuration."""
+    # Create .env file with indexing config
+    dotenv_path = temp_project_dir / ".env"
+    dotenv_path.write_text(
+        "CHUNKHOUND_INDEXING__FORCE_REINDEX=true\n"
+        "CHUNKHOUND_INDEXING__CLEANUP=false\n"
+        "CHUNKHOUND_INDEXING__MAX_CONCURRENT=8\n"
+    )
+
+    # Create config
+    config = Config(target_dir=temp_project_dir)
+
+    # Verify indexing config was loaded
+    assert config.indexing.force_reindex is True
+    assert config.indexing.cleanup is False
+    assert config.indexing.max_concurrent == 8

--- a/tests/unit/test_dotenv_loading.py
+++ b/tests/unit/test_dotenv_loading.py
@@ -7,7 +7,6 @@ chain works as expected: CLI > env vars > .env file > config file > defaults
 import os
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/unit/test_dotenv_loading.py
+++ b/tests/unit/test_dotenv_loading.py
@@ -136,7 +136,7 @@ def test_cli_args_override_dotenv_and_env_vars(
     # Set environment variable
     os.environ["CHUNKHOUND_EMBEDDING__API_KEY"] = "sk-test-from-env-var"
 
-    # Create mock CLI args
+    # Create mock CLI args with api_key set (simulating actual CLI --api-key argument)
     from argparse import Namespace
 
     args = Namespace(
@@ -144,10 +144,11 @@ def test_cli_args_override_dotenv_and_env_vars(
         path=str(temp_project_dir),
         config=None,
         debug=False,
+        api_key="sk-test-from-cli",  # CLI argument
     )
 
-    # Override via kwargs (simulating CLI args for embedding config)
-    config = Config(args=args, embedding={"api_key": "sk-test-from-cli"})
+    # Create config with CLI args
+    config = Config(args=args)
 
     # Verify CLI took precedence
     assert config.embedding is not None
@@ -293,8 +294,10 @@ def test_dotenv_not_loaded_from_other_directories(
     config = Config(target_dir=temp_project_dir)
 
     # Verify .env from subdirectory was NOT loaded
-    if config.embedding:
-        assert config.embedding.api_key != "sk-should-not-load"
+    # Since no .env exists in target_dir and no env vars are set, embedding should be None
+    assert config.embedding is None, (
+        "Embedding config should be None when no .env exists in target directory"
+    )
 
 
 def test_dotenv_rerank_config(temp_project_dir: Path, clean_env: None) -> None:


### PR DESCRIPTION
## Summary
Adds support for loading configuration via `.env` files.

- Loads `.env` file from the target directory if present.
- Maintains precedence: CLI > Env Vars > `.env` > Config Files > Defaults.
- Includes `.env.example` template and comprehensive unit tests.