### PR TITLE
cli(research): add --path-filter to scope deep research

### DIFF
--- a/chunkhound/api/cli/commands/research.py
+++ b/chunkhound/api/cli/commands/research.py
@@ -101,6 +101,7 @@ async def research_command(args: argparse.Namespace, config: Config) -> None:
                 llm_manager=llm_manager,
                 query=args.query,
                 progress=tree_progress,
+                path=args.path_filter,
                 config=config,
             )
 

--- a/chunkhound/api/cli/parsers/research_parser.py
+++ b/chunkhound/api/cli/parsers/research_parser.py
@@ -37,6 +37,12 @@ def add_research_subparser(subparsers: Any) -> argparse.ArgumentParser:
         help="Directory path to research (default: current directory)",
     )
 
+    research_parser.add_argument(
+        "--path-filter",
+        type=str,
+        help="Optional path filter (e.g., 'src/', 'tests/')",
+    )
+
     # Add common arguments
     add_common_arguments(research_parser)
 

--- a/tests/cli/test_research_help_mentions_path_filter.py
+++ b/tests/cli/test_research_help_mentions_path_filter.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import subprocess
+
+
+def _run(cmd: list[str], timeout: int = 20) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["uv", "run", *cmd], text=True, capture_output=True, timeout=timeout
+    )
+
+
+def test_research_help_mentions_path_filter() -> None:
+    proc = _run(["chunkhound", "research", "--help"])
+    assert proc.returncode == 0, proc.stderr
+    assert "--path-filter" in proc.stdout
+

--- a/tests/cli/test_research_parser.py
+++ b/tests/cli/test_research_parser.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from chunkhound.api.cli.parsers.research_parser import add_research_subparser
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    add_research_subparser(subparsers)
+    return parser
+
+
+def test_research_parser_defaults_and_flags() -> None:
+    parser = _build_parser()
+
+    args = parser.parse_args(["research", "why is x slow"])
+    assert args.query == "why is x slow"
+    assert args.path == Path(".")
+    assert args.path_filter is None
+
+    args = parser.parse_args(["research", "why is x slow", "--path-filter", "src/"])
+    assert args.path == Path(".")
+    assert args.path_filter == "src/"
+
+    args = parser.parse_args(["research", "why is x slow", "repo", "--path-filter", "src/"])
+    assert args.path == Path("repo")
+    assert args.path_filter == "src/"
+


### PR DESCRIPTION
**Note**: This summary was generated by an AI agent.
If you'd like to discuss with humans, drop by our [Discord](https://discord.gg/BAepHEXXnX)!
---

This branch adds an explicit scoping knob to the deep research CLI: `chunkhound research` now accepts `--path-filter` (matching `chunkhound search`) and forwards it into the existing `code_research` plumbing. That means you can restrict retrieval/synthesis to a path prefix like `src/` without changing how the positional `[path]` continues to drive config/DB discovery.

No breaking changes. The value is mostly UX parity and correctness: users get a first-class way to limit the search space in CLI research, and we lock it in with small CLI help + parser tests to avoid regressions.

[feat_research-path-filter_AGENT_SUMMARY.md](https://github.com/user-attachments/files/25219505/feat_research-path-filter_AGENT_SUMMARY.md)
