### PR TITLE
feat: add Azure OpenAI support (#74)

### DIFF
--- a/chunkhound/core/config/embedding_config.py
+++ b/chunkhound/core/config/embedding_config.py
@@ -16,8 +16,7 @@ from typing_extensions import Self
 
 from chunkhound.core.constants import VOYAGE_DEFAULT_MODEL
 
-from .openai_utils import is_official_openai_endpoint
-
+from .openai_utils import is_azure_openai_endpoint, is_official_openai_endpoint
 
 # Error message constants for consistent messaging across config and provider
 RERANK_MODEL_REQUIRED_COHERE = (
@@ -111,6 +110,20 @@ class EmbeddingConfig(BaseSettings):
         default=None, description="Base URL for the embedding API"
     )
 
+    # Azure OpenAI Configuration
+    api_version: str | None = Field(
+        default=None, description="Azure OpenAI API version (e.g., '2024-02-01')"
+    )
+
+    azure_endpoint: str | None = Field(
+        default=None,
+        description="Azure OpenAI endpoint URL (e.g., 'https://myresource.openai.azure.com')",
+    )
+
+    azure_deployment: str | None = Field(
+        default=None, description="Azure OpenAI deployment name"
+    )
+
     rerank_model: str | None = Field(
         default=None,
         description="Reranking model name (enables multi-hop search if specified)",
@@ -194,6 +207,34 @@ class EmbeddingConfig(BaseSettings):
         )
         return self
 
+    @model_validator(mode="after")
+    def validate_azure_config(self) -> Self:
+        """Validate Azure OpenAI configuration."""
+        # If azure_endpoint is set, validate Azure-specific requirements
+        if self.azure_endpoint:
+            # Validate endpoint format
+            if not is_azure_openai_endpoint(self.azure_endpoint):
+                raise ValueError(
+                    "azure_endpoint must be a valid Azure OpenAI endpoint "
+                    "(e.g., 'https://myresource.openai.azure.com')"
+                )
+
+            # api_version is required for Azure
+            if not self.api_version:
+                raise ValueError(
+                    "api_version is required when using Azure OpenAI "
+                    "(e.g., '2024-02-01')"
+                )
+
+            # azure_endpoint and base_url are mutually exclusive
+            if self.base_url:
+                raise ValueError(
+                    "azure_endpoint and base_url are mutually exclusive. "
+                    "Use azure_endpoint for Azure OpenAI, base_url for custom OpenAI-compatible endpoints."
+                )
+
+        return self
+
     def get_provider_config(self) -> dict[str, Any]:
         """
         Get provider-specific configuration dictionary.
@@ -217,6 +258,14 @@ class EmbeddingConfig(BaseSettings):
         # Add base URL if available
         if self.base_url:
             base_config["base_url"] = self.base_url
+
+        # Add Azure OpenAI configuration if available
+        if self.api_version:
+            base_config["api_version"] = self.api_version
+        if self.azure_endpoint:
+            base_config["azure_endpoint"] = self.azure_endpoint
+        if self.azure_deployment:
+            base_config["azure_deployment"] = self.azure_deployment
 
         # Add rerank configuration if available
         if self.rerank_model:
@@ -252,6 +301,9 @@ class EmbeddingConfig(BaseSettings):
             True if provider is properly configured
         """
         if self.provider == "openai":
+            # Azure OpenAI always requires API key
+            if self.azure_endpoint:
+                return self.api_key is not None
             # For OpenAI provider, only require API key for official endpoints
             if is_official_openai_endpoint(self.base_url):
                 return self.api_key is not None
@@ -272,13 +324,17 @@ class EmbeddingConfig(BaseSettings):
         missing = []
 
         if self.provider == "openai":
+            # Azure OpenAI always requires API key
+            if self.azure_endpoint:
+                if not self.api_key:
+                    missing.append("api_key (set CHUNKHOUND_EMBEDDING__API_KEY)")
             # For OpenAI provider, only require API key for official endpoints
-            if is_official_openai_endpoint(self.base_url) and not self.api_key:
-                missing.append("api_key (set CHUNKHOUND_EMBEDDING_API_KEY)")
+            elif is_official_openai_endpoint(self.base_url) and not self.api_key:
+                missing.append("api_key (set CHUNKHOUND_EMBEDDING__API_KEY)")
         else:
             # For other providers (voyageai, etc.), always require API key
             if not self.api_key:
-                missing.append("api_key (set CHUNKHOUND_EMBEDDING_API_KEY)")
+                missing.append("api_key (set CHUNKHOUND_EMBEDDING__API_KEY)")
 
         return missing
 
@@ -309,6 +365,25 @@ class EmbeddingConfig(BaseSettings):
             help="Skip embedding generation (index code only)",
         )
 
+        # Azure OpenAI arguments
+        parser.add_argument(
+            "--azure-endpoint",
+            "--embedding-azure-endpoint",
+            help="Azure OpenAI endpoint URL (e.g., 'https://myresource.openai.azure.com')",
+        )
+
+        parser.add_argument(
+            "--api-version",
+            "--embedding-api-version",
+            help="Azure OpenAI API version (e.g., '2024-02-01')",
+        )
+
+        parser.add_argument(
+            "--azure-deployment",
+            "--embedding-azure-deployment",
+            help="Azure OpenAI deployment name",
+        )
+
     @classmethod
     def load_from_env(cls) -> dict[str, Any]:
         """Load embedding config from environment variables."""
@@ -322,6 +397,14 @@ class EmbeddingConfig(BaseSettings):
             config["provider"] = provider
         if model := os.getenv("CHUNKHOUND_EMBEDDING__MODEL"):
             config["model"] = model
+
+        # Azure OpenAI configuration
+        if api_version := os.getenv("CHUNKHOUND_EMBEDDING__API_VERSION"):
+            config["api_version"] = api_version
+        if azure_endpoint := os.getenv("CHUNKHOUND_EMBEDDING__AZURE_ENDPOINT"):
+            config["azure_endpoint"] = azure_endpoint
+        if azure_deployment := os.getenv("CHUNKHOUND_EMBEDDING__AZURE_DEPLOYMENT"):
+            config["azure_deployment"] = azure_deployment
 
         # Reranking configuration
         if rerank_model := os.getenv("CHUNKHOUND_EMBEDDING__RERANK_MODEL"):
@@ -361,6 +444,25 @@ class EmbeddingConfig(BaseSettings):
         if hasattr(args, "embedding_base_url") and args.embedding_base_url:
             overrides["base_url"] = args.embedding_base_url
 
+        # Handle Azure OpenAI arguments
+        if hasattr(args, "azure_endpoint") and args.azure_endpoint:
+            overrides["azure_endpoint"] = args.azure_endpoint
+        if hasattr(args, "embedding_azure_endpoint") and args.embedding_azure_endpoint:
+            overrides["azure_endpoint"] = args.embedding_azure_endpoint
+
+        if hasattr(args, "api_version") and args.api_version:
+            overrides["api_version"] = args.api_version
+        if hasattr(args, "embedding_api_version") and args.embedding_api_version:
+            overrides["api_version"] = args.embedding_api_version
+
+        if hasattr(args, "azure_deployment") and args.azure_deployment:
+            overrides["azure_deployment"] = args.azure_deployment
+        if (
+            hasattr(args, "embedding_azure_deployment")
+            and args.embedding_azure_deployment
+        ):
+            overrides["azure_deployment"] = args.embedding_azure_deployment
+
         # Handle no-embeddings flag (special case - disables embeddings)
         if hasattr(args, "no_embeddings") and args.no_embeddings:
             return {"disabled": True}  # This will be handled specially in main Config
@@ -370,10 +472,16 @@ class EmbeddingConfig(BaseSettings):
     def __repr__(self) -> str:
         """String representation hiding sensitive information."""
         api_key_display = "***" if self.api_key else None
-        return (
-            f"EmbeddingConfig("
-            f"provider={self.provider}, "
-            f"model={self.get_default_model()}, "
-            f"api_key={api_key_display}, "
-            f"base_url={self.base_url})"
-        )
+        parts = [
+            f"provider={self.provider}",
+            f"model={self.get_default_model()}",
+            f"api_key={api_key_display}",
+        ]
+        if self.azure_endpoint:
+            parts.append(f"azure_endpoint={self.azure_endpoint}")
+            parts.append(f"api_version={self.api_version}")
+            if self.azure_deployment:
+                parts.append(f"azure_deployment={self.azure_deployment}")
+        elif self.base_url:
+            parts.append(f"base_url={self.base_url}")
+        return f"EmbeddingConfig({', '.join(parts)})"

--- a/chunkhound/core/config/embedding_factory.py
+++ b/chunkhound/core/config/embedding_factory.py
@@ -84,16 +84,32 @@ class EmbeddingProviderFactory:
         rerank_format = config.get("rerank_format", "auto")
         rerank_batch_size = config.get("rerank_batch_size")
 
+        # Azure OpenAI parameters
+        api_version = config.get("api_version")
+        azure_endpoint = config.get("azure_endpoint")
+        azure_deployment = config.get("azure_deployment")
+
         # Model should come from config, but handle None case safely
         if not model:
             raise ValueError("Model not specified in provider configuration")
 
-        logger.debug(
-            f"Creating OpenAI provider: model={model}, "
-            f"base_url={base_url}, api_key={'***' if api_key else None}, "
-            f"rerank_model={rerank_model}, rerank_format={rerank_format}, "
-            f"rerank_batch_size={rerank_batch_size}"
-        )
+        # Log Azure configuration if present
+        if azure_endpoint:
+            logger.debug(
+                f"Creating Azure OpenAI provider: model={model}, "
+                f"azure_endpoint={azure_endpoint}, api_version={api_version}, "
+                f"azure_deployment={azure_deployment}, "
+                f"api_key={'***' if api_key else None}, "
+                f"rerank_model={rerank_model}, rerank_format={rerank_format}, "
+                f"rerank_batch_size={rerank_batch_size}"
+            )
+        else:
+            logger.debug(
+                f"Creating OpenAI provider: model={model}, "
+                f"base_url={base_url}, api_key={'***' if api_key else None}, "
+                f"rerank_model={rerank_model}, rerank_format={rerank_format}, "
+                f"rerank_batch_size={rerank_batch_size}"
+            )
 
         try:
             return create_openai_provider(
@@ -104,6 +120,9 @@ class EmbeddingProviderFactory:
                 rerank_url=rerank_url,
                 rerank_format=rerank_format,
                 rerank_batch_size=rerank_batch_size,
+                api_version=api_version,
+                azure_endpoint=azure_endpoint,
+                azure_deployment=azure_deployment,
             )
         except Exception as e:
             raise ValueError(f"Failed to create OpenAI provider: {e}") from e

--- a/chunkhound/core/config/openai_utils.py
+++ b/chunkhound/core/config/openai_utils.py
@@ -1,6 +1,31 @@
 """Utilities for OpenAI API endpoint detection."""
 
 
+def is_azure_openai_endpoint(azure_endpoint: str | None) -> bool:
+    """
+    Check if this is an Azure OpenAI endpoint.
+
+    Azure OpenAI endpoints follow the pattern:
+    https://<resource-name>.openai.azure.com
+
+    Args:
+        azure_endpoint: The Azure endpoint URL to check, or None
+
+    Returns:
+        True if this is a valid Azure OpenAI endpoint
+    """
+    if not azure_endpoint:
+        return False
+
+    # Normalize URL for comparison
+    endpoint = azure_endpoint.lower().rstrip("/")
+
+    # Azure OpenAI endpoints must:
+    # 1. Start with https://
+    # 2. End with .openai.azure.com (to prevent URLs like https://evil.com/openai.azure.com/)
+    return endpoint.startswith("https://") and endpoint.endswith(".openai.azure.com")
+
+
 def is_official_openai_endpoint(base_url: str | None) -> bool:
     """
     Determine if a base URL points to the official OpenAI API.

--- a/chunkhound/embeddings.py
+++ b/chunkhound/embeddings.py
@@ -7,6 +7,8 @@ from loguru import logger
 
 from chunkhound.interfaces.embedding_provider import (
     EmbeddingProvider as InterfaceEmbeddingProvider,
+)
+from chunkhound.interfaces.embedding_provider import (
     RerankResult,
 )
 
@@ -186,8 +188,14 @@ def create_openai_provider(
     rerank_url: str = "/rerank",
     rerank_format: str = "auto",
     rerank_batch_size: int | None = None,
+    api_version: str | None = None,
+    azure_endpoint: str | None = None,
+    azure_deployment: str | None = None,
 ) -> "OpenAIEmbeddingProvider":
     """Create an OpenAI embedding provider with default settings.
+
+    Supports both standard OpenAI and Azure OpenAI endpoints. For Azure,
+    provide azure_endpoint, api_version, and optionally azure_deployment.
 
     Args:
         api_key: OpenAI API key (uses OPENAI_API_KEY env var if None)
@@ -197,6 +205,9 @@ def create_openai_provider(
         rerank_url: Rerank endpoint URL (defaults to /rerank)
         rerank_format: Reranking API format - 'cohere', 'tei', or 'auto' (default: 'auto')
         rerank_batch_size: Max documents per rerank batch (overrides model defaults, bounded by model caps)
+        api_version: Azure OpenAI API version (e.g., '2024-02-01')
+        azure_endpoint: Azure OpenAI endpoint URL (e.g., 'https://myresource.openai.azure.com')
+        azure_deployment: Azure OpenAI deployment name
 
     Returns:
         Configured OpenAI embedding provider
@@ -212,4 +223,7 @@ def create_openai_provider(
         rerank_url=rerank_url,
         rerank_format=rerank_format,
         rerank_batch_size=rerank_batch_size,
+        api_version=api_version,
+        azure_endpoint=azure_endpoint,
+        azure_deployment=azure_deployment,
     )


### PR DESCRIPTION
Add support for Azure OpenAI embeddings with proper configuration validation:

- Add azure_endpoint, api_version, and azure_deployment configuration options
- Add is_azure_openai_endpoint() validation with security hardening
- Update EmbeddingConfig with Azure-specific validators
- Update OpenAIEmbeddingProvider to use AsyncAzureOpenAI client
- Add CLI arguments and environment variable support for Azure config
- Fix env var hint typo (single to double underscore)

Security: Azure endpoint validation now uses endswith() check to prevent malicious URLs like https://evil.com/openai.azure.com/

Closes #74