### PR TITLE
fix: replace 4 bare excepts with except Exception

### DIFF
--- a/chunkhound/parsers/mapping_adapter.py
+++ b/chunkhound/parsers/mapping_adapter.py
@@ -228,7 +228,7 @@ class MappingAdapter(LanguageMapping):
                     params = self.base_mapping.extract_parameters(def_node, source)
                     if params:
                         metadata["parameters"] = params
-                except:
+                except Exception:
                     pass  # Ignore extraction errors
 
         return metadata

--- a/chunkhound/parsers/mappings/json.py
+++ b/chunkhound/parsers/mappings/json.py
@@ -253,7 +253,7 @@ class JsonMapping(BaseMapping):
             # Store formatted version in metadata for cases where pretty-printed JSON is needed
             try:
                 metadata["formatted_json"] = json.dumps(data, indent=2)
-            except:
+            except Exception:
                 pass  # Skip if formatting fails
 
         return metadata

--- a/chunkhound/providers/database/duckdb_provider.py
+++ b/chunkhound/providers/database/duckdb_provider.py
@@ -1028,7 +1028,7 @@ class DuckDBProvider(SerialDatabaseProvider):
                 conn.execute("ROLLBACK")
                 state["transaction_active"] = False
                 logger.info("Transaction rolled back due to error")
-            except:
+            except Exception:
                 pass
 
             # Attempt to recreate dropped indexes on failure

--- a/chunkhound/providers/database/serial_executor.py
+++ b/chunkhound/providers/database/serial_executor.py
@@ -252,5 +252,5 @@ class SerialDatabaseExecutor:
         try:
             future = self._db_executor.submit(get_activity_time)
             return future.result(timeout=1.0)  # Quick operation, short timeout
-        except:
+        except Exception:
             return None


### PR DESCRIPTION
Replace 4 bare `except:` with `except Exception:`. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.