### PR TITLE
fix: forward batch_size and max_concurrent_batches config to Embedding Service during indexing

### DIFF
--- a/chunkhound/services/indexing_coordinator.py
+++ b/chunkhound/services/indexing_coordinator.py
@@ -1645,9 +1645,28 @@ class IndexingCoordinator(BaseService):
             # Use EmbeddingService for embedding generation
             from .embedding_service import EmbeddingService
 
+            # Read batch configuration from config (matching registry path)
+            embedding_batch_size = 1000
+            max_concurrent_batches = None
+            db_batch_size = 5000
+            if self.config and getattr(self.config, "embedding", None):
+                embedding_batch_size = getattr(
+                    self.config.embedding, "batch_size", 1000
+                )
+                max_concurrent_batches = getattr(
+                    self.config.embedding, "max_concurrent_batches", None
+                )
+            if self.config and getattr(self.config, "indexing", None):
+                db_batch_size = getattr(
+                    self.config.indexing, "db_batch_size", 5000
+                )
+
             embedding_service = EmbeddingService(
                 database_provider=self._db,
                 embedding_provider=self._embedding_provider,
+                embedding_batch_size=embedding_batch_size,
+                db_batch_size=db_batch_size,
+                max_concurrent_batches=max_concurrent_batches,
                 progress=self.progress,
                 metrics_collector=metrics_collector,
             )

--- a/tests/unit/test_batch_size_config_forwarding.py
+++ b/tests/unit/test_batch_size_config_forwarding.py
@@ -1,0 +1,89 @@
+"""Test that batch_size and max_concurrent_batches config is forwarded
+to EmbeddingService during indexing (issue #244).
+
+The registry code path correctly passes these values, but the
+IndexingCoordinator.process_directory() path was missing them.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from chunkhound.services.indexing_coordinator import IndexingCoordinator
+
+
+def _make_config(batch_size=1, max_concurrent=2, db_batch_size=500):
+    """Create a mock config with embedding and indexing settings."""
+    config = MagicMock()
+    config.embedding.batch_size = batch_size
+    config.embedding.max_concurrent_batches = max_concurrent
+    config.indexing.db_batch_size = db_batch_size
+    return config
+
+
+def _make_coordinator(tmp_path, config=None):
+    """Create an IndexingCoordinator with optional config."""
+    db = MagicMock()
+    embedding_provider = MagicMock()
+    return IndexingCoordinator(
+        database_provider=db,
+        base_directory=tmp_path,
+        embedding_provider=embedding_provider,
+        config=config,
+    )
+
+
+@pytest.mark.asyncio
+async def test_embedding_service_receives_batch_config(tmp_path):
+    """Verify EmbeddingService is constructed with batch config from user settings."""
+    config = _make_config(batch_size=1, max_concurrent=2, db_batch_size=500)
+    coordinator = _make_coordinator(tmp_path, config=config)
+
+    with patch(
+        "chunkhound.services.embedding_service.EmbeddingService"
+    ) as MockEmbeddingService:
+        mock_service = MagicMock()
+        mock_service.generate_missing_embeddings = AsyncMock(
+            return_value={"status": "ok", "generated": 0}
+        )
+        MockEmbeddingService.return_value = mock_service
+
+        # Patch the local import inside generate_missing_embeddings
+        with patch.dict(
+            "sys.modules",
+            {"chunkhound.services.embedding_service": MagicMock(EmbeddingService=MockEmbeddingService)},
+        ):
+            await coordinator.generate_missing_embeddings()
+
+        MockEmbeddingService.assert_called_once()
+        call_kwargs = MockEmbeddingService.call_args[1]
+        assert call_kwargs["embedding_batch_size"] == 1
+        assert call_kwargs["max_concurrent_batches"] == 2
+        assert call_kwargs["db_batch_size"] == 500
+
+
+@pytest.mark.asyncio
+async def test_embedding_service_defaults_without_config(tmp_path):
+    """Verify EmbeddingService uses defaults when no config is set."""
+    coordinator = _make_coordinator(tmp_path, config=None)
+
+    with patch(
+        "chunkhound.services.embedding_service.EmbeddingService"
+    ) as MockEmbeddingService:
+        mock_service = MagicMock()
+        mock_service.generate_missing_embeddings = AsyncMock(
+            return_value={"status": "ok", "generated": 0}
+        )
+        MockEmbeddingService.return_value = mock_service
+
+        with patch.dict(
+            "sys.modules",
+            {"chunkhound.services.embedding_service": MagicMock(EmbeddingService=MockEmbeddingService)},
+        ):
+            await coordinator.generate_missing_embeddings()
+
+        MockEmbeddingService.assert_called_once()
+        call_kwargs = MockEmbeddingService.call_args[1]
+        assert call_kwargs["embedding_batch_size"] == 1000
+        assert call_kwargs["max_concurrent_batches"] is None
+        assert call_kwargs["db_batch_size"] == 5000


### PR DESCRIPTION
The IndexingCoordinator.generate_missing_embeddings() path was constructing EmbeddingService without forwarding embedding.batch_size, embedding.max_concurrent_batches, or indexing.db_batch_size from the user's config. These always defaulted to 1000/auto/5000 regardless of .chunkhound.json settings.

This broke users with embedding providers that need batch_size=1 (e.g. FastFlowLM which returns 1 embedding regardless of input array size).

The fix reads batch config from self.config using the same pattern as the registry code path (registry/__init__.py), with safe defaults when config is absent.

Adds 2 unit tests verifying config forwarding and default behavior.

Closes #244