### PR TITLE
fix: lazy-load numpy/hdbscan/sklearn to prevent MCP crash on WDAC systems

### DIFF
--- a/chunkhound/services/clustering_service.py
+++ b/chunkhound/services/clustering_service.py
@@ -3,17 +3,24 @@
 Uses HDBSCAN for natural semantic clustering (first pass) and k-means
 for budget-based clustering (subsequent passes) to group files into
 token-bounded clusters for parallel synthesis operations.
+
+Heavy scientific computing deps (numpy, hdbscan, sklearn) are lazy-loaded
+inside methods to avoid crashing the MCP server at startup on systems with
+WDAC code-integrity policies that block unsigned .pyd files. See #192.
 """
 
-from dataclasses import dataclass
+from __future__ import annotations
 
-import hdbscan
-import numpy as np
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
 from loguru import logger
-from sklearn.cluster import KMeans  # type: ignore[import-untyped]
 
 from chunkhound.interfaces.embedding_provider import EmbeddingProvider
 from chunkhound.interfaces.llm_provider import LLMProvider
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @dataclass
@@ -62,6 +69,9 @@ class ClusteringService:
         Raises:
             ValueError: If files dict is empty or n_clusters < 1
         """
+        import numpy as np
+        from sklearn.cluster import KMeans  # type: ignore[import-untyped]
+
         if not files:
             raise ValueError("Cannot cluster empty files dictionary")
         if n_clusters < 1:
@@ -179,6 +189,9 @@ class ClusteringService:
         Raises:
             ValueError: If files dict is empty
         """
+        import hdbscan
+        import numpy as np
+
         if not files:
             raise ValueError("Cannot cluster empty files dictionary")
 
@@ -310,6 +323,8 @@ class ClusteringService:
         Returns:
             Modified labels array with no -1 values
         """
+        import numpy as np
+
         outlier_mask = labels == -1
         if not outlier_mask.any():
             return labels
@@ -381,6 +396,10 @@ class ClusteringService:
             Such files are returned as-is in their own cluster, potentially
             exceeding the configured bound. A warning is logged when this occurs.
         """
+        import hdbscan
+        import numpy as np
+        from sklearn.cluster import KMeans  # type: ignore[import-untyped]
+
         if not files:
             raise ValueError("Cannot cluster empty files dictionary")
 

--- a/chunkhound/services/research/shared/elbow_detection.py
+++ b/chunkhound/services/research/shared/elbow_detection.py
@@ -2,9 +2,11 @@
 
 Implements the Kneedle algorithm (Satopaa et al. 2011) for finding elbow points
 in score curves. Used for adaptive threshold computation in research phases.
+
+numpy is lazy-loaded inside functions to avoid pulling heavy deps at MCP startup.
+See #192.
 """
 
-import numpy as np
 from loguru import logger
 
 
@@ -37,6 +39,8 @@ def find_elbow_kneedle(sorted_scores: list[float]) -> int | None:
         >>> find_elbow_kneedle(scores)
         None  # Need at least 3 points
     """
+    import numpy as np
+
     if len(sorted_scores) < 3:
         logger.debug("Kneedle: Too few points (<3), cannot detect elbow")
         return None  # Need at least 3 points for elbow


### PR DESCRIPTION
## Summary

- Defer heavy scientific computing imports (numpy, hdbscan, sklearn) from module level to method level in 3 files, preventing MCP server crash at startup on Windows systems with WDAC code integrity policies that block numpy's unsigned `.pyd` files
- Move DuckDB's numpy threading pre-import from module level into `connect()` method, preserving the safety guarantee while deferring the load
- Add `from __future__ import annotations` + `TYPE_CHECKING` guards to maintain mypy compatibility for `np.ndarray` type annotations

Fixes #192

## Details

Three import paths were eagerly loading numpy at MCP startup:

1. **`clustering_service.py`** — Top-level `import hdbscan`, `import numpy`, `from sklearn.cluster import KMeans`. Moved into the 4 methods that use them (`cluster_files`, `cluster_files_hdbscan`, `_reassign_outliers_to_nearest`, `cluster_files_hdbscan_bounded`).

2. **`connection_manager.py`** — Module-level numpy pre-import for DuckDB threading safety. Moved into a `_preload_numpy()` static method called from `connect()`. Same safety guarantee, just deferred until the DB connection is actually established.

3. **`elbow_detection.py`** — Top-level `import numpy`. Moved into `find_elbow_kneedle()` function body.

Python caches module imports after first load, so subsequent calls within the same process have zero overhead.

## Verification

- MCP import chain confirmed clean: `import chunkhound.mcp_server.tools` loads zero heavy deps (numpy, sklearn, hdbscan, scipy)
- 95 clustering/elbow tests pass
- 6 smoke import tests pass
- mypy shows no new errors

## Upstream

Filed https://github.com/numpy/numpy/issues/30832 requesting Authenticode signing of `.pyd` files so numpy works natively on WDAC-enforced systems.

## Test plan

- [x] Verify `import chunkhound.mcp_server.tools` does not load numpy/sklearn/hdbscan/scipy
- [x] Run clustering tests: `pytest tests/ -k "cluster or elbow"` — 95 passed
- [x] Run smoke import tests: `pytest tests/test_smoke.py -k "not cli and not server"` — 6 passed
- [ ] Manual test on a WDAC-enforced system (reporter can verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)