### PR TITLE
Guard against overlapping daemon roots

### DIFF
--- a/chunkhound/daemon/discovery.py
+++ b/chunkhound/daemon/discovery.py
@@ -26,6 +26,8 @@ from .process import pid_alive
 _LOCK_FILE_REL = ".chunkhound/daemon.lock"
 # Starter lock — prevents two proxies from both spawning a daemon simultaneously
 _STARTER_LOCK_REL = ".chunkhound/daemon.starter.lock"
+# User-scoped registry of running daemons, keyed by canonical project root hash
+_REGISTRY_DIR_REL = ".chunkhound/daemon-registry"
 # Socket directory (Linux/macOS)
 _SOCKET_DIR = "/tmp"
 # Startup polling interval and timeout
@@ -33,11 +35,66 @@ _STARTUP_POLL_INTERVAL = 0.1
 _STARTUP_TIMEOUT = 30.0
 
 
+def _canonical_project_dir(project_dir: Path) -> Path:
+    """Return the canonical project root used for daemon identity."""
+    return project_dir.resolve()
+
+
+def _normalized_project_dir(project_dir: Path) -> Path:
+    """Return the comparison-safe project root for overlap checks."""
+    canonical = _canonical_project_dir(project_dir)
+    if sys.platform == "win32":
+        return Path(os.path.normcase(str(canonical)))
+    return canonical
+
+
+def _project_dir_identity(project_dir: Path) -> str:
+    """Return the stable string identity used for hashing and comparisons."""
+    return str(_normalized_project_dir(project_dir))
+
+
+def _roots_overlap(root_a: Path, root_b: Path) -> bool:
+    """Return True if two canonical roots are identical or nested."""
+    left = _normalized_project_dir(root_a)
+    right = _normalized_project_dir(root_b)
+    if left == right:
+        return True
+    try:
+        right.relative_to(left)
+        return True
+    except ValueError:
+        pass
+    try:
+        left.relative_to(right)
+        return True
+    except ValueError:
+        return False
+
+
+def _write_json_atomically(
+    path: Path,
+    data: dict[str, Any],
+    *,
+    private: bool = False,
+) -> None:
+    """Write JSON to *path* atomically using a sibling temp file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f"{path.name}.tmp")
+    with open(tmp_path, "w") as f:
+        json.dump(data, f)
+    tmp_path.replace(path)
+    if private and sys.platform != "win32":
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+
+
 class DaemonDiscovery:
     """Locate or start the daemon for a given project directory."""
 
     def __init__(self, project_dir: Path) -> None:
-        self._project_dir = project_dir.resolve()
+        self._project_dir = _canonical_project_dir(project_dir)
 
     # ------------------------------------------------------------------
     # Path helpers
@@ -50,6 +107,17 @@ class DaemonDiscovery:
     def get_starter_lock_path(self) -> Path:
         """Return the absolute path of the starter lock file."""
         return self._project_dir / _STARTER_LOCK_REL
+
+    def get_registry_dir(self) -> Path:
+        """Return the user-scoped daemon registry directory."""
+        return Path.home() / _REGISTRY_DIR_REL
+
+    def get_registry_entry_path(self) -> Path:
+        """Return the registry entry path for this canonical project root."""
+        digest = hashlib.sha256(
+            _project_dir_identity(self._project_dir).encode()
+        ).hexdigest()[:16]
+        return self.get_registry_dir() / f"{digest}.json"
 
     def get_ipc_address(self) -> str:
         """Derive a unique IPC address from the project directory.
@@ -75,7 +143,8 @@ class DaemonDiscovery:
 
         Returns:
             Dict with keys ``pid``, ``socket_path``, ``started_at``,
-            ``auth_token``, or ``None`` if the file does not exist or is corrupt.
+            ``auth_token``, ``project_dir``, or ``None`` if the file does
+            not exist or is corrupt.
         """
         lock_path = self.get_lock_path()
         try:
@@ -97,24 +166,16 @@ class DaemonDiscovery:
         the owning user can read the auth token.
         """
         lock_path = self.get_lock_path()
-        lock_path.parent.mkdir(parents=True, exist_ok=True)
         data = {
             "pid": pid,
             "socket_path": socket_path,
             "started_at": time.time(),
+            "project_dir": str(self._project_dir),
             "auth_token": (
                 auth_token if auth_token is not None else secrets.token_hex(32)
             ),
         }
-        tmp_path = lock_path.with_suffix(".lock.tmp")
-        with open(tmp_path, "w") as f:
-            json.dump(data, f)
-        tmp_path.replace(lock_path)  # replace() is atomic and overwrites on Windows
-        if sys.platform != "win32":
-            try:
-                os.chmod(lock_path, 0o600)
-            except OSError:
-                pass
+        _write_json_atomically(lock_path, data, private=True)
 
     def remove_lock(self) -> None:
         """Remove the lock file, ignoring errors if it does not exist."""
@@ -122,6 +183,115 @@ class DaemonDiscovery:
             self.get_lock_path().unlink()
         except FileNotFoundError:
             pass
+
+    def write_registry_entry(self, pid: int, socket_path: str) -> None:
+        """Publish this daemon in the user-scoped registry."""
+        data = {
+            "project_dir": str(self._project_dir),
+            "pid": pid,
+            "socket_path": socket_path,
+            "lock_path": str(self.get_lock_path()),
+            "started_at": time.time(),
+        }
+        _write_json_atomically(self.get_registry_entry_path(), data)
+
+    def remove_registry_entry(self) -> None:
+        """Remove this daemon's registry entry if present."""
+        try:
+            self.get_registry_entry_path().unlink()
+        except FileNotFoundError:
+            pass
+
+    def _remove_registry_entry_file(self, entry_path: Path) -> None:
+        """Best-effort removal for a stale registry entry."""
+        try:
+            entry_path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError:
+            pass
+
+    def _read_registry_entry(self, entry_path: Path) -> dict[str, Any] | None:
+        """Read a registry entry, deleting malformed files opportunistically."""
+        try:
+            with open(entry_path) as f:
+                data = json.load(f)
+            if isinstance(data, dict):
+                return data
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            pass
+        self._remove_registry_entry_file(entry_path)
+        return None
+
+    def _validated_registry_entry(self, entry_path: Path) -> dict[str, Any] | None:
+        """Return authoritative live-daemon metadata for a registry entry."""
+        entry = self._read_registry_entry(entry_path)
+        if entry is None:
+            return None
+
+        project_dir_raw = entry.get("project_dir")
+        pid = entry.get("pid")
+        lock_path_raw = entry.get("lock_path")
+        if not isinstance(project_dir_raw, str) or not isinstance(pid, int):
+            self._remove_registry_entry_file(entry_path)
+            return None
+
+        root = _canonical_project_dir(Path(project_dir_raw))
+        expected_lock_path = root / _LOCK_FILE_REL
+        if (
+            not isinstance(lock_path_raw, str)
+            or Path(lock_path_raw) != expected_lock_path
+        ):
+            self._remove_registry_entry_file(entry_path)
+            return None
+
+        if not pid_alive(pid):
+            self._remove_registry_entry_file(entry_path)
+            return None
+
+        other_discovery = DaemonDiscovery(root)
+        lock = other_discovery.read_lock()
+        if lock is None:
+            self._remove_registry_entry_file(entry_path)
+            return None
+
+        lock_pid = lock.get("pid")
+        if not isinstance(lock_pid, int) or lock_pid != pid:
+            self._remove_registry_entry_file(entry_path)
+            return None
+
+        lock_project_dir = lock.get("project_dir")
+        if isinstance(lock_project_dir, str):
+            if _canonical_project_dir(Path(lock_project_dir)) != root:
+                self._remove_registry_entry_file(entry_path)
+                return None
+
+        return {
+            "project_dir": str(root),
+            "pid": pid,
+            "socket_path": str(lock.get("socket_path", entry.get("socket_path", ""))),
+            "lock_path": str(expected_lock_path),
+            "started_at": float(lock.get("started_at", entry.get("started_at", 0.0))),
+        }
+
+    def find_conflicting_daemon(self) -> dict[str, Any] | None:
+        """Return overlapping live-daemon metadata for a different root, if any."""
+        registry_dir = self.get_registry_dir()
+        if not registry_dir.exists():
+            return None
+
+        for entry_path in registry_dir.glob("*.json"):
+            entry = self._validated_registry_entry(entry_path)
+            if entry is None:
+                continue
+            other_root = _canonical_project_dir(Path(str(entry["project_dir"])))
+            if _normalized_project_dir(other_root) == _normalized_project_dir(
+                self._project_dir
+            ):
+                continue
+            if _roots_overlap(self._project_dir, other_root):
+                return entry
+        return None
 
     # ------------------------------------------------------------------
     # Starter lock (prevents duplicate-daemon race on concurrent proxy start)
@@ -186,6 +356,7 @@ class DaemonDiscovery:
         Returns True if the server accepts connections.
         """
         from . import ipc
+
         return await ipc.is_connectable(address)
 
     def is_daemon_alive(self) -> bool:
@@ -281,10 +452,14 @@ class DaemonDiscovery:
         socket_path = self.get_ipc_address()
 
         cmd = [
-            sys.executable, "-m", "chunkhound.api.cli.main",
+            sys.executable,
+            "-m",
+            "chunkhound.api.cli.main",
             "_daemon",
-            "--project-dir", str(self._project_dir),
-            "--socket-path", socket_path,
+            "--project-dir",
+            str(self._project_dir),
+            "--socket-path",
+            socket_path,
         ]
 
         # Forward all config flags by introspecting the daemon parser's own
@@ -360,6 +535,19 @@ class DaemonDiscovery:
                     os.unlink(initial_address)
                 except FileNotFoundError:
                     pass
+
+        conflict = self.find_conflicting_daemon()
+        if conflict is not None:
+            conflict_root = str(conflict["project_dir"])
+            conflict_pid = conflict.get("pid")
+            pid_suffix = (
+                f" (pid {conflict_pid})" if isinstance(conflict_pid, int) else ""
+            )
+            raise RuntimeError(
+                f"Cannot start ChunkHound daemon for '{self._project_dir}' because "
+                f"a daemon is already running for overlapping root '{conflict_root}'"
+                f"{pid_suffix}. Overlapping daemon roots are not supported."
+            )
 
         # No live daemon — race to become the sole daemon starter.
         if self._acquire_starter_lock():

--- a/chunkhound/daemon/server.py
+++ b/chunkhound/daemon/server.py
@@ -129,14 +129,13 @@ class ChunkHoundDaemon(MCPServerBase):
                 return
 
             self._lock_written = True
+            self._discovery.write_registry_entry(os.getpid(), self._socket_path)
             self.debug_log(
                 f"Lock file written (pid={os.getpid()}, address={self._socket_path})"
             )
 
             # Start PID poll background task
-            self._pid_poll_task = asyncio.create_task(
-                self._client_manager.poll_pids()
-            )
+            self._pid_poll_task = asyncio.create_task(self._client_manager.poll_pids())
 
             self.debug_log(f"Listening on {self._socket_path}")
 
@@ -148,6 +147,7 @@ class ChunkHoundDaemon(MCPServerBase):
         except Exception as e:
             self.debug_log(f"Daemon run() error: {e}")
             import traceback
+
             traceback.print_exc(file=sys.stderr)
         finally:
             await self._graceful_shutdown()
@@ -299,9 +299,7 @@ class ChunkHoundDaemon(MCPServerBase):
     async def _handle_tools_list(self, msg: dict[str, Any]) -> dict[str, Any]:
         """Respond to the tools/list request with available tool schemas."""
         try:
-            await asyncio.wait_for(
-                self._initialization_complete.wait(), timeout=5.0
-            )
+            await asyncio.wait_for(self._initialization_complete.wait(), timeout=5.0)
         except asyncio.TimeoutError:
             pass
 
@@ -330,10 +328,7 @@ class ChunkHoundDaemon(MCPServerBase):
             config=self.config,
         )
 
-        content = [
-            {"type": tc.type, "text": tc.text}
-            for tc in text_contents
-        ]
+        content = [{"type": tc.type, "text": tc.text} for tc in text_contents]
 
         return {
             "jsonrpc": "2.0",
@@ -375,5 +370,7 @@ class ChunkHoundDaemon(MCPServerBase):
                     os.unlink(self._socket_path)
                 except FileNotFoundError:
                     pass
+
+            self._discovery.remove_registry_entry()
 
         self.debug_log("Daemon shutdown complete")

--- a/tests/test_daemon_smoke.py
+++ b/tests/test_daemon_smoke.py
@@ -18,18 +18,21 @@ import json
 import os
 import shutil
 import sys
+from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import AsyncIterator
 
 import psutil
 import pytest
 
 from tests.helpers.daemon_test_helpers import (
-    is_daemon_running,
     wait_for_daemon_shutdown,
     wait_for_daemon_start,
 )
-from tests.utils import SubprocessJsonRpcClient, create_subprocess_exec_safe, get_safe_subprocess_env
+from tests.utils import (
+    SubprocessJsonRpcClient,
+    create_subprocess_exec_safe,
+    get_safe_subprocess_env,
+)
 
 
 def _chunkhound_exe() -> str:
@@ -40,6 +43,7 @@ def _chunkhound_exe() -> str:
             "chunkhound not found in PATH — run tests via 'uv run pytest'"
         )
     return exe
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -57,22 +61,37 @@ _SEARCH_REGEX_PARAMS = {
 }
 
 
-def _make_env(project_dir: Path) -> dict[str, str]:
+def _registry_dir(home_dir: Path) -> Path:
+    """Return the daemon registry directory under a test-controlled home."""
+    return home_dir / ".chunkhound" / "daemon-registry"
+
+
+def _make_env(project_dir: Path, *, fake_home: Path | None = None) -> dict[str, str]:
     """Return a clean subprocess environment pointing to project_dir."""
-    env = get_safe_subprocess_env()
+    env = get_safe_subprocess_env(os.environ.copy())
     # Clear any stale CHUNKHOUND_* vars that could interfere
     for key in list(env.keys()):
         if key.startswith("CHUNKHOUND_"):
             del env[key]
     env["CHUNKHOUND_MCP_MODE"] = "1"
+    if fake_home is not None:
+        fake_home.mkdir(parents=True, exist_ok=True)
+        env["HOME"] = str(fake_home)
+        env["USERPROFILE"] = str(fake_home)
     return env
 
 
-async def _start_proxy(project_dir: Path) -> tuple[asyncio.subprocess.Process, SubprocessJsonRpcClient]:
+async def _start_proxy(
+    project_dir: Path,
+    *,
+    fake_home: Path | None = None,
+) -> tuple[asyncio.subprocess.Process, SubprocessJsonRpcClient]:
     """Launch a ``chunkhound mcp`` proxy subprocess and return (proc, client)."""
-    env = _make_env(project_dir)
+    env = _make_env(project_dir, fake_home=fake_home)
     proc = await create_subprocess_exec_safe(
-        _chunkhound_exe(), "mcp", str(project_dir),
+        _chunkhound_exe(),
+        "mcp",
+        str(project_dir),
         stdin=asyncio.subprocess.PIPE,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.DEVNULL,
@@ -84,7 +103,30 @@ async def _start_proxy(project_dir: Path) -> tuple[asyncio.subprocess.Process, S
     return proc, client
 
 
-async def _do_mcp_handshake(client: SubprocessJsonRpcClient, timeout: float = 30.0) -> dict:
+async def _run_proxy_to_failure(
+    project_dir: Path,
+    *,
+    fake_home: Path | None = None,
+    timeout: float = 30.0,
+) -> tuple[int, str, str]:
+    """Run ``chunkhound mcp`` until it exits and capture stdio."""
+    proc = await create_subprocess_exec_safe(
+        _chunkhound_exe(),
+        "mcp",
+        str(project_dir),
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=_make_env(project_dir, fake_home=fake_home),
+        cwd=str(project_dir),
+    )
+    stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    return proc.returncode or 0, stdout.decode(), stderr.decode()
+
+
+async def _do_mcp_handshake(
+    client: SubprocessJsonRpcClient, timeout: float = 30.0
+) -> dict:
     """Send initialize + initialized notification; return server capabilities."""
     result = await client.send_request("initialize", _MCP_INIT_PARAMS, timeout=timeout)
     await client.send_notification("notifications/initialized", {})
@@ -110,6 +152,115 @@ async def _teardown_proxy(
             pass
 
 
+def _write_project_files(project_dir: Path) -> None:
+    """Create a minimal test project with config and source files."""
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "auth.py").write_text(
+        "def authenticate(user, password):\n"
+        '    """Authenticate a user."""\n'
+        "    return user == 'admin' and password == 'secret'\n"
+        "\n"
+        "def logout(session):\n"
+        "    session.clear()\n"
+    )
+    (project_dir / "search.py").write_text(
+        "def search_items(query, index):\n"
+        '    """Search items in the index."""\n'
+        "    results = []\n"
+        "    for item in index:\n"
+        "        if query.lower() in item.lower():\n"
+        "            results.append(item)\n"
+        "    return results\n"
+    )
+    (project_dir / "utils.py").write_text(
+        "def format_result(result):\n"
+        '    """Format a search result."""\n'
+        "    return str(result)\n"
+        "\n"
+        "def validate_input(data):\n"
+        "    return data is not None\n"
+    )
+
+    db_path = project_dir / ".chunkhound" / "test.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    config = {
+        "database": {"path": str(db_path), "provider": "duckdb"},
+        "indexing": {"include": ["*.py"]},
+    }
+    (project_dir / ".chunkhound.json").write_text(json.dumps(config))
+
+
+async def _prepare_project_dir(project_dir: Path) -> None:
+    """Create and index a minimal project for daemon smoke tests."""
+    _write_project_files(project_dir)
+    index_proc = await create_subprocess_exec_safe(
+        _chunkhound_exe(),
+        "index",
+        str(project_dir),
+        "--no-embeddings",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=str(project_dir),
+        env=get_safe_subprocess_env(),
+    )
+    _, stderr = await asyncio.wait_for(index_proc.communicate(), timeout=60.0)
+    assert index_proc.returncode == 0, (
+        f"Pre-indexing failed (rc={index_proc.returncode}): {stderr.decode()}"
+    )
+
+
+def _cleanup_project_dir(project_dir: Path) -> None:
+    """Stop any lingering daemon for a test project and remove local artifacts."""
+    from chunkhound.daemon.discovery import DaemonDiscovery
+
+    discovery = DaemonDiscovery(project_dir)
+    lock = discovery.read_lock()
+    if lock:
+        pid = lock.get("pid")
+        if isinstance(pid, int):
+            try:
+                proc = psutil.Process(pid)
+                proc.terminate()
+                try:
+                    proc.wait(timeout=5.0)
+                except psutil.TimeoutExpired:
+                    proc.kill()
+                    proc.wait(timeout=2.0)
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+            except Exception:
+                pass
+        discovery.remove_lock()
+    socket_path = discovery.get_socket_path()
+    if not socket_path.startswith("tcp:"):
+        try:
+            os.unlink(socket_path)
+        except Exception:
+            pass
+
+
+async def _wait_for_registry_entry(
+    home_dir: Path,
+    project_dir: Path,
+    timeout: float = 10.0,
+) -> Path | None:
+    """Wait until a registry entry appears for the canonical project root."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    expected_root = str(project_dir.resolve())
+    while asyncio.get_running_loop().time() < deadline:
+        registry_dir = _registry_dir(home_dir)
+        if registry_dir.exists():
+            for entry_path in registry_dir.glob("*.json"):
+                try:
+                    data = json.loads(entry_path.read_text())
+                except (OSError, json.JSONDecodeError):
+                    continue
+                if data.get("project_dir") == expected_root:
+                    return entry_path
+        await asyncio.sleep(0.1)
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -123,88 +274,11 @@ async def pre_indexed_project_dir(tmp_path: Path) -> AsyncIterator[Path]:
     and indexes the files without embeddings so that regex search works.
     The fixture does NOT require an embedding API key.
     """
-    # --- Synthetic source files ---
-    (tmp_path / "auth.py").write_text(
-        "def authenticate(user, password):\n"
-        "    \"\"\"Authenticate a user.\"\"\"\n"
-        "    return user == 'admin' and password == 'secret'\n"
-        "\n"
-        "def logout(session):\n"
-        "    session.clear()\n"
-    )
-    (tmp_path / "search.py").write_text(
-        "def search_items(query, index):\n"
-        "    \"\"\"Search items in the index.\"\"\"\n"
-        "    results = []\n"
-        "    for item in index:\n"
-        "        if query.lower() in item.lower():\n"
-        "            results.append(item)\n"
-        "    return results\n"
-    )
-    (tmp_path / "utils.py").write_text(
-        "def format_result(result):\n"
-        "    \"\"\"Format a search result.\"\"\"\n"
-        "    return str(result)\n"
-        "\n"
-        "def validate_input(data):\n"
-        "    return data is not None\n"
-    )
-
-    # --- ChunkHound config ---
-    db_path = tmp_path / ".chunkhound" / "test.db"
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-    config = {
-        "database": {"path": str(db_path), "provider": "duckdb"},
-        "indexing": {"include": ["*.py"]},
-    }
-    (tmp_path / ".chunkhound.json").write_text(json.dumps(config))
-
-    # --- Index files (no embeddings — keeps tests API-key-free) ---
-    index_proc = await create_subprocess_exec_safe(
-        _chunkhound_exe(), "index", str(tmp_path), "--no-embeddings",
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        cwd=str(tmp_path),
-        env=get_safe_subprocess_env(),
-    )
-    _, stderr = await asyncio.wait_for(index_proc.communicate(), timeout=60.0)
-    assert index_proc.returncode == 0, (
-        f"Pre-indexing failed (rc={index_proc.returncode}): {stderr.decode()}"
-    )
+    await _prepare_project_dir(tmp_path)
 
     yield tmp_path
 
-    # --- Cleanup: stop any lingering daemon ---
-    from chunkhound.daemon.discovery import DaemonDiscovery
-
-    discovery = DaemonDiscovery(tmp_path)
-    lock = discovery.read_lock()
-    if lock:
-        pid = lock.get("pid")
-        if isinstance(pid, int):
-            try:
-                # Use psutil for cross-platform process termination
-                proc = psutil.Process(pid)
-                proc.terminate()  # SIGTERM on Unix, TerminateProcess on Windows
-                # Wait up to 5 seconds for graceful shutdown
-                try:
-                    proc.wait(timeout=5.0)
-                except psutil.TimeoutExpired:
-                    # Force kill if graceful shutdown fails
-                    proc.kill()
-                    proc.wait(timeout=2.0)
-            except (psutil.NoSuchProcess, psutil.AccessDenied):
-                pass
-            except Exception:
-                pass
-        discovery.remove_lock()
-    # Clean up Unix socket file (not applicable on Windows where TCP is used)
-    socket_path = discovery.get_socket_path()
-    if not socket_path.startswith("tcp:"):
-        try:
-            os.unlink(socket_path)
-        except Exception:
-            pass
+    _cleanup_project_dir(tmp_path)
 
 
 # ---------------------------------------------------------------------------
@@ -254,7 +328,8 @@ async def test_daemon_single_client_basic(pre_indexed_project_dir: Path) -> None
         await _teardown_proxy(proc, client)
 
     # After the proxy disconnects, the daemon should shut down
-    # Windows requires significantly more time for cleanup (see test_daemon_lock_file_created comments)
+    # Windows requires significantly more time for cleanup
+    # (see test_daemon_lock_file_created comments).
     stopped = await wait_for_daemon_shutdown(project_dir, timeout=30.0)
     assert stopped, "Daemon did not shut down after last client disconnected"
 
@@ -318,7 +393,8 @@ async def test_daemon_two_clients_concurrent(pre_indexed_project_dir: Path) -> N
         )
 
     # After both clients disconnect, daemon should shut down
-    # Windows requires significantly more time for cleanup (see test_daemon_lock_file_created comments)
+    # Windows requires significantly more time for cleanup
+    # (see test_daemon_lock_file_created comments).
     stopped = await wait_for_daemon_shutdown(project_dir, timeout=30.0)
     assert stopped, "Daemon did not shut down after all clients disconnected"
 
@@ -326,7 +402,7 @@ async def test_daemon_two_clients_concurrent(pre_indexed_project_dir: Path) -> N
 @pytest.mark.asyncio
 @pytest.mark.skipif(
     sys.platform == "win32",
-    reason="Daemon shutdown is unreliable on Windows due to process termination timing"
+    reason="Daemon shutdown is unreliable on Windows due to process termination timing",
 )
 async def test_daemon_lock_file_created(pre_indexed_project_dir: Path) -> None:
     """Verify the daemon lock file is created with correct content and cleaned up.
@@ -358,8 +434,14 @@ async def test_daemon_lock_file_created(pre_indexed_project_dir: Path) -> None:
         # Parse and validate lock file contents
         lock_data = json.loads(lock_path.read_text())
         assert "pid" in lock_data, f"Lock file missing 'pid': {lock_data}"
-        assert "socket_path" in lock_data, f"Lock file missing 'socket_path': {lock_data}"
+        assert "socket_path" in lock_data, (
+            f"Lock file missing 'socket_path': {lock_data}"
+        )
         assert "started_at" in lock_data, f"Lock file missing 'started_at': {lock_data}"
+        assert "project_dir" in lock_data, (
+            f"Lock file missing 'project_dir': {lock_data}"
+        )
+        assert lock_data["project_dir"] == str(project_dir.resolve())
 
         pid = lock_data["pid"]
         assert isinstance(pid, int) and pid > 0, f"Invalid PID in lock file: {pid}"
@@ -397,4 +479,164 @@ async def test_daemon_lock_file_created(pre_indexed_project_dir: Path) -> None:
     assert stopped, "Daemon did not shut down in time"
     assert not lock_path.exists(), (
         f"Lock file was not cleaned up after daemon shutdown: {lock_path}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_daemon_sibling_roots_allowed(tmp_path: Path) -> None:
+    """Sibling project roots should start separate daemons without conflict."""
+    root_a = tmp_path / "repo-a"
+    root_b = tmp_path / "repo-b"
+    fake_home = tmp_path / "home"
+    await _prepare_project_dir(root_a)
+    await _prepare_project_dir(root_b)
+
+    proc_a = client_a = proc_b = client_b = None
+    try:
+        proc_a, client_a = await _start_proxy(root_a, fake_home=fake_home)
+        await _do_mcp_handshake(client_a, timeout=30.0)
+        assert await wait_for_daemon_start(root_a, timeout=15.0)
+
+        proc_b, client_b = await _start_proxy(root_b, fake_home=fake_home)
+        await _do_mcp_handshake(client_b, timeout=30.0)
+        assert await wait_for_daemon_start(root_b, timeout=15.0)
+    finally:
+        await asyncio.gather(
+            *[
+                _teardown_proxy(proc, client)
+                for proc, client in ((proc_a, client_a), (proc_b, client_b))
+                if proc is not None and client is not None
+            ],
+            return_exceptions=True,
+        )
+        _cleanup_project_dir(root_a)
+        _cleanup_project_dir(root_b)
+
+
+@pytest.mark.asyncio
+async def test_daemon_parent_then_child_blocks(tmp_path: Path) -> None:
+    """A nested child root should be rejected while parent daemon is live."""
+    parent = tmp_path / "repo"
+    child = parent / "subdir"
+    fake_home = tmp_path / "home"
+    await _prepare_project_dir(parent)
+    await _prepare_project_dir(child)
+
+    proc = client = None
+    try:
+        proc, client = await _start_proxy(parent, fake_home=fake_home)
+        await _do_mcp_handshake(client, timeout=30.0)
+        assert await wait_for_daemon_start(parent, timeout=15.0)
+
+        returncode, _, stderr = await _run_proxy_to_failure(child, fake_home=fake_home)
+        assert returncode != 0
+        assert "Overlapping daemon roots are not supported." in stderr
+        assert str(parent.resolve()) in stderr
+        assert str(child.resolve()) in stderr
+    finally:
+        if proc is not None and client is not None:
+            await _teardown_proxy(proc, client)
+        _cleanup_project_dir(child)
+        _cleanup_project_dir(parent)
+
+
+@pytest.mark.asyncio
+async def test_daemon_child_then_parent_blocks(tmp_path: Path) -> None:
+    """A parent root should be rejected while child daemon is live."""
+    parent = tmp_path / "repo"
+    child = parent / "subdir"
+    fake_home = tmp_path / "home"
+    await _prepare_project_dir(parent)
+    await _prepare_project_dir(child)
+
+    proc = client = None
+    try:
+        proc, client = await _start_proxy(child, fake_home=fake_home)
+        await _do_mcp_handshake(client, timeout=30.0)
+        assert await wait_for_daemon_start(child, timeout=15.0)
+
+        returncode, _, stderr = await _run_proxy_to_failure(parent, fake_home=fake_home)
+        assert returncode != 0
+        assert "Overlapping daemon roots are not supported." in stderr
+        assert str(parent.resolve()) in stderr
+        assert str(child.resolve()) in stderr
+    finally:
+        if proc is not None and client is not None:
+            await _teardown_proxy(proc, client)
+        _cleanup_project_dir(child)
+        _cleanup_project_dir(parent)
+
+
+@pytest.mark.asyncio
+async def test_daemon_symlink_path_reuses_canonical_root(tmp_path: Path) -> None:
+    """A symlinked path to the same project should reuse the existing daemon."""
+    project_dir = tmp_path / "repo"
+    fake_home = tmp_path / "home"
+    await _prepare_project_dir(project_dir)
+
+    alias = tmp_path / "repo-link"
+    try:
+        alias.symlink_to(project_dir, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symbolic links not supported on this platform")
+
+    proc1 = client1 = proc2 = client2 = None
+    try:
+        proc1, client1 = await _start_proxy(project_dir, fake_home=fake_home)
+        await _do_mcp_handshake(client1, timeout=30.0)
+        assert await wait_for_daemon_start(project_dir, timeout=15.0)
+        first_pid = json.loads(
+            (project_dir / ".chunkhound" / "daemon.lock").read_text()
+        )["pid"]
+
+        proc2, client2 = await _start_proxy(alias, fake_home=fake_home)
+        await _do_mcp_handshake(client2, timeout=30.0)
+        second_pid = json.loads(
+            (project_dir / ".chunkhound" / "daemon.lock").read_text()
+        )["pid"]
+
+        assert first_pid == second_pid
+    finally:
+        await asyncio.gather(
+            *[
+                _teardown_proxy(proc, client)
+                for proc, client in ((proc1, client1), (proc2, client2))
+                if proc is not None and client is not None
+            ],
+            return_exceptions=True,
+        )
+        _cleanup_project_dir(project_dir)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Daemon shutdown is unreliable on Windows due to process termination timing",
+)
+async def test_daemon_registry_entry_removed_on_shutdown(
+    pre_indexed_project_dir: Path,
+) -> None:
+    """Daemon should publish and then remove its registry entry on shutdown."""
+    project_dir = pre_indexed_project_dir
+    fake_home = project_dir / "_home"
+
+    proc, client = await _start_proxy(project_dir, fake_home=fake_home)
+    registry_entry = None
+    try:
+        await _do_mcp_handshake(client, timeout=30.0)
+        assert await wait_for_daemon_start(project_dir, timeout=15.0)
+
+        registry_entry = await _wait_for_registry_entry(
+            fake_home, project_dir, timeout=15.0
+        )
+        assert registry_entry is not None, "Registry entry was not published"
+        assert registry_entry.exists()
+    finally:
+        await _teardown_proxy(proc, client)
+
+    stopped = await wait_for_daemon_shutdown(project_dir, timeout=30.0)
+    assert stopped, "Daemon did not shut down in time"
+    assert registry_entry is not None
+    assert not registry_entry.exists(), (
+        "Registry entry was not cleaned up after shutdown"
     )

--- a/tests/unit/test_daemon_overlap_guard.py
+++ b/tests/unit/test_daemon_overlap_guard.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from chunkhound.daemon.discovery import (
+    DaemonDiscovery,
+    _normalized_project_dir,
+    _roots_overlap,
+)
+
+
+def test_roots_overlap_classifies_same_parent_child_and_siblings(
+    tmp_path: Path,
+) -> None:
+    """Overlap checks should be path-segment aware."""
+    parent = tmp_path / "repo"
+    child = parent / "subdir"
+    sibling = tmp_path / "repo-b"
+
+    child.mkdir(parents=True)
+    sibling.mkdir()
+
+    assert _roots_overlap(parent, parent)
+    assert _roots_overlap(parent, child)
+    assert _roots_overlap(child, parent)
+    assert not _roots_overlap(parent, sibling)
+
+
+def test_normalized_project_dir_resolves_symlink_to_same_root(tmp_path: Path) -> None:
+    """Symlinked paths should normalize to the same canonical root."""
+    real_root = tmp_path / "real"
+    real_root.mkdir()
+    link_root = tmp_path / "link"
+    try:
+        link_root.symlink_to(real_root, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("Symbolic links not supported on this platform")
+
+    assert _normalized_project_dir(real_root) == _normalized_project_dir(link_root)
+    assert _roots_overlap(real_root, link_root)
+
+
+def test_registry_validation_removes_dead_entry(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Dead registry entries should be removed instead of blocking startup."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+    discovery = DaemonDiscovery(project_dir)
+    discovery.write_lock(999_999_999, "tcp:127.0.0.1:54321", auth_token="token")
+    discovery.write_registry_entry(999_999_999, "tcp:127.0.0.1:54321")
+
+    other = DaemonDiscovery(tmp_path / "other")
+    assert other.find_conflicting_daemon() is None
+    assert not discovery.get_registry_entry_path().exists()
+
+
+def test_registry_validation_removes_entry_without_lock(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Live-PID entries without a material lock should be cleaned up."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+    discovery = DaemonDiscovery(project_dir)
+    discovery.write_registry_entry(os.getpid(), "tcp:127.0.0.1:54321")
+
+    other = DaemonDiscovery(tmp_path / "other")
+    assert other.find_conflicting_daemon() is None
+    assert not discovery.get_registry_entry_path().exists()
+
+
+def test_registry_validation_reports_live_overlapping_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Validated registry entries should block overlapping parent/child roots."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    parent = tmp_path / "repo"
+    child = parent / "subdir"
+    child.mkdir(parents=True)
+
+    discovery = DaemonDiscovery(parent)
+    discovery.write_lock(os.getpid(), "tcp:127.0.0.1:54321", auth_token="token")
+    discovery.write_registry_entry(os.getpid(), "tcp:127.0.0.1:54321")
+
+    conflict = DaemonDiscovery(child).find_conflicting_daemon()
+    assert conflict is not None
+    assert conflict["project_dir"] == str(parent.resolve())
+    assert conflict["pid"] == os.getpid()
+    assert Path(conflict["lock_path"]) == parent / ".chunkhound" / "daemon.lock"


### PR DESCRIPTION
**Note**: This summary was generated by an AI agent.
If you'd like to discuss with humans, drop by our [Discord](https://discord.gg/BAepHEXXnX)!
---

Closes #212

## Summary
`main` only reuses daemons by exact canonical project root. That means `/repo` and `/repo/subdir` can both start separate daemons because discovery is limited to `<project>/.chunkhound/daemon.lock`.

This MR adds cross-root overlap detection while preserving exact-root reuse.

## What changed
- Added a user-scoped daemon registry for cross-root discovery.
- Kept `daemon.lock` as the source of truth. Registry entries are only used after validating:
  - live PID
  - expected lock path
  - matching canonical project root
- Extended `daemon.lock` with `project_dir`.
- Published registry entries after bind/lock ownership is confirmed and removed them on shutdown.
- Added unit coverage for overlap classification and stale registry cleanup.
- Added smoke coverage for sibling roots, parent/child blocking in both directions, symlink same-root reuse, and registry cleanup.

## Why this shape
We need visibility beyond the current project root, but we do not want a registry file to become the new authority. Using the registry as an index and validating against the existing lock keeps the current daemon contract intact and makes stale-entry cleanup straightforward.

## Breaking changes
No API or protocol breaking changes.

Behavior change only: starting a daemon for an overlapping parent/child root now fails fast instead of launching a second daemon. Exact-root reuse is unchanged.

## Value
- Prevents overlapping daemon topologies in nested project layouts.
- Avoids duplicate background work for the same tree.
- Preserves existing same-root reuse semantics.
- Establishes the daemon ownership guard needed before watcher-sidecar work.
