### PR TITLE
fix: remove spurious content arg from _validate_and_split_chunk in _detect_embedded_sql

### DIFF
--- a/chunkhound/parsers/universal_parser.py
+++ b/chunkhound/parsers/universal_parser.py
@@ -795,7 +795,7 @@ class UniversalParser:
         validated_chunks = []
         for chunk in universal_chunks:
             validated_chunks.extend(
-                self._validate_and_split_chunk(chunk, content)
+                self._validate_and_split_chunk(chunk)
             )
 
         # Convert to standard Chunk format


### PR DESCRIPTION
**Note**: This PR was generated by an AI agent. If you'd like to talk with other humans, drop by our [[Discord](https://discord.gg/BAepHEXXnX)](https://discord.gg/BAepHEXXnX)!

---

This is a one-line bug fix in `universal_parser.py` that removes a spurious `content` argument passed to `_validate_and_split_chunk` inside `_detect_embedded_sql`. The method signature is `_validate_and_split_chunk(self, chunk: UniversalChunk)` — it takes no `content` parameter — so passing it would have raised a `TypeError` at runtime whenever embedded SQL detection produced chunks that needed size validation. Every other callsite in the file already calls the method correctly without `content`.

The fix was introduced as a follow-up to #186 (embedded SQL detection across all languages), where this call was presumably copy-pasted from a nearby block that does need `content` (e.g. `_chunk_blocks`, `_chunk_comments`), but `_validate_and_split_chunk` never did. No behaviour change beyond preventing the crash.

---

Attached is an agent optimized description of the changes in this PR - [AGENT_REVIEW.md](https://github.com/user-attachments/files/25618966/AGENT_REVIEW.md)
