### PR TITLE
fix: add elapsed attribute to _Task shim for non-TTY mode

### DIFF
--- a/chunkhound/api/cli/utils/rich_output.py
+++ b/chunkhound/api/cli/utils/rich_output.py
@@ -605,6 +605,7 @@ class _NoRichProgressManager:
                     def __init__(self, total: int | None = None) -> None:
                         self.total = total
                         self.completed = 0
+                        self.elapsed = 0.0
 
                 self._Task = _Task
                 self.tasks: dict[int, _Task] = {}


### PR DESCRIPTION
Fixes #168

## Problem

The `_Task` shim class in `_NoRichProgressManager` is missing the `elapsed` attribute. When `embedding_service.py` tries to access it in non-TTY mode, all embedding batches fail with:

```
'_Task' object has no attribute 'elapsed'
```

This affects:
- SSH sessions
- Cron jobs
- Piped output (`chunkhound index . | cat`)

## Fix

Add `self.elapsed = 0.0` to match the Rich Progress Task interface.

## Testing

Before fix (non-TTY):
```
Embeddings: 0 (all batches failed)
```

After fix (non-TTY):
```
Embeddings: 949 ✓
```