### PR TITLE
Add TwinCAT TcPOU language

### DIFF
--- a/chunkhound/core/types/common.py
+++ b/chunkhound/core/types/common.py
@@ -50,6 +50,11 @@ class ChunkType(Enum):
     DATA_CLASS = "data_class"
     EXTENSION_FUNCTION = "extension_function"
 
+    # IEC 61131-3 / PLC types
+    PROGRAM = "program"
+    FUNCTION_BLOCK = "function_block"
+    ACTION = "action"
+
     # C-specific types
     VARIABLE = "variable"
     TYPE = "type"
@@ -120,6 +125,9 @@ class ChunkType(Enum):
             ChunkType.MACRO,
             ChunkType.IMPORT,
             ChunkType.EMBEDDED_SQL,
+            ChunkType.PROGRAM,
+            ChunkType.FUNCTION_BLOCK,
+            ChunkType.ACTION,
         }
 
     @property
@@ -171,6 +179,7 @@ class Language(Enum):
     DART = "dart"
     ELIXIR = "elixir"
     LUA = "lua"
+    TWINCAT = "twincat"
 
     # Documentation languages
     MARKDOWN = "markdown"
@@ -281,6 +290,7 @@ class Language(Enum):
             ".ex": cls.ELIXIR,
             ".exs": cls.ELIXIR,
             ".lua": cls.LUA,
+            ".tcpou": cls.TWINCAT,
         }
 
         return extension_map.get(extension, cls.UNKNOWN)
@@ -323,6 +333,7 @@ class Language(Enum):
             Language.DART,
             Language.ELIXIR,
             Language.LUA,
+            Language.TWINCAT,
         }
 
     @property

--- a/chunkhound/mcp_server/stdio.py
+++ b/chunkhound/mcp_server/stdio.py
@@ -413,9 +413,7 @@ async def main(args: Any = None) -> None:
 
     if validation_errors:
         msg = "; ".join(str(e) for e in validation_errors)
-        _respond_with_startup_error(
-            Exception(f"Configuration errors: {msg}"), config
-        )
+        _respond_with_startup_error(Exception(f"Configuration errors: {msg}"), config)
         sys.exit(1)
 
     # Create and run the stdio server

--- a/chunkhound/parsers/chunk_splitter.py
+++ b/chunkhound/parsers/chunk_splitter.py
@@ -474,6 +474,10 @@ CHUNK_TYPE_TO_CONCEPT: dict[ChunkType, UniversalConcept] = {
     ChunkType.EXTENSION_FUNCTION: UniversalConcept.DEFINITION,
     ChunkType.VARIABLE: UniversalConcept.DEFINITION,
     ChunkType.MACRO: UniversalConcept.DEFINITION,
+    # IEC 61131-3 / TwinCAT-only kinds (not mapped above) -> DEFINITION
+    ChunkType.PROGRAM: UniversalConcept.DEFINITION,
+    ChunkType.FUNCTION_BLOCK: UniversalConcept.DEFINITION,
+    ChunkType.ACTION: UniversalConcept.DEFINITION,
     # Code structure -> STRUCTURE
     ChunkType.CLASS: UniversalConcept.STRUCTURE,
     ChunkType.INTERFACE: UniversalConcept.STRUCTURE,

--- a/chunkhound/parsers/mappings/elixir.py
+++ b/chunkhound/parsers/mappings/elixir.py
@@ -248,8 +248,14 @@ class ElixirMapping(BaseMapping):
                 metadata["node_type"] = def_node.type
 
                 # Count body lines for functions
-                if keyword in ("def", "defp", "defmacro", "defmacrop",
-                               "defguard", "defguardp"):
+                if keyword in (
+                    "def",
+                    "defp",
+                    "defmacro",
+                    "defmacrop",
+                    "defguard",
+                    "defguardp",
+                ):
                     body = self.find_child_by_type(def_node, "do_block")
                     if body:
                         body_text = self.get_node_text(body, source)
@@ -263,8 +269,10 @@ class ElixirMapping(BaseMapping):
                     clean = self.clean_comment_text(text)
                     if clean:
                         upper = clean.upper()
-                        if any(p in upper for p in
-                               ["TODO:", "FIXME:", "HACK:", "NOTE:", "WARNING:"]):
+                        if any(
+                            p in upper
+                            for p in ["TODO:", "FIXME:", "HACK:", "NOTE:", "WARNING:"]
+                        ):
                             metadata["comment_type"] = "annotation"
                         else:
                             metadata["comment_type"] = "regular"
@@ -309,9 +317,7 @@ class ElixirMapping(BaseMapping):
     ) -> list[Path]:
         # Elixir imports are module aliases, not file paths.
         # We can try to resolve alias/import to lib/ paths.
-        match = re.search(
-            r"(?:alias|import|use|require)\s+([\w.]+)", import_text
-        )
+        match = re.search(r"(?:alias|import|use|require)\s+([\w.]+)", import_text)
         if not match:
             return []
 
@@ -414,9 +420,7 @@ class ElixirMapping(BaseMapping):
         name = self._extract_func_name_from_args(args_node, source)
         return (keyword, name)
 
-    def _extract_func_name_from_args(
-        self, args_node: Node, source: str
-    ) -> str | None:
+    def _extract_func_name_from_args(self, args_node: Node, source: str) -> str | None:
         """Extract function name from a def/defp arguments node.
 
         Handles: def foo(a, b), def foo, defguard is_pos(x) when x > 0
@@ -464,9 +468,7 @@ class ElixirMapping(BaseMapping):
             if call_node:
                 inner_args = self.find_child_by_type(call_node, "arguments")
                 if inner_args:
-                    name = self._extract_type_name_from_args(
-                        inner_args, source
-                    )
+                    name = self._extract_type_name_from_args(inner_args, source)
                     if name:
                         return f"{attr_keyword}_{name}"
 
@@ -476,9 +478,7 @@ class ElixirMapping(BaseMapping):
 
         return attr_keyword
 
-    def _extract_type_name_from_args(
-        self, args_node: Node, source: str
-    ) -> str | None:
+    def _extract_type_name_from_args(self, args_node: Node, source: str) -> str | None:
         """Extract the type/spec name from attribute arguments.
 
         @spec foo(integer()) :: atom() -> 'foo'

--- a/chunkhound/parsers/parser_factory.py
+++ b/chunkhound/parsers/parser_factory.py
@@ -412,7 +412,9 @@ class ParserFactory:
             from chunkhound.parsers.twincat.twincat_mapping import TwinCATMapping
 
             mapping = TwinCATMapping()
-            return UniversalParser(engine=None, mapping=mapping, cast_config=cast_config)
+            return UniversalParser(
+                engine=None, mapping=mapping, cast_config=cast_config
+            )
 
         # Use cache to avoid recreating parsers
         cache_key = self._cache_key(language, detect_embedded_sql)

--- a/chunkhound/parsers/parser_factory.py
+++ b/chunkhound/parsers/parser_factory.py
@@ -435,7 +435,7 @@ class ParserFactory:
         parser: UniversalParser
 
         # Special handling for non-tree-sitter languages (text, PDF, TwinCAT)
-        if language in (Language.TEXT, Language.PDF, Language.TWINCAT):
+        if config.tree_sitter_module is None:
             # These mappings don't need a tree-sitter engine
             mapping = config.mapping_class()
             parser = UniversalParser(None, mapping, cast_config, detect_embedded_sql)  # type: ignore[arg-type]
@@ -594,7 +594,7 @@ class ParserFactory:
         """
         missing = {}
         for language, config in LANGUAGE_CONFIGS.items():
-            if not config.available and language not in (Language.TEXT, Language.PDF):
+            if not config.available and config.tree_sitter_module is not None:
                 missing[language] = (
                     f"pip install tree-sitter-{config.language_name.lower()}"
                 )

--- a/chunkhound/parsers/parser_factory.py
+++ b/chunkhound/parsers/parser_factory.py
@@ -81,6 +81,7 @@ from chunkhound.parsers.mappings import (
     ZigMapping,
 )
 from chunkhound.parsers.mappings.base import BaseMapping
+from chunkhound.parsers.twincat.twincat_mapping import TwinCATMapping
 from chunkhound.parsers.universal_engine import SetupError, TreeSitterEngine
 from chunkhound.parsers.universal_parser import CASTConfig, UniversalParser
 
@@ -241,7 +242,7 @@ LANGUAGE_CONFIGS: dict[Language, LanguageConfig] = {
     ),  # PDF doesn't need tree-sitter
     Language.TWINCAT: LanguageConfig(
         None,  # No tree-sitter module (uses Lark)
-        None,  # No mapping class (custom parser)
+        TwinCATMapping,
         True,  # Always available - lark is a hard dependency
         "twincat",
     ),
@@ -405,17 +406,6 @@ class ParserFactory:
 
             return MakefileParser(cast_config, detect_embedded_sql)
 
-        # Special case: TwinCAT uses Lark-based custom parser via mapping
-        # This routes TwinCAT through UniversalParser to benefit from
-        # cAST algorithm (deduplication, comment merging, greedy merge)
-        if language == Language.TWINCAT:
-            from chunkhound.parsers.twincat.twincat_mapping import TwinCATMapping
-
-            mapping = TwinCATMapping()
-            return UniversalParser(
-                engine=None, mapping=mapping, cast_config=cast_config
-            )
-
         # Use cache to avoid recreating parsers
         cache_key = self._cache_key(language, detect_embedded_sql)
         if cache_key in self._parser_cache:
@@ -444,9 +434,9 @@ class ParserFactory:
 
         parser: UniversalParser
 
-        # Special handling for text and PDF files (no tree-sitter required)
-        if language in (Language.TEXT, Language.PDF):
-            # Text and PDF mappings don't need tree-sitter engine
+        # Special handling for non-tree-sitter languages (text, PDF, TwinCAT)
+        if language in (Language.TEXT, Language.PDF, Language.TWINCAT):
+            # These mappings don't need a tree-sitter engine
             mapping = config.mapping_class()
             parser = UniversalParser(None, mapping, cast_config, detect_embedded_sql)  # type: ignore[arg-type]
             wrapped = self._maybe_wrap_yaml_parser(language, parser, cast_config)

--- a/chunkhound/parsers/parser_factory.py
+++ b/chunkhound/parsers/parser_factory.py
@@ -239,6 +239,12 @@ LANGUAGE_CONFIGS: dict[Language, LanguageConfig] = {
     Language.PDF: LanguageConfig(
         None, PDFMapping, True, "pdf"
     ),  # PDF doesn't need tree-sitter
+    Language.TWINCAT: LanguageConfig(
+        None,  # No tree-sitter module (uses Lark)
+        None,  # No mapping class (custom parser)
+        True,  # Always available - lark is a hard dependency
+        "twincat",
+    ),
 }
 
 # File extension to language mapping
@@ -338,6 +344,9 @@ EXTENSION_TO_LANGUAGE: dict[str, Language] = {
     ".text": Language.TEXT,
     # PDF files
     ".pdf": Language.PDF,
+    # TwinCAT / IEC 61131-3 Structured Text
+    ".TcPOU": Language.TWINCAT,
+    ".tcpou": Language.TWINCAT,
 }
 
 
@@ -395,6 +404,15 @@ class ParserFactory:
             from chunkhound.parsers.makefile_parser import MakefileParser
 
             return MakefileParser(cast_config, detect_embedded_sql)
+
+        # Special case: TwinCAT uses Lark-based custom parser via mapping
+        # This routes TwinCAT through UniversalParser to benefit from
+        # cAST algorithm (deduplication, comment merging, greedy merge)
+        if language == Language.TWINCAT:
+            from chunkhound.parsers.twincat.twincat_mapping import TwinCATMapping
+
+            mapping = TwinCATMapping()
+            return UniversalParser(engine=None, mapping=mapping, cast_config=cast_config)
 
         # Use cache to avoid recreating parsers
         cache_key = self._cache_key(language, detect_embedded_sql)

--- a/chunkhound/parsers/twincat/__init__.py
+++ b/chunkhound/parsers/twincat/__init__.py
@@ -1,0 +1,10 @@
+"""TwinCAT Structured Text parser for ChunkHound."""
+
+# Conditional export - only when lark is available
+try:
+    from .twincat_mapping import TwinCATMapping
+    from .twincat_parser import TwinCATParser
+
+    __all__ = ["TwinCATParser", "TwinCATMapping"]
+except ImportError:
+    __all__ = []

--- a/chunkhound/parsers/twincat/__init__.py
+++ b/chunkhound/parsers/twincat/__init__.py
@@ -1,10 +1,6 @@
 """TwinCAT Structured Text parser for ChunkHound."""
 
-# Conditional export - only when lark is available
-try:
-    from .twincat_mapping import TwinCATMapping
-    from .twincat_parser import TwinCATParser
+from .twincat_mapping import TwinCATMapping
+from .twincat_parser import TwinCATParser
 
-    __all__ = ["TwinCATParser", "TwinCATMapping"]
-except ImportError:
-    __all__ = []
+__all__ = ["TwinCATParser", "TwinCATMapping"]

--- a/chunkhound/parsers/twincat/common.lark
+++ b/chunkhound/parsers/twincat/common.lark
@@ -1,0 +1,72 @@
+// Common terminals and rules shared between declaration and implementation grammars
+
+// Whitespace and comments - to be ignored
+%import common.WS
+%ignore WS
+
+// Comments
+BLOCK_COMMENT: /\(\*[\s\S]*?\*\)/
+LINE_COMMENT: /\/\/[^\n]*/
+%ignore BLOCK_COMMENT
+%ignore LINE_COMMENT
+
+// Numbers
+HEX_NUMBER: /16#[0-9A-Fa-f_]+/
+BINARY_NUMBER: /2#[01_]+/
+OCTAL_NUMBER: /8#[0-7_]+/
+// FLOAT matches decimal numbers and scientific notation (with or without decimal point)
+FLOAT: /\d+\.\d+([eE][+-]?\d+)?/ | /\d+[eE][+-]?\d+/
+INTEGER: /\d+/
+
+// Time literals - various formats
+TIME_LITERAL: /[tT]#-?\d+(\.\d+)?([dDhHmMsS]|[mM][sS])+/
+           | /[tT][iI][mM][eE]#-?\d+(\.\d+)?([dDhHmMsS]|[mM][sS])+/
+
+// String literals
+STRING: /"[^"]*"/ | /'[^']*'/
+
+// Hardware addresses (I/O mapping)
+HW_ADDRESS: /%[IQM][XBWDLxbwdl]?\*/ | /%[IQM][XBWDLxbwdl]?\d+(\.\d+)?/
+
+// Primitive data types
+BOOL: /BOOL/i
+BYTE: /BYTE/i
+WORD: /WORD/i
+DWORD: /DWORD/i
+LWORD: /LWORD/i
+SINT: /SINT/i
+USINT: /USINT/i
+INT: /INT/i
+UINT: /UINT/i
+DINT: /DINT/i
+UDINT: /UDINT/i
+LINT: /LINT/i
+ULINT: /ULINT/i
+REAL: /REAL/i
+LREAL: /LREAL/i
+TIME: /TIME/i
+DATE: /DATE/i
+TIME_OF_DAY: /TIME_OF_DAY/i | /TOD/i
+DATE_AND_TIME: /DATE_AND_TIME/i | /DT/i
+STRING_TYPE: /STRING/i
+WSTRING: /WSTRING/i
+
+// Boolean literals
+TRUE: /TRUE/i
+FALSE: /FALSE/i
+
+// Shared keywords
+OF: /OF/i
+TO: /TO/i
+
+// Arithmetic operator
+MINUS: "-"
+
+// Integer value rule (array bounds, case labels)
+integer_value: MINUS? INTEGER
+             | HEX_NUMBER
+             | BINARY_NUMBER
+             | OCTAL_NUMBER
+
+// Note: IDENTIFIER is intentionally NOT shared. Each grammar defines its own
+// IDENTIFIER with a negative lookahead that excludes grammar-specific keywords.

--- a/chunkhound/parsers/twincat/declarations.lark
+++ b/chunkhound/parsers/twincat/declarations.lark
@@ -1,0 +1,224 @@
+// Grammar for TwinCAT Structured Text variable declarations
+//
+// IMPORT STRATEGY: Shared terminals (numbers, strings, booleans, etc.) are imported
+// from common.lark. IDENTIFIER is defined locally with a negative lookahead that
+// excludes declaration-specific keywords (VAR, FUNCTION_BLOCK, type names, etc.).
+// This prevents keywords from being parsed as identifiers while allowing keywords
+// from other grammars (e.g., IF, WHILE) to be valid variable names here.
+
+// Import shared terminals and rules from common.lark
+%import .common (HEX_NUMBER, BINARY_NUMBER, OCTAL_NUMBER, FLOAT, INTEGER, TIME_LITERAL, STRING, TRUE, FALSE, MINUS, OF, TO, integer_value, HW_ADDRESS, BOOL, BYTE, WORD, DWORD, LWORD, SINT, USINT, INT, UINT, DINT, UDINT, LINT, ULINT, REAL, LREAL, TIME, DATE, TIME_OF_DAY, DATE_AND_TIME, STRING_TYPE, WSTRING, WS, BLOCK_COMMENT, LINE_COMMENT)
+%ignore WS
+%ignore BLOCK_COMMENT
+%ignore LINE_COMMENT
+
+// Entry point - complete declaration section
+start: pou_declaration
+     | action_declaration
+     | method_declaration
+
+// POU (Program Organization Unit) header and body
+pou_declaration: pou_header var_block* pou_end?
+
+// Action declarations have only VAR blocks (no POU header)
+action_declaration: var_block+
+
+// Method declarations (within FUNCTION_BLOCK)
+method_declaration: attribute* method_header var_block* method_end?
+
+method_header: METHOD access_specifier? IDENTIFIER (":" type_spec)?
+
+access_specifier: PUBLIC | PRIVATE | PROTECTED | INTERNAL | FINAL | ABSTRACT
+
+method_end: END_METHOD
+
+pou_header: PROGRAM IDENTIFIER
+          | FUNCTION_BLOCK IDENTIFIER extends_clause? implements_clause?
+          | FUNCTION IDENTIFIER ":" type_spec
+
+extends_clause: EXTENDS IDENTIFIER
+implements_clause: IMPLEMENTS IDENTIFIER ("," IDENTIFIER)*
+
+pou_end: END_PROGRAM
+       | END_FUNCTION_BLOCK
+       | END_FUNCTION
+
+// Variable blocks
+var_block: attribute* var_block_start var_qualifier* var_declaration* var_block_end
+
+var_block_start: VAR_INPUT
+               | VAR_OUTPUT
+               | VAR_IN_OUT
+               | VAR_GLOBAL
+               | VAR_EXTERNAL
+               | VAR_TEMP
+               | VAR_STAT
+               | VAR
+
+var_qualifier: CONSTANT
+             | RETAIN
+             | PERSISTENT
+
+var_block_end: END_VAR
+
+// Variable declaration
+var_declaration: attribute* IDENTIFIER ("," IDENTIFIER)* hw_location? ":" type_spec (":=" initial_value)? ";"
+
+// Hardware location (AT directive)
+hw_location: "AT" HW_ADDRESS
+
+// Type specification
+type_spec: primitive_type
+         | string_type_with_size
+         | array_type
+         | pointer_type
+         | reference_type
+         | user_type
+
+primitive_type: BOOL | BYTE | WORD | DWORD | LWORD
+              | SINT | USINT | INT | UINT | DINT | UDINT | LINT | ULINT
+              | REAL | LREAL | TIME | DATE | TIME_OF_DAY | DATE_AND_TIME
+
+// STRING can have size in brackets [n] or parentheses (n)
+string_type_with_size: STRING_TYPE ("[" INTEGER "]")?
+                     | STRING_TYPE "(" INTEGER ")"
+                     | WSTRING ("[" INTEGER "]")?
+                     | WSTRING "(" INTEGER ")"
+
+array_type: ARRAY "[" array_range ("," array_range)* "]" OF type_spec
+
+array_range: array_bound ".." array_bound
+
+// Array bounds can be integer literals or constant identifiers
+array_bound: integer_value
+           | IDENTIFIER
+
+pointer_type: POINTER TO type_spec
+
+reference_type: REFERENCE TO type_spec
+
+user_type: IDENTIFIER
+
+// Initial values
+initial_value: literal
+             | array_initializer
+             | struct_initializer
+             | const_expression
+             | identifier_value
+
+// Combined rule for IDENTIFIER-starting initial values
+// Left-factors the common IDENTIFIER prefix to eliminate shift-reduce conflict
+// After IDENTIFIER, the parser looks ahead to determine:
+//   - "(" → function_call path
+//   - "." or end → qualified_identifier path
+identifier_value: IDENTIFIER "(" (init_call_arg ("," init_call_arg)*)? ")" -> function_call
+                | IDENTIFIER ("." IDENTIFIER)* -> qualified_identifier
+
+init_call_arg: IDENTIFIER ":=" init_call_arg_value?
+             | init_call_arg_value
+
+// Values that can appear as function call arguments
+// Uses same left-factoring pattern as identifier_value for IDENTIFIER-starting alternatives
+init_call_arg_value: literal
+                   | IDENTIFIER "(" (init_call_arg ("," init_call_arg)*)? ")" -> function_call
+                   | IDENTIFIER ("." IDENTIFIER)* -> qualified_identifier
+
+// Constant expressions (for use in initial values)
+const_expression: SIZEOF "(" type_or_var ")"
+                | "(" const_expr_operand (const_op const_expr_operand)* ")"
+
+const_expr_operand: const_expression
+                  | IDENTIFIER
+                  | integer_value
+
+type_or_var: IDENTIFIER
+           | primitive_type
+
+const_op: "+" | "-" | "*" | "/"
+
+SIZEOF: /SIZEOF/i
+
+literal: boolean_literal
+       | numeric_literal
+       | string_literal
+       | time_literal
+
+boolean_literal: TRUE | FALSE
+
+numeric_literal: MINUS? FLOAT
+               | MINUS? INTEGER
+               | HEX_NUMBER
+               | BINARY_NUMBER
+               | OCTAL_NUMBER
+
+string_literal: STRING
+
+time_literal: TIME_LITERAL
+
+// Array initializer
+array_initializer: "[" (array_init_element ("," array_init_element)*)? "]"
+
+// Array init element can be a simple value or a repetition like 81(0)
+array_init_element: INTEGER "(" initial_value ")"  // repetition: count(value)
+                  | initial_value
+
+// Struct initializer (parenthesized)
+struct_initializer: "(" (field_init ("," field_init)*)? ")"
+
+field_init: IDENTIFIER ":=" initial_value
+
+// Attribute pragmas
+attribute: "{" ATTRIBUTE_CONTENT "}"
+
+// Keywords - use negative lookahead for prefix keywords to prevent partial matching
+// With contextual lexer, parser state determines valid tokens
+FUNCTION_BLOCK: /FUNCTION_BLOCK/i
+END_FUNCTION_BLOCK: /END_FUNCTION_BLOCK/i
+END_FUNCTION: /END_FUNCTION/i
+FUNCTION: /FUNCTION(?!_)/i
+PROGRAM: /PROGRAM/i
+END_PROGRAM: /END_PROGRAM/i
+METHOD: /METHOD(?!_)/i
+END_METHOD: /END_METHOD/i
+
+// Access specifiers for methods
+PUBLIC: /PUBLIC/i
+PRIVATE: /PRIVATE/i
+PROTECTED: /PROTECTED/i
+INTERNAL: /INTERNAL/i
+FINAL: /FINAL/i
+ABSTRACT: /ABSTRACT/i
+
+// VAR compound keywords
+VAR_INPUT: /VAR_INPUT/i
+VAR_OUTPUT: /VAR_OUTPUT/i
+VAR_IN_OUT: /VAR_IN_OUT/i
+VAR_GLOBAL: /VAR_GLOBAL/i
+VAR_EXTERNAL: /VAR_EXTERNAL/i
+VAR_TEMP: /VAR_TEMP/i
+VAR_STAT: /VAR_STAT/i
+END_VAR: /END_VAR/i
+VAR: /VAR(?!_)/i
+
+CONSTANT: /CONSTANT/i
+RETAIN: /RETAIN/i
+PERSISTENT: /PERSISTENT/i
+
+ARRAY: /ARRAY/i
+POINTER: /POINTER/i
+REFERENCE: /REFERENCE/i
+
+// Inheritance keywords
+EXTENDS: /EXTENDS/i
+IMPLEMENTS: /IMPLEMENTS/i
+
+// Identifiers - negative lookahead prevents matching keywords and time literal prefix
+// Keywords that could conflict: END_VAR, END_PROGRAM, END_FUNCTION, END_FUNCTION_BLOCK,
+// END_METHOD, METHOD, VAR_*, VAR, FUNCTION_BLOCK, FUNCTION, PROGRAM, CONSTANT, RETAIN,
+// PERSISTENT, ARRAY, OF, POINTER, REFERENCE, TO, type keywords, TRUE, FALSE, SIZEOF,
+// PUBLIC, PRIVATE, PROTECTED, INTERNAL, FINAL, ABSTRACT, EXTENDS, IMPLEMENTS
+// Also exclude T# and t# which are time literal prefixes
+IDENTIFIER: /(?!(END_VAR|END_PROGRAM|END_FUNCTION_BLOCK|END_FUNCTION|END_METHOD|VAR_INPUT|VAR_OUTPUT|VAR_IN_OUT|VAR_GLOBAL|VAR_EXTERNAL|VAR_TEMP|VAR_STAT|VAR|FUNCTION_BLOCK|FUNCTION|PROGRAM|METHOD|CONSTANT|RETAIN|PERSISTENT|ARRAY|OF|POINTER|REFERENCE|TO|TIME_OF_DAY|DATE_AND_TIME|TOD|DT|BOOL|BYTE|WORD|DWORD|LWORD|SINT|USINT|UINT|UDINT|DINT|LINT|ULINT|INT|REAL|LREAL|TIME|DATE|STRING|WSTRING|TRUE|FALSE|SIZEOF|PUBLIC|PRIVATE|PROTECTED|INTERNAL|FINAL|ABSTRACT|EXTENDS|IMPLEMENTS)\b)(?![tT]#)[a-zA-Z_][a-zA-Z0-9_]*/i
+
+// Attribute content
+ATTRIBUTE_CONTENT: /[^}]+/

--- a/chunkhound/parsers/twincat/exceptions.py
+++ b/chunkhound/parsers/twincat/exceptions.py
@@ -1,0 +1,35 @@
+"""Custom exceptions for the ST parser."""
+
+
+class STParserError(Exception):
+    """Base exception for ST parser errors."""
+
+    def __init__(
+        self, message: str, line: int | None = None, column: int | None = None
+    ):
+        self.line = line
+        self.column = column
+        location = ""
+        if line is not None:
+            location = f" at line {line}"
+            if column is not None:
+                location += f", column {column}"
+        super().__init__(f"{message}{location}")
+
+
+class XMLExtractionError(STParserError):
+    """Error extracting ST code from TcPOU XML."""
+
+    pass
+
+
+class DeclarationParseError(STParserError):
+    """Error parsing variable declarations."""
+
+    pass
+
+
+class ImplementationParseError(STParserError):
+    """Error parsing ST implementation code."""
+
+    pass

--- a/chunkhound/parsers/twincat/implementation.lark
+++ b/chunkhound/parsers/twincat/implementation.lark
@@ -1,0 +1,252 @@
+// Grammar for TwinCAT Structured Text implementation code
+//
+// IMPORT STRATEGY: Shared terminals (numbers, strings, booleans, etc.) are imported
+// from common.lark. IDENTIFIER is defined locally with a negative lookahead that
+// excludes implementation-specific keywords (IF, WHILE, FOR, etc.). This prevents
+// keywords from being parsed as identifiers while allowing keywords from other
+// grammars (e.g., VAR, FUNCTION_BLOCK) to be valid variable names here.
+
+// Import shared terminals and rules from common.lark
+%import .common (HEX_NUMBER, BINARY_NUMBER, OCTAL_NUMBER, FLOAT, INTEGER, TIME_LITERAL, STRING, TRUE, FALSE, MINUS, OF, TO, integer_value, WS, BLOCK_COMMENT, LINE_COMMENT)
+%ignore WS
+%ignore BLOCK_COMMENT
+%ignore LINE_COMMENT
+
+// Entry point - sequence of statements
+start: statement*
+
+// Statements
+?statement: assignment_stmt
+          | function_call_stmt
+          | if_stmt
+          | case_stmt
+          | for_stmt
+          | while_stmt
+          | repeat_stmt
+          | exit_stmt
+          | continue_stmt
+          | return_stmt
+          | expression_stmt
+          | empty_stmt
+
+// Expression statement: standalone expression like member access
+// Must be placed after function_call_stmt so function calls take priority
+expression_stmt: variable ";"
+
+// Assignment statement: var := expr;
+assignment_stmt: variable ASSIGN expression ";"
+
+ASSIGN: ":="
+OUTPUT_ARROW: "=>"
+
+// Standalone function call: MyFunc(a, b);
+function_call_stmt: function_call ";"
+
+// IF statement
+if_stmt: IF expression THEN statement* elsif_clause* else_clause? END_IF ";"?
+
+elsif_clause: ELSIF expression THEN statement*
+
+else_clause: ELSE statement*
+
+// CASE statement
+// Uses left-factoring to resolve LALR shift-reduce conflict between:
+// - case_label: IDENTIFIER(.IDENTIFIER)* followed by ":"
+// - statement: IDENTIFIER(.IDENTIFIER)* followed by ":=" or ";" or "("
+// The common prefix is factored out, then disambiguation happens based on the following token.
+case_stmt: CASE expression OF case_body else_clause? END_CASE ";"?
+
+// Case body contains a sequence of case items
+// Each item is either a case label line or a statement
+case_body: case_item*
+
+// A case item starts with either an integer (unambiguous case label)
+// or an identifier (ambiguous - could be case label or statement)
+?case_item: integer_case_label
+          | identifier_case_item
+          | keyword_statement
+          | empty_stmt
+
+// Integer-based case labels are unambiguous
+// Handles: 1:  or  1..5:  or  1, 2, 3:
+integer_case_label: integer_case_value ("," integer_case_value)* ":"
+
+integer_case_value: integer_value
+                  | integer_value ".." integer_value
+
+// Identifier-starting items: left-factor the common IDENTIFIER prefix
+// After parsing IDENTIFIER, look at what follows to determine the path
+identifier_case_item: IDENTIFIER id_case_continuation
+
+// Continuation after IDENTIFIER in case body context
+// Determines whether this is a case label, assignment, expression stmt, or function call
+?id_case_continuation: "." IDENTIFIER id_case_continuation                           -> id_member_path
+                     | "." INTEGER id_case_continuation                              -> id_bit_path
+                     | "[" expression ("," expression)* "]" id_case_continuation     -> id_array_path
+                     | "^" id_case_continuation                                      -> id_deref_path
+                     | "(" (call_arg ("," call_arg)*)? ")" ";"                        -> id_func_call_end
+                     | ":"                                                             -> id_case_label_end
+                     | "," case_label_tail ":"                                         -> id_case_label_list_end
+                     | ASSIGN expression ";"                                          -> id_assignment_end
+                     | ";"                                                            -> id_expr_stmt_end
+
+// For case labels with multiple values after the first identifier path
+// e.g., Enum.a, Enum.b, 3:
+case_label_tail: case_label_value ("," case_label_value)*
+
+case_label_value: integer_value
+                | integer_value ".." integer_value
+                | IDENTIFIER ("." IDENTIFIER)*
+
+// Keyword-starting statements that cannot be confused with case labels
+// These are unambiguous because they start with reserved keywords
+?keyword_statement: if_stmt
+                  | for_stmt
+                  | while_stmt
+                  | repeat_stmt
+                  | exit_stmt
+                  | continue_stmt
+                  | return_stmt
+                  | case_stmt
+
+// FOR loop - supports both normal syntax and parenthesized initial assignment
+for_stmt: FOR IDENTIFIER ASSIGN expression TO expression by_clause? DO statement* END_FOR ";"?
+        | FOR "(" IDENTIFIER ASSIGN expression ")" TO expression by_clause? DO statement* END_FOR ";"?
+
+by_clause: BY expression
+
+// WHILE loop
+while_stmt: WHILE expression DO statement* END_WHILE ";"?
+
+// REPEAT loop
+repeat_stmt: REPEAT statement* UNTIL expression END_REPEAT ";"?
+
+// Jump statements
+exit_stmt: EXIT ";"
+continue_stmt: CONTINUE ";"
+return_stmt: RETURN ("(" expression ")")? ";"
+
+// Empty statement (just semicolon)
+empty_stmt: ";"
+
+// Expressions - precedence from lowest to highest
+?expression: or_xor_expr
+
+?or_xor_expr: and_expr ((OR | OR_ELSE | XOR) and_expr)*
+
+?and_expr: equality ((AND | AND_THEN) equality)*
+
+?equality: relational (eq_op relational)*
+eq_op: "=" -> eq
+     | "<>" -> ne
+
+?relational: add_expr (rel_op add_expr)*
+rel_op: "<=" -> le
+      | ">=" -> ge
+      | "<" -> lt
+      | ">" -> gt
+
+?add_expr: mul_expr ((PLUS | MINUS) mul_expr)*
+
+?mul_expr: unary_expr ((STAR | SLASH | MOD) unary_expr)*
+
+?unary_expr: NOT unary_expr -> not_expr
+           | MINUS unary_expr -> neg_expr
+           | exp_expr
+
+// Exponentiation binds tighter than unary operators per IEC 61131-3
+// i.e., -2**3 = -(2**3), NOT a**b = NOT(a**b)
+// Supports both ** operator and EXPT keyword
+?exp_expr: primary ((POWER | EXPT) exp_expr)?
+
+?primary: "(" expression ")"
+        | function_call
+        | literal
+        | variable
+
+// Function call: FUNC(arg1, arg2) or TYPE_CONVERSION(val)
+// Also handles FB invocations with named parameters
+// Also handles method calls: obj.Method(args)
+// Note: EXPT can be used as a function call (EXPT(a, b)) in addition to infix operator (a EXPT b)
+function_call: IDENTIFIER "(" (call_arg ("," call_arg)*)? ")"
+             | variable "(" (call_arg ("," call_arg)*)? ")"
+             | EXPT "(" (call_arg ("," call_arg)*)? ")"
+
+call_arg: IDENTIFIER ASSIGN expression? -> named_input_arg
+        | IDENTIFIER OUTPUT_ARROW variable? -> named_output_arg
+        | expression
+
+// Variable reference with possible member/array/bit access
+variable: IDENTIFIER accessor*
+
+accessor: "." IDENTIFIER -> member_access
+        | "." INTEGER -> bit_access
+        | "[" expression ("," expression)* "]" -> array_access
+        | "^" -> dereference
+
+// Literals
+literal: boolean_literal
+       | numeric_literal
+       | string_literal
+       | time_literal
+
+boolean_literal: TRUE -> true_lit
+               | FALSE -> false_lit
+
+numeric_literal: FLOAT -> float_lit
+               | INTEGER -> int_lit
+               | HEX_NUMBER -> hex_lit
+               | BINARY_NUMBER -> bin_lit
+               | OCTAL_NUMBER -> oct_lit
+
+string_literal: STRING -> string_lit
+
+time_literal: TIME_LITERAL -> time_lit
+
+// Keywords - contextual lexer will match correctly with IDENTIFIER negative lookahead
+IF: /IF/i
+THEN: /THEN/i
+ELSIF: /ELSIF/i
+ELSE: /ELSE/i
+END_IF: /END_IF/i
+
+CASE: /CASE/i
+END_CASE: /END_CASE/i
+
+FOR: /FOR/i
+BY: /BY/i
+DO: /DO/i
+END_FOR: /END_FOR/i
+
+WHILE: /WHILE/i
+END_WHILE: /END_WHILE/i
+
+REPEAT: /REPEAT/i
+UNTIL: /UNTIL/i
+END_REPEAT: /END_REPEAT/i
+
+EXIT: /EXIT/i
+CONTINUE: /CONTINUE/i
+RETURN: /RETURN/i
+
+// Operators
+AND: /AND(?!_THEN)/i
+AND_THEN: /AND_THEN/i
+OR: /OR(?!_ELSE)/i
+OR_ELSE: /OR_ELSE/i
+XOR: /XOR/i
+NOT: /NOT/i
+MOD: /MOD/i
+
+// Arithmetic operators as terminals
+PLUS: "+"
+STAR: "*"
+SLASH: "/"
+POWER: "**"
+EXPT: /EXPT/i
+
+// Identifiers - negative lookahead prevents matching keywords
+// Keywords: IF, THEN, ELSIF, ELSE, END_IF, CASE, OF, END_CASE, FOR, TO, BY, DO, END_FOR,
+// WHILE, END_WHILE, REPEAT, UNTIL, END_REPEAT, EXIT, CONTINUE, RETURN, AND, AND_THEN, OR, OR_ELSE, XOR, NOT, MOD, EXPT, TRUE, FALSE
+// Also exclude T# which is a time literal prefix
+IDENTIFIER: /(?!(IF|THEN|ELSIF|ELSE|END_IF|CASE|OF|END_CASE|FOR|TO|BY|DO|END_FOR|WHILE|END_WHILE|REPEAT|UNTIL|END_REPEAT|EXIT|CONTINUE|RETURN|AND_THEN|AND|OR_ELSE|OR|XOR|NOT|MOD|EXPT|TRUE|FALSE)\b)(?![tT]#)[a-zA-Z_][a-zA-Z0-9_]*/i

--- a/chunkhound/parsers/twincat/twincat_mapping.py
+++ b/chunkhound/parsers/twincat/twincat_mapping.py
@@ -186,12 +186,11 @@ class TwinCATMapping(BaseMapping):
         if symbol_upper in _STDLIB_TYPES:
             return []
 
-        # Search from source file's directory rather than base_dir.
-        # While base_dir would provide complete coverage, searching the entire
-        # project tree on every import resolution is expensive. We compromise
-        # by searching from source_file's directory, which covers most cases
-        # since TwinCAT projects typically co-locate related POUs.
-        result = self._find_symbol_file(symbol, source_file.parent)
+        # TwinCAT has project-wide symbol visibility: any POU can reference any
+        # other regardless of directory structure. This requires scanning from
+        # base_dir on every call (O(files × symbols)), but is acceptable in
+        # practice — typical TwinCAT projects have tens to low hundreds of POUs.
+        result = self._find_symbol_file(symbol, base_dir)
         if result is not None:
             return [result.resolve()]  # Ensure absolute path
         return []

--- a/chunkhound/parsers/twincat/twincat_mapping.py
+++ b/chunkhound/parsers/twincat/twincat_mapping.py
@@ -1,0 +1,237 @@
+"""TwinCAT mapping for UniversalParser integration.
+
+This module provides the TwinCATMapping class that enables TwinCAT Structured Text
+files to be processed through the UniversalParser pipeline, benefiting from
+chunk deduplication, cAST algorithm optimization, and comment merging.
+
+Unlike other mappings that use tree-sitter queries, this mapping delegates
+to TwinCATParser (Lark-based) and provides an `extract_universal_chunks()`
+method that UniversalParser calls when engine=None.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from chunkhound.core.types.common import Language
+from chunkhound.parsers.mappings.base import BaseMapping
+from chunkhound.parsers.universal_engine import UniversalChunk
+
+if TYPE_CHECKING:
+    from chunkhound.parsers.twincat.twincat_parser import TwinCATParser
+
+# IEC 61131-3 primitive types to skip
+_PRIMITIVE_TYPES = frozenset({
+    "BOOL", "BYTE", "WORD", "DWORD", "LWORD",
+    "SINT", "USINT", "INT", "UINT", "DINT", "UDINT", "LINT", "ULINT",
+    "REAL", "LREAL", "TIME", "LTIME", "DATE", "LDATE",
+    "TIME_OF_DAY", "TOD", "LTOD", "DATE_AND_TIME", "DT", "LDT",
+    "STRING", "WSTRING",
+    "ANY", "ANY_INT", "ANY_REAL", "ANY_NUM", "ANY_BIT", "ANY_STRING", "ANY_DATE",
+})
+
+# IEC 61131-3 Standard Library function blocks to skip
+_STDLIB_TYPES = frozenset({
+    "TON", "TOF", "TP", "RTC",           # Timers
+    "CTU", "CTD", "CTUD",                # Counters
+    "R_TRIG", "F_TRIG",                  # Triggers
+    "SR", "RS",                          # Flip-flops
+})
+
+# File extension for TcPOU files (Function Blocks, Interfaces, Programs, Functions)
+_TWINCAT_EXTENSION = ".TcPOU"
+
+# Lazy import to avoid circular dependency
+_parser: TwinCATParser | None = None
+
+
+def _get_parser() -> TwinCATParser:
+    """Get or create the TwinCATParser instance (lazy loading)."""
+    global _parser
+    if _parser is None:
+        from chunkhound.parsers.twincat.twincat_parser import TwinCATParser
+
+        _parser = TwinCATParser()
+    return _parser
+
+
+class TwinCATMapping(BaseMapping):
+    """Mapping for TwinCAT Structured Text via Lark parser.
+
+    Unlike other mappings that use tree-sitter queries, this mapping
+    uses TwinCATParser (Lark-based) to extract UniversalChunk objects.
+
+    The mapping provides `extract_universal_chunks()` which UniversalParser
+    calls when engine=None, enabling TwinCAT files to benefit from the
+    full cAST pipeline (deduplication, comment merging, greedy merge).
+    """
+
+    def __init__(self) -> None:
+        """Initialize TwinCAT mapping."""
+        super().__init__(Language.TWINCAT)
+
+    def extract_universal_chunks(
+        self,
+        content: str,
+        file_path: Path | None = None,
+    ) -> list[UniversalChunk]:
+        """Extract UniversalChunk objects from TcPOU content.
+
+        Called by UniversalParser when engine is None and this method exists.
+
+        Args:
+            content: TcPOU XML content string
+            file_path: Optional path to the source file
+
+        Returns:
+            List of UniversalChunk objects for cAST processing
+        """
+        parser = _get_parser()
+        return parser.extract_universal_chunks(content, file_path)
+
+    def extract_imports(
+        self,
+        content: str,
+    ) -> list[UniversalChunk]:
+        """Extract only import chunks from TcPOU content.
+
+        More efficient than extract_universal_chunks() when only
+        imports are needed.
+
+        Args:
+            content: TcPOU XML content string
+
+        Returns:
+            List of UniversalChunk objects representing imports
+        """
+        parser = _get_parser()
+        return parser.extract_import_chunks(content)
+
+    def _extract_symbol_name(self, import_text: str) -> str:
+        """Extract symbol name from import text.
+
+        Handles formats like:
+        - "FB_Motor" (direct symbol)
+        - "gMotor : FB_Motor;" (var declaration)
+        - "EXTENDS FB_Base" (inheritance)
+        - "type reference: ST_Config" (type ref metadata)
+        - "pMotor : POINTER TO FB_Motor;" (pointer)
+        - "refMotor : REFERENCE TO FB_Motor;" (reference)
+        - "pArray : POINTER TO ARRAY[0..9] OF FB_Motor;" (nested)
+        """
+        # Extract type part after colon if present (var declaration or type ref)
+        if ":" in import_text:
+            parts = import_text.split(":")
+            type_part = parts[-1].strip().rstrip(";").strip()
+        else:
+            type_part = import_text.strip()
+
+        upper_part = type_part.upper()
+
+        # Handle EXTENDS/IMPLEMENTS keywords
+        for keyword in ["EXTENDS", "IMPLEMENTS"]:
+            if keyword in upper_part:
+                pos = upper_part.rfind(keyword)
+                type_part = type_part[pos + len(keyword) :].strip()
+                upper_part = type_part.upper()
+                break
+
+        # Handle ARRAY types FIRST - extract element type after last OF
+        of_matches = list(re.finditer(r"\bOF\b", upper_part))
+        if of_matches:
+            of_pos = of_matches[-1].start()  # Last match for nested arrays
+            type_part = type_part[of_pos + 2 :].strip()
+            upper_part = type_part.upper()
+
+        # THEN strip POINTER TO / REFERENCE TO prefixes (may be nested)
+        while True:
+            stripped = False
+            for keyword in ["POINTER TO", "REFERENCE TO"]:
+                if upper_part.startswith(keyword):
+                    type_part = type_part[len(keyword) :].strip()
+                    upper_part = type_part.upper()
+                    stripped = True
+                    break
+            if not stripped:
+                break
+
+        return type_part
+
+    def _find_symbol_file(self, symbol: str, base_dir: Path) -> Path | None:
+        """Search for symbol file with case-insensitive matching."""
+        symbol_lower = symbol.lower()
+
+        for file_path in base_dir.rglob(f"*{_TWINCAT_EXTENSION}"):
+            if file_path.stem.lower() == symbol_lower:
+                return file_path
+        return None
+
+    def resolve_import_paths(
+        self,
+        import_text: str,
+        base_dir: Path,
+        source_file: Path,
+    ) -> list[Path]:
+        """Resolve TwinCAT import symbol to .TcPOU file paths.
+
+        Unlike Python/JS with `import "file.py"` syntax, TwinCAT uses
+        symbol-based imports (e.g., `FB_Motor`). This method maps symbol
+        names to `.TcPOU` files.
+
+        Args:
+            import_text: Import text (symbol name or declaration)
+            base_dir: Base directory to search for files
+            source_file: Path to the source file containing the import
+
+        Returns:
+            List of paths to resolved .TcPOU files (empty if not found)
+        """
+        # Extract symbol name from various import formats
+        symbol = self._extract_symbol_name(import_text)
+        if not symbol:
+            return []
+
+        symbol_upper = symbol.upper()
+
+        # Skip primitive types (BOOL, DINT, etc.)
+        if symbol_upper in _PRIMITIVE_TYPES:
+            return []
+
+        # Skip standard library types (TON, CTU, etc.)
+        if symbol_upper in _STDLIB_TYPES:
+            return []
+
+        # Search from source file's directory rather than base_dir.
+        # While base_dir would provide complete coverage, searching the entire
+        # project tree on every import resolution is expensive. We compromise
+        # by searching from source_file's directory, which covers most cases
+        # since TwinCAT projects typically co-locate related POUs.
+        result = self._find_symbol_file(symbol, source_file.parent)
+        if result is not None:
+            return [result.resolve()]  # Ensure absolute path
+        return []
+
+    # Required abstract method implementations (not used for TwinCAT)
+    # These are required by BaseMapping but TwinCAT uses Lark instead of tree-sitter
+
+    def get_function_query(self) -> str:
+        """Not used - TwinCAT uses Lark parser, not tree-sitter queries."""
+        return ""
+
+    def get_class_query(self) -> str:
+        """Not used - TwinCAT uses Lark parser, not tree-sitter queries."""
+        return ""
+
+    def get_comment_query(self) -> str:
+        """Not used - TwinCAT uses Lark parser, not tree-sitter queries."""
+        return ""
+
+    def extract_function_name(self, node: Any, source: str) -> str:
+        """Not used - TwinCAT uses Lark parser, not tree-sitter nodes."""
+        return ""
+
+    def extract_class_name(self, node: Any, source: str) -> str:
+        """Not used - TwinCAT uses Lark parser, not tree-sitter nodes."""
+        return ""

--- a/chunkhound/parsers/twincat/twincat_mapping.py
+++ b/chunkhound/parsers/twincat/twincat_mapping.py
@@ -13,24 +13,15 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from chunkhound.core.types.common import Language
 from chunkhound.parsers.mappings.base import BaseMapping
+from chunkhound.parsers.twincat.twincat_parser import TwinCATParser
 from chunkhound.parsers.universal_engine import UniversalChunk
 
-if TYPE_CHECKING:
-    from chunkhound.parsers.twincat.twincat_parser import TwinCATParser
-
-# IEC 61131-3 primitive types to skip
-_PRIMITIVE_TYPES = frozenset({
-    "BOOL", "BYTE", "WORD", "DWORD", "LWORD",
-    "SINT", "USINT", "INT", "UINT", "DINT", "UDINT", "LINT", "ULINT",
-    "REAL", "LREAL", "TIME", "LTIME", "DATE", "LDATE",
-    "TIME_OF_DAY", "TOD", "LTOD", "DATE_AND_TIME", "DT", "LDT",
-    "STRING", "WSTRING",
-    "ANY", "ANY_INT", "ANY_REAL", "ANY_NUM", "ANY_BIT", "ANY_STRING", "ANY_DATE",
-})
+# Import primitive types from parser (single source of truth)
+_PRIMITIVE_TYPES = TwinCATParser.PRIMITIVE_TYPES
 
 # IEC 61131-3 Standard Library function blocks to skip
 _STDLIB_TYPES = frozenset({
@@ -43,16 +34,13 @@ _STDLIB_TYPES = frozenset({
 # File extension for TcPOU files (Function Blocks, Interfaces, Programs, Functions)
 _TWINCAT_EXTENSION = ".TcPOU"
 
-# Lazy import to avoid circular dependency
 _parser: TwinCATParser | None = None
 
 
 def _get_parser() -> TwinCATParser:
-    """Get or create the TwinCATParser instance (lazy loading)."""
+    """Get or create the cached TwinCATParser instance."""
     global _parser
     if _parser is None:
-        from chunkhound.parsers.twincat.twincat_parser import TwinCATParser
-
         _parser = TwinCATParser()
     return _parser
 

--- a/chunkhound/parsers/twincat/twincat_mapping.py
+++ b/chunkhound/parsers/twincat/twincat_mapping.py
@@ -11,6 +11,7 @@ method that UniversalParser calls when engine=None.
 
 from __future__ import annotations
 
+import functools
 import re
 from pathlib import Path
 from typing import Any
@@ -34,15 +35,9 @@ _STDLIB_TYPES = frozenset({
 # File extension for TcPOU files (Function Blocks, Interfaces, Programs, Functions)
 _TWINCAT_EXTENSION = ".TcPOU"
 
-_parser: TwinCATParser | None = None
-
-
+@functools.lru_cache(maxsize=1)
 def _get_parser() -> TwinCATParser:
-    """Get or create the cached TwinCATParser instance."""
-    global _parser
-    if _parser is None:
-        _parser = TwinCATParser()
-    return _parser
+    return TwinCATParser()
 
 
 class TwinCATMapping(BaseMapping):

--- a/chunkhound/parsers/twincat/twincat_parser.py
+++ b/chunkhound/parsers/twincat/twincat_parser.py
@@ -1323,12 +1323,14 @@ class TwinCATParser:
     # Import Extraction (Tier 5 - Dependencies)
     # =========================================================================
 
-    # Primitive types to skip when extracting type references
-    _PRIMITIVE_TYPES = frozenset({
+    # IEC 61131-3 primitive types to skip when extracting type references
+    PRIMITIVE_TYPES = frozenset({
         "BOOL", "BYTE", "WORD", "DWORD", "LWORD",
         "SINT", "USINT", "INT", "UINT", "DINT", "UDINT", "LINT", "ULINT",
-        "REAL", "LREAL", "TIME", "DATE", "TIME_OF_DAY", "DATE_AND_TIME",
-        "STRING", "WSTRING", "TOD", "DT",
+        "REAL", "LREAL", "TIME", "LTIME", "DATE", "LDATE",
+        "TIME_OF_DAY", "TOD", "LTOD", "DATE_AND_TIME", "DT", "LDT",
+        "STRING", "WSTRING",
+        "ANY", "ANY_INT", "ANY_REAL", "ANY_NUM", "ANY_BIT", "ANY_STRING", "ANY_DATE",
     })
 
     def extract_import_chunks(
@@ -1664,7 +1666,7 @@ class TwinCATParser:
                     for token in child.children:
                         if isinstance(token, Token) and token.type == "IDENTIFIER":
                             type_name = str(token).upper()
-                            if type_name not in self._PRIMITIVE_TYPES:
+                            if type_name not in self.PRIMITIVE_TYPES:
                                 user_types.append(str(token))
                 elif child.data in ("array_type", "pointer_type", "reference_type"):
                     # Recurse into nested type_spec

--- a/chunkhound/parsers/twincat/twincat_parser.py
+++ b/chunkhound/parsers/twincat/twincat_parser.py
@@ -410,7 +410,7 @@ class TwinCATParser:
         location = declaration_location or content.declaration_location
 
         # Find all var_block nodes
-        var_blocks = self._find_nodes(tree, "var_block")
+        var_blocks = list(tree.find_data("var_block"))
 
         for var_block in var_blocks:
             # Extract var class from var_block_start
@@ -1234,17 +1234,6 @@ class TwinCATParser:
             return f"{pou_name}.{action_name}.{element_name}"
         return f"{pou_name}.{element_name}"
 
-    def _find_nodes(self, tree: Tree, rule_name: str) -> list[Tree]:
-        """Recursively find all nodes with given rule name."""
-        results: list[Tree] = []
-        if isinstance(tree, Tree):
-            if tree.data == rule_name:
-                results.append(tree)
-            for child in tree.children:
-                if isinstance(child, Tree):
-                    results.extend(self._find_nodes(child, rule_name))
-        return results
-
     def _get_token_value(self, tree: Tree, token_type: str) -> str | None:
         """Find first token of given type in tree's children."""
         for child in tree.children:
@@ -1403,7 +1392,7 @@ class TwinCATParser:
         chunks: list[UniversalChunk] = []
 
         # Find all var_block nodes
-        var_blocks = self._find_nodes(tree, "var_block")
+        var_blocks = list(tree.find_data("var_block"))
 
         for var_block in var_blocks:
             # Check if this is a VAR_EXTERNAL block
@@ -1490,21 +1479,21 @@ class TwinCATParser:
         chunks: list[UniversalChunk] = []
 
         # Find pou_header node
-        pou_headers = self._find_nodes(tree, "pou_header")
+        pou_headers = list(tree.find_data("pou_header"))
         if not pou_headers:
             return chunks
 
         pou_header = pou_headers[0]
 
         # Extract extends_clause
-        extends_clauses = self._find_nodes(pou_header, "extends_clause")
+        extends_clauses = list(pou_header.find_data("extends_clause"))
         for extends_clause in extends_clauses:
             chunk = self._create_extends_import_chunk(extends_clause, content)
             if chunk:
                 chunks.append(chunk)
 
         # Extract implements_clause
-        implements_clauses = self._find_nodes(pou_header, "implements_clause")
+        implements_clauses = list(pou_header.find_data("implements_clause"))
         for implements_clause in implements_clauses:
             impl_chunks = self._create_implements_import_chunks(
                 implements_clause, content
@@ -1622,7 +1611,7 @@ class TwinCATParser:
         seen_types: set[str] = set()  # Deduplicate type references
 
         # Find all var_declaration nodes
-        var_decls = self._find_nodes(tree, "var_declaration")
+        var_decls = list(tree.find_data("var_declaration"))
 
         for var_decl in var_decls:
             # Get variable name(s) for context
@@ -1670,7 +1659,7 @@ class TwinCATParser:
                                 user_types.append(str(token))
                 elif child.data in ("array_type", "pointer_type", "reference_type"):
                     # Recurse into nested type_spec
-                    nested_type_specs = self._find_nodes(child, "type_spec")
+                    nested_type_specs = list(child.find_data("type_spec"))
                     for nested in nested_type_specs:
                         user_types.extend(
                             self._extract_user_types_from_type_spec(nested)

--- a/chunkhound/parsers/twincat/twincat_parser.py
+++ b/chunkhound/parsers/twincat/twincat_parser.py
@@ -1,0 +1,1718 @@
+"""TwinCAT Structured Text parser for ChunkHound.
+
+Architecture: Custom Orchestration (like Svelte/Vue)
+- Uses Lark for parsing (not tree-sitter)
+- Directly processes lark.Tree and lark.Token objects (no AST transformation)
+- Handles multi-section XML files (declaration + implementation)
+- Adjusts line numbers from CDATA-relative to XML-absolute
+"""
+
+import re
+from pathlib import Path
+from typing import Any
+
+from lark import Lark, Token, Tree
+from lark.exceptions import LarkError
+from loguru import logger
+
+from chunkhound.core.types.common import ChunkType
+from chunkhound.parsers.twincat.xml_extractor import (
+    ActionContent,
+    MethodContent,
+    POUContent,
+    PropertyContent,
+    SourceLocation,
+    TcPOUExtractor,
+)
+from chunkhound.parsers.universal_engine import UniversalChunk, UniversalConcept
+from chunkhound.parsers.universal_parser import CASTConfig
+
+# Regex patterns for comment extraction
+# Block comments: (* ... *)
+BLOCK_COMMENT_RE = re.compile(r"\(\*[\s\S]*?\*\)")
+# Line comments: // ...
+LINE_COMMENT_RE = re.compile(r"//[^\n]*")
+
+# Map VAR block keywords to semantic variable classes
+VAR_BLOCK_MAP = {
+    "VAR_INPUT": "input",
+    "VAR_OUTPUT": "output",
+    "VAR_IN_OUT": "in_out",
+    "VAR_GLOBAL": "global",
+    "VAR_EXTERNAL": "external",
+    "VAR_TEMP": "temp",
+    "VAR_STAT": "static",
+    "VAR": "local",
+}
+
+
+class TwinCATParser:
+    """Parser for TwinCAT TcPOU files.
+
+    Directly processes Lark parse trees (Tree/Token objects) without
+    AST transformation to extract semantic chunks.
+    """
+
+    def __init__(self, cast_config: CASTConfig | None = None) -> None:
+        self._grammar_dir = Path(__file__).parent
+        self._decl_parser: Lark | None = None
+        self._impl_parser: Lark | None = None
+        self._extractor = TcPOUExtractor()
+        self.cast_config = cast_config or CASTConfig()
+        self._parse_errors: list[str] = []
+
+    @property
+    def parse_errors(self) -> list[str]:
+        """Errors from the most recent parse operation. Cleared on each parse."""
+        return self._parse_errors
+
+    @property
+    def decl_parser(self) -> Lark:
+        """Lazy-load declaration parser."""
+        if self._decl_parser is None:
+            grammar_path = self._grammar_dir / "declarations.lark"
+            self._decl_parser = Lark.open(
+                str(grammar_path),
+                parser="lalr",
+                lexer="contextual",
+                propagate_positions=True,
+            )
+        return self._decl_parser
+
+    @property
+    def impl_parser(self) -> Lark:
+        """Lazy-load implementation parser for Structured Text code blocks.
+
+        Used to parse METHOD, ACTION, and PROPERTY implementation bodies
+        when extracting detailed chunk information from TcPOU files.
+        """
+        if self._impl_parser is None:
+            grammar_path = self._grammar_dir / "implementation.lark"
+            self._impl_parser = Lark.open(
+                str(grammar_path),
+                parser="lalr",
+                lexer="contextual",
+                propagate_positions=True,
+            )
+        return self._impl_parser
+
+    # =========================================================================
+    # UniversalChunk Extraction (for UniversalParser integration)
+    # =========================================================================
+
+    def extract_universal_chunks(
+        self,
+        content: str,
+        file_path: Path | None = None,
+    ) -> list[UniversalChunk]:
+        """Extract UniversalChunk objects from TcPOU content.
+
+        This method produces UniversalChunk objects that can flow through
+        the UniversalParser's cAST pipeline for deduplication, comment
+        merging, and greedy merge optimization.
+
+        Args:
+            content: TcPOU XML content string
+            file_path: Optional path to the source file
+
+        Returns:
+            List of UniversalChunk objects
+        """
+        pou_content = self._extractor.extract_string(content)
+        return self._process_pou_content_to_universal(pou_content, file_path, content)
+
+    def _process_pou_content_to_universal(
+        self,
+        content: POUContent,
+        file_path: Path | None,
+        raw_content: str,
+    ) -> list[UniversalChunk]:
+        """Process extracted POU content into UniversalChunk objects."""
+        self._parse_errors = []  # Clear errors at start of each parse
+        chunks: list[UniversalChunk] = []
+
+        # 1. Create POU declaration and implementation chunks
+        pou_chunks = self._create_pou_universal_chunks(content, file_path)
+        chunks.extend(pou_chunks)
+
+        # 2. Parse declaration section → extract variable chunks
+        if content.declaration and content.declaration.strip():
+            try:
+                decl_tree = self.decl_parser.parse(content.declaration)
+                var_chunks = self._extract_var_universal_chunks_from_tree(
+                    decl_tree, content, file_path
+                )
+                chunks.extend(var_chunks)
+            except LarkError as e:
+                error_msg = f"Declaration parse error in {content.name}: {e}"
+                logger.error(error_msg)
+                self._parse_errors.append(error_msg)
+
+        if content.implementation and content.implementation.strip():
+            block_chunks = self._extract_block_universal_chunks_from_implementation(
+                content.implementation,
+                content.implementation_location,
+                content.name,
+                content.pou_type.upper(),
+                file_path,
+            )
+            chunks.extend(block_chunks)
+
+        # 3. Extract comments from declaration and implementation
+        decl_base_line = (
+            content.declaration_location.line if content.declaration_location else 1
+        )
+        impl_base_line = (
+            content.implementation_location.line
+            if content.implementation_location
+            else decl_base_line
+        )
+
+        if content.declaration and content.declaration.strip():
+            comment_chunks = self._extract_comment_universal_chunks(
+                content.declaration,
+                file_path,
+                content.name,
+                content.pou_type.upper(),
+                decl_base_line,
+            )
+            chunks.extend(comment_chunks)
+
+        if content.implementation and content.implementation.strip():
+            comment_chunks = self._extract_comment_universal_chunks(
+                content.implementation,
+                file_path,
+                content.name,
+                content.pou_type.upper(),
+                impl_base_line,
+            )
+            chunks.extend(comment_chunks)
+
+        # 4. Parse actions → create action chunks
+        for action in content.actions:
+            action_chunks = self._extract_action_universal_chunks(
+                action, content, file_path
+            )
+            chunks.extend(action_chunks)
+
+        # 5. Parse methods → create method chunks
+        for method in content.methods:
+            method_chunks = self._extract_method_universal_chunks(
+                method, content, file_path
+            )
+            chunks.extend(method_chunks)
+
+        # 6. Parse properties → create property chunks
+        for prop in content.properties:
+            property_chunks = self._extract_property_universal_chunks(
+                prop, content, file_path
+            )
+            chunks.extend(property_chunks)
+
+        # 7. Extract imports (VAR_EXTERNAL, EXTENDS, IMPLEMENTS, type references)
+        import_chunks = self._extract_import_universal_chunks_from_pou(content)
+        chunks.extend(import_chunks)
+
+        # Validate chunk positions against raw file content
+        self._validate_chunk_positions(chunks, raw_content)
+
+        # Stable sort: by start line, then larger spans first (containers first).
+        # The -end_line trick: when chunks share a start line, larger spans
+        # (more negative -end_line) sort first, placing containers before children.
+        return sorted(chunks, key=lambda c: (c.start_line, -c.end_line))
+
+
+    def _map_chunk_type_to_concept(self, chunk_type: ChunkType) -> UniversalConcept:
+        """Map TwinCAT ChunkType to UniversalConcept.
+
+        Mapping:
+        - PROGRAM, FUNCTION_BLOCK, FUNCTION → DEFINITION
+        - METHOD, ACTION, PROPERTY → DEFINITION
+        - VARIABLE, FIELD → DEFINITION
+        - BLOCK (control flow) → BLOCK
+        - COMMENT → COMMENT
+        """
+        if chunk_type in (
+            ChunkType.PROGRAM,
+            ChunkType.FUNCTION_BLOCK,
+            ChunkType.FUNCTION,
+            ChunkType.METHOD,
+            ChunkType.ACTION,
+            ChunkType.PROPERTY,
+            ChunkType.VARIABLE,
+            ChunkType.FIELD,
+        ):
+            return UniversalConcept.DEFINITION
+        elif chunk_type == ChunkType.BLOCK:
+            return UniversalConcept.BLOCK
+        elif chunk_type == ChunkType.COMMENT:
+            return UniversalConcept.COMMENT
+        else:
+            return UniversalConcept.DEFINITION  # Default for unknown types
+
+    def _create_universal_chunk(
+        self,
+        chunk_type: ChunkType,
+        name: str,
+        content: str,
+        start_line: int,
+        end_line: int,
+        metadata: dict[str, Any],
+        language_node_type: str,
+    ) -> UniversalChunk:
+        """Create UniversalChunk from TwinCAT extraction data.
+
+        Args:
+            chunk_type: The TwinCAT ChunkType
+            name: Symbol name for the chunk
+            content: Code content
+            start_line: Starting line number (1-based)
+            end_line: Ending line number (1-based)
+            metadata: Additional metadata dict
+            language_node_type: Original node type (using "lark_{rule}" format)
+
+        Returns:
+            UniversalChunk instance
+        """
+        # Store original ChunkType name for accurate reverse mapping
+        enriched_metadata = {
+            **metadata,
+            "chunk_type_hint": chunk_type.name.lower(),
+        }
+
+        return UniversalChunk(
+            concept=self._map_chunk_type_to_concept(chunk_type),
+            name=name,
+            content=content,
+            start_line=start_line,
+            end_line=end_line,
+            metadata=enriched_metadata,
+            language_node_type=language_node_type,
+        )
+
+    def _create_cdata_chunk(
+        self,
+        content: str | None,
+        location: SourceLocation | None,
+        name_suffix: str,
+        base_name: str,
+        chunk_type: ChunkType,
+        base_metadata: dict[str, Any],
+        language_node_type: str,
+    ) -> UniversalChunk | None:
+        """Create UniversalChunk for a single CDATA section.
+
+        Args:
+            content: The CDATA content (declaration or implementation)
+            location: Source location of the CDATA section
+            name_suffix: Section type ("declaration", "implementation", "get", "set")
+            base_name: Base FQN name (e.g., "FB_Test" or "FB_Test.Method1")
+            chunk_type: The ChunkType for this chunk
+            base_metadata: Base metadata dict to extend
+            language_node_type: Original node type for the chunk
+
+        Returns:
+            UniversalChunk if content is non-empty, None otherwise
+        """
+        if not content or not content.strip():
+            return None
+
+        # Calculate line numbers
+        start_line = location.line if location else 1
+        end_line = start_line + content.count("\n")
+
+        # Build FQN with section suffix
+        fqn = f"{base_name}.{name_suffix}"
+
+        # Extend metadata with section info
+        metadata = {
+            **base_metadata,
+            "section": name_suffix,
+        }
+
+        return self._create_universal_chunk(
+            chunk_type=chunk_type,
+            name=fqn,
+            content=content,
+            start_line=start_line,
+            end_line=end_line,
+            metadata=metadata,
+            language_node_type=language_node_type,
+        )
+
+    def _create_pou_universal_chunks(
+        self,
+        content: POUContent,
+        file_path: Path | None,
+    ) -> list[UniversalChunk]:
+        """Create UniversalChunks for POU declaration and implementation sections."""
+        chunks: list[UniversalChunk] = []
+
+        # Map POU type to ChunkType
+        pou_type = content.pou_type.upper()
+        if pou_type == "PROGRAM":
+            chunk_type = ChunkType.PROGRAM
+        elif pou_type == "FUNCTION_BLOCK":
+            chunk_type = ChunkType.FUNCTION_BLOCK
+        elif pou_type == "FUNCTION":
+            chunk_type = ChunkType.FUNCTION
+        else:
+            chunk_type = ChunkType.BLOCK
+
+        base_metadata = {
+            "kind": pou_type.lower(),
+            "pou_type": pou_type,
+            "pou_name": content.name,
+            "pou_id": content.id,
+        }
+
+        # Create declaration chunk
+        decl_chunk = self._create_cdata_chunk(
+            content=content.declaration,
+            location=content.declaration_location,
+            name_suffix="declaration",
+            base_name=content.name,
+            chunk_type=chunk_type,
+            base_metadata=base_metadata,
+            language_node_type="lark_pou_declaration",
+        )
+        if decl_chunk:
+            chunks.append(decl_chunk)
+
+        # Create implementation chunk
+        impl_chunk = self._create_cdata_chunk(
+            content=content.implementation,
+            location=content.implementation_location,
+            name_suffix="implementation",
+            base_name=content.name,
+            chunk_type=chunk_type,
+            base_metadata=base_metadata,
+            language_node_type="lark_pou_implementation",
+        )
+        if impl_chunk:
+            chunks.append(impl_chunk)
+
+        return chunks
+
+    def _extract_var_universal_chunks_from_tree(
+        self,
+        tree: Tree,
+        content: POUContent,
+        file_path: Path | None,
+        declaration_location: SourceLocation | None = None,
+        action_name: str | None = None,
+        method_name: str | None = None,
+    ) -> list[UniversalChunk]:
+        """Walk Lark tree and extract variable UniversalChunks from VAR blocks."""
+        chunks: list[UniversalChunk] = []
+
+        # Use provided location or fall back to POU declaration location
+        location = declaration_location or content.declaration_location
+
+        # Find all var_block nodes
+        var_blocks = self._find_nodes(tree, "var_block")
+
+        for var_block in var_blocks:
+            # Extract var class from var_block_start
+            var_class = "local"  # default
+            retain = False
+            persistent = False
+            constant = False
+
+            for child in var_block.children:
+                if isinstance(child, Tree):
+                    if child.data == "var_block_start":
+                        for token in child.children:
+                            if isinstance(token, Token):
+                                var_class = VAR_BLOCK_MAP.get(
+                                    token.type, token.value.lower()
+                                )
+                                break
+                    elif child.data == "var_qualifier":
+                        for token in child.children:
+                            if isinstance(token, Token):
+                                if token.type == "RETAIN":
+                                    retain = True
+                                elif token.type == "PERSISTENT":
+                                    persistent = True
+                                elif token.type == "CONSTANT":
+                                    constant = True
+                    elif child.data == "var_declaration":
+                        var_chunks = self._extract_var_decl_universal_chunk(
+                            child,
+                            content,
+                            file_path,
+                            var_class,
+                            retain,
+                            persistent,
+                            constant,
+                            location,
+                            action_name,
+                            method_name,
+                        )
+                        chunks.extend(var_chunks)
+
+        return chunks
+
+    def _extract_var_decl_universal_chunk(
+        self,
+        var_decl: Tree,
+        content: POUContent,
+        file_path: Path | None,
+        var_class: str,
+        retain: bool,
+        persistent: bool,
+        constant: bool,
+        declaration_location: SourceLocation | None = None,
+        action_name: str | None = None,
+        method_name: str | None = None,
+    ) -> list[UniversalChunk]:
+        """Extract UniversalChunk(s) from a var_declaration node."""
+        chunks: list[UniversalChunk] = []
+
+        # Collect variable names (IDENTIFIERs before the colon)
+        var_names: list[str] = []
+        data_type: str | None = None
+        hw_address: str | None = None
+
+        # Get line number from node metadata
+        line = var_decl.meta.line if hasattr(var_decl, "meta") and var_decl.meta else 1
+
+        # Use provided location or fall back to POU declaration location
+        location = declaration_location or content.declaration_location
+
+        # Adjust line number to XML position
+        adjusted_line = self._adjust_line_number(line, location)
+
+        for child in var_decl.children:
+            if isinstance(child, Token):
+                if child.type == "IDENTIFIER" and data_type is None:
+                    var_names.append(str(child))
+            elif isinstance(child, Tree):
+                if child.data == "hw_location":
+                    hw_addr_token = self._get_token_value(child, "HW_ADDRESS")
+                    if hw_addr_token:
+                        hw_address = hw_addr_token
+                elif child.data == "type_spec":
+                    data_type = self._extract_type_spec(child)
+
+        # Reconstruct the declaration code
+        code = ", ".join(var_names)
+        if hw_address:
+            code += f" AT {hw_address}"
+        code += f" : {data_type or 'UNKNOWN'};"
+
+        # Determine ChunkType and kind based on variable scope
+        if var_class in ("global", "external"):
+            chunk_type = ChunkType.VARIABLE
+            kind = "variable"
+        else:
+            chunk_type = ChunkType.FIELD
+            kind = "field"
+
+        # Build metadata
+        metadata: dict[str, Any] = {
+            "kind": kind,
+            "pou_type": content.pou_type,
+            "pou_name": content.name,
+            "var_class": var_class,
+            "data_type": data_type,
+            "hw_address": hw_address,
+            "retain": retain,
+            "persistent": persistent,
+            "constant": constant,
+        }
+        if action_name:
+            metadata["action_name"] = action_name
+        if method_name:
+            metadata["method_name"] = method_name
+
+        # Create a chunk for each variable name
+        for var_name in var_names:
+            fqn = self._build_fqn(content.name, var_name, method_name, action_name)
+            chunk = self._create_universal_chunk(
+                chunk_type=chunk_type,
+                name=fqn,
+                content=code,
+                start_line=adjusted_line,
+                end_line=adjusted_line,
+                metadata=metadata.copy(),
+                language_node_type="lark_var_declaration",
+            )
+            chunks.append(chunk)
+
+        return chunks
+
+    def _extract_action_universal_chunks(
+        self,
+        action: ActionContent,
+        content: POUContent,
+        file_path: Path | None,
+    ) -> list[UniversalChunk]:
+        """Create UniversalChunks for action declaration and implementation sections."""
+        chunks: list[UniversalChunk] = []
+
+        # Base metadata for action chunks
+        base_metadata = {
+            "kind": "action",
+            "pou_type": content.pou_type,
+            "pou_name": content.name,
+            "action_id": action.id,
+        }
+
+        base_name = f"{content.name}.{action.name}"
+
+        # Create declaration chunk (only if declaration exists)
+        if action.declaration and action.declaration.strip():
+            decl_chunk = self._create_cdata_chunk(
+                content=action.declaration,
+                location=action.declaration_location,
+                name_suffix="declaration",
+                base_name=base_name,
+                chunk_type=ChunkType.ACTION,
+                base_metadata=base_metadata,
+                language_node_type="lark_action_declaration",
+            )
+            if decl_chunk:
+                chunks.append(decl_chunk)
+
+        # Create implementation chunk
+        impl_chunk = self._create_cdata_chunk(
+            content=action.implementation,
+            location=action.implementation_location,
+            name_suffix="implementation",
+            base_name=base_name,
+            chunk_type=ChunkType.ACTION,
+            base_metadata=base_metadata,
+            language_node_type="lark_action_implementation",
+        )
+        if impl_chunk:
+            chunks.append(impl_chunk)
+
+        # Skip further processing if no chunks created
+        if not chunks:
+            return chunks
+
+        # Parse action declaration for variables
+        if action.declaration and action.declaration.strip():
+            try:
+                decl_tree = self.decl_parser.parse(action.declaration)
+                var_chunks = self._extract_var_universal_chunks_from_tree(
+                    decl_tree,
+                    content,
+                    file_path,
+                    declaration_location=action.declaration_location,
+                    action_name=action.name,
+                )
+                chunks.extend(var_chunks)
+            except LarkError as e:
+                error_msg = f"Action '{action.name}' declaration parse error: {e}"
+                logger.error(error_msg)
+                self._parse_errors.append(error_msg)
+
+        # Parse action implementation for control flow blocks
+        if action.implementation and action.implementation.strip():
+            block_chunks = self._extract_block_universal_chunks_from_implementation(
+                action.implementation,
+                action.implementation_location,
+                content.name,
+                content.pou_type.upper(),
+                file_path,
+                action_name=action.name,
+            )
+            chunks.extend(block_chunks)
+
+        # Extract comments
+        if action.declaration and action.declaration.strip():
+            decl_base = (
+                action.declaration_location.line
+                if action.declaration_location
+                else 1
+            )
+            comment_chunks = self._extract_comment_universal_chunks(
+                action.declaration,
+                file_path,
+                content.name,
+                content.pou_type.upper(),
+                decl_base,
+                action_name=action.name,
+            )
+            chunks.extend(comment_chunks)
+
+        if action.implementation and action.implementation.strip():
+            impl_base = (
+                action.implementation_location.line
+                if action.implementation_location
+                else 1
+            )
+            comment_chunks = self._extract_comment_universal_chunks(
+                action.implementation,
+                file_path,
+                content.name,
+                content.pou_type.upper(),
+                impl_base,
+                action_name=action.name,
+            )
+            chunks.extend(comment_chunks)
+
+        return chunks
+
+    def _extract_method_universal_chunks(
+        self,
+        method: MethodContent,
+        content: POUContent,
+        file_path: Path | None,
+    ) -> list[UniversalChunk]:
+        """Create UniversalChunks for method declaration and implementation sections."""
+        chunks: list[UniversalChunk] = []
+
+        # Base metadata for method chunks
+        base_metadata = {
+            "kind": "method",
+            "pou_type": content.pou_type,
+            "pou_name": content.name,
+            "method_id": method.id,
+        }
+
+        base_name = f"{content.name}.{method.name}"
+
+        # Create declaration chunk
+        decl_chunk = self._create_cdata_chunk(
+            content=method.declaration,
+            location=method.declaration_location,
+            name_suffix="declaration",
+            base_name=base_name,
+            chunk_type=ChunkType.METHOD,
+            base_metadata=base_metadata,
+            language_node_type="lark_method_declaration",
+        )
+        if decl_chunk:
+            chunks.append(decl_chunk)
+
+        # Create implementation chunk
+        impl_chunk = self._create_cdata_chunk(
+            content=method.implementation,
+            location=method.implementation_location,
+            name_suffix="implementation",
+            base_name=base_name,
+            chunk_type=ChunkType.METHOD,
+            base_metadata=base_metadata,
+            language_node_type="lark_method_implementation",
+        )
+        if impl_chunk:
+            chunks.append(impl_chunk)
+
+        # Skip further processing if no chunks created
+        if not chunks:
+            return chunks
+
+        # Parse method declaration for variables
+        if method.declaration and method.declaration.strip():
+            try:
+                decl_tree = self.decl_parser.parse(method.declaration)
+                var_chunks = self._extract_var_universal_chunks_from_tree(
+                    decl_tree,
+                    content,
+                    file_path,
+                    declaration_location=method.declaration_location,
+                    method_name=method.name,
+                )
+                chunks.extend(var_chunks)
+            except LarkError as e:
+                error_msg = f"Method '{method.name}' declaration parse error: {e}"
+                logger.error(error_msg)
+                self._parse_errors.append(error_msg)
+
+        # Parse method implementation for control flow blocks
+        if method.implementation and method.implementation.strip():
+            block_chunks = self._extract_block_universal_chunks_from_implementation(
+                method.implementation,
+                method.implementation_location,
+                content.name,
+                content.pou_type.upper(),
+                file_path,
+                method_name=method.name,
+            )
+            chunks.extend(block_chunks)
+
+        # Extract comments
+        if method.declaration and method.declaration.strip():
+            decl_base = (
+                method.declaration_location.line
+                if method.declaration_location
+                else 1
+            )
+            comment_chunks = self._extract_comment_universal_chunks(
+                method.declaration,
+                file_path,
+                content.name,
+                content.pou_type.upper(),
+                decl_base,
+                method_name=method.name,
+            )
+            chunks.extend(comment_chunks)
+
+        if method.implementation and method.implementation.strip():
+            impl_base = (
+                method.implementation_location.line
+                if method.implementation_location
+                else 1
+            )
+            comment_chunks = self._extract_comment_universal_chunks(
+                method.implementation,
+                file_path,
+                content.name,
+                content.pou_type.upper(),
+                impl_base,
+                method_name=method.name,
+            )
+            chunks.extend(comment_chunks)
+
+        return chunks
+
+    def _extract_property_universal_chunks(
+        self,
+        prop: PropertyContent,
+        content: POUContent,
+        file_path: Path | None,
+    ) -> list[UniversalChunk]:
+        """Create UniversalChunks for a property's declaration and accessor sections."""
+        chunks: list[UniversalChunk] = []
+
+        # Base metadata for property chunks
+        base_metadata = {
+            "kind": "property",
+            "pou_type": content.pou_type,
+            "pou_name": content.name,
+            "property_id": prop.id,
+        }
+
+        base_name = f"{content.name}.{prop.name}"
+
+        # Create declaration chunk
+        decl_chunk = self._create_cdata_chunk(
+            content=prop.declaration,
+            location=prop.declaration_location,
+            name_suffix="declaration",
+            base_name=base_name,
+            chunk_type=ChunkType.PROPERTY,
+            base_metadata=base_metadata,
+            language_node_type="lark_property_declaration",
+        )
+        if decl_chunk:
+            chunks.append(decl_chunk)
+
+        # Create get accessor chunk
+        if prop.get and prop.get.implementation and prop.get.implementation.strip():
+            get_chunk = self._create_cdata_chunk(
+                content=prop.get.implementation,
+                location=prop.get.implementation_location,
+                name_suffix="get",
+                base_name=base_name,
+                chunk_type=ChunkType.PROPERTY,
+                base_metadata=base_metadata,
+                language_node_type="lark_property_get",
+            )
+            if get_chunk:
+                chunks.append(get_chunk)
+
+        # Create set accessor chunk
+        if prop.set and prop.set.implementation and prop.set.implementation.strip():
+            set_chunk = self._create_cdata_chunk(
+                content=prop.set.implementation,
+                location=prop.set.implementation_location,
+                name_suffix="set",
+                base_name=base_name,
+                chunk_type=ChunkType.PROPERTY,
+                base_metadata=base_metadata,
+                language_node_type="lark_property_set",
+            )
+            if set_chunk:
+                chunks.append(set_chunk)
+
+        return chunks
+
+    def _extract_block_universal_chunks_from_implementation(
+        self,
+        implementation: str,
+        implementation_location: SourceLocation | None,
+        pou_name: str,
+        pou_type: str,
+        file_path: Path | None,
+        action_name: str | None = None,
+        method_name: str | None = None,
+    ) -> list[UniversalChunk]:
+        """Extract control flow blocks as UniversalChunks."""
+        chunks: list[UniversalChunk] = []
+
+        try:
+            tree = self.impl_parser.parse(implementation)
+        except LarkError as e:
+            if method_name:
+                context = f"method '{method_name}'"
+            elif action_name:
+                context = f"action '{action_name}'"
+            else:
+                context = f"FUNCTION '{pou_name}'"
+            error_msg = f"Implementation parse error in {context}: {e}"
+            logger.error(error_msg)
+            self._parse_errors.append(error_msg)
+            return chunks
+
+        # Find all control flow statement nodes
+        statement_nodes = self._find_statement_nodes(tree)
+
+        for node in statement_nodes:
+            chunk = self._create_block_universal_chunk(
+                node,
+                implementation,
+                implementation_location,
+                pou_name,
+                pou_type,
+                file_path,
+                action_name,
+                method_name,
+            )
+            if chunk:
+                chunks.append(chunk)
+
+        return chunks
+
+    def _create_block_universal_chunk(
+        self,
+        node: Tree,
+        implementation: str,
+        implementation_location: SourceLocation | None,
+        pou_name: str,
+        pou_type: str,
+        file_path: Path | None,
+        action_name: str | None,
+        method_name: str | None = None,
+    ) -> UniversalChunk | None:
+        """Create UniversalChunk for a control flow block."""
+        # Get line numbers from node metadata
+        if not hasattr(node, "meta") or node.meta is None:
+            return None
+
+        start_line = node.meta.line
+        end_line = node.meta.end_line or start_line
+
+        # Reconstruct code from implementation using line numbers
+        code = self._reconstruct_code_from_lines(implementation, start_line, end_line)
+
+        # Adjust line numbers to XML-absolute
+        adjusted_start = self._adjust_line_number(start_line, implementation_location)
+        adjusted_end = self._adjust_line_number(end_line, implementation_location)
+
+        # Determine kind from statement type
+        kind = self._STATEMENT_KIND_MAP.get(node.data, "block")
+
+        # Build FQN
+        symbol = self._build_fqn(
+            pou_name, f"{kind}_{adjusted_start}", method_name, action_name
+        )
+
+        # Build metadata
+        metadata: dict[str, Any] = {
+            "kind": kind,
+            "pou_type": pou_type,
+            "pou_name": pou_name,
+        }
+        if action_name:
+            metadata["action_name"] = action_name
+        if method_name:
+            metadata["method_name"] = method_name
+
+        return self._create_universal_chunk(
+            chunk_type=ChunkType.BLOCK,
+            name=symbol,
+            content=code,
+            start_line=adjusted_start,
+            end_line=adjusted_end,
+            metadata=metadata,
+            language_node_type=f"lark_{node.data}",
+        )
+
+    def _extract_comment_universal_chunks(
+        self,
+        source: str,
+        file_path: Path | None,
+        pou_name: str,
+        pou_type: str,
+        base_line: int,
+        method_name: str | None = None,
+        action_name: str | None = None,
+    ) -> list[UniversalChunk]:
+        """Extract comments as UniversalChunks."""
+        chunks: list[UniversalChunk] = []
+
+        # Block comments: (* ... *)
+        for match in BLOCK_COMMENT_RE.finditer(source):
+            line = source[: match.start()].count("\n") + base_line
+            chunk = self._create_comment_universal_chunk(
+                content=match.group(),
+                line=line,
+                file_path=file_path,
+                pou_name=pou_name,
+                pou_type=pou_type,
+                comment_type="block",
+                method_name=method_name,
+                action_name=action_name,
+            )
+            chunks.append(chunk)
+
+        # Line comments: // ...
+        for match in LINE_COMMENT_RE.finditer(source):
+            line = source[: match.start()].count("\n") + base_line
+            chunk = self._create_comment_universal_chunk(
+                content=match.group(),
+                line=line,
+                file_path=file_path,
+                pou_name=pou_name,
+                pou_type=pou_type,
+                comment_type="line",
+                method_name=method_name,
+                action_name=action_name,
+            )
+            chunks.append(chunk)
+
+        return chunks
+
+    def _create_comment_universal_chunk(
+        self,
+        content: str,
+        line: int,
+        file_path: Path | None,
+        pou_name: str,
+        pou_type: str,
+        comment_type: str,
+        method_name: str | None = None,
+        action_name: str | None = None,
+    ) -> UniversalChunk:
+        """Create a comment UniversalChunk."""
+        # Build FQN
+        element_name = f"comment_line_{line}"
+        fqn = self._build_fqn(pou_name, element_name, method_name, action_name)
+
+        # Calculate end line for multi-line block comments
+        end_line = line + content.count("\n")
+
+        # Clean comment text (strip markers)
+        cleaned_text = self._clean_st_comment(content)
+
+        # Build metadata
+        metadata: dict[str, Any] = {
+            "kind": "comment",
+            "comment_type": comment_type,
+            "pou_name": pou_name,
+            "pou_type": pou_type,
+            "cleaned_text": cleaned_text,
+        }
+        if method_name:
+            metadata["method_name"] = method_name
+        if action_name:
+            metadata["action_name"] = action_name
+
+        return self._create_universal_chunk(
+            chunk_type=ChunkType.COMMENT,
+            name=fqn,
+            content=content,
+            start_line=line,
+            end_line=end_line,
+            metadata=metadata,
+            language_node_type="lark_comment",
+        )
+
+    def _extract_type_spec(self, type_spec: Tree) -> str:
+        """Extract type specification as a string."""
+        parts: list[str] = []
+
+        for child in type_spec.children:
+            if isinstance(child, Token):
+                parts.append(str(child))
+            elif isinstance(child, Tree):
+                if child.data == "primitive_type":
+                    # Get the token from primitive_type
+                    for token in child.children:
+                        if isinstance(token, Token):
+                            parts.append(str(token))
+                elif child.data == "string_type_with_size":
+                    # STRING(80) or WSTRING[100]
+                    parts.append(self._extract_string_type(child))
+                elif child.data == "array_type":
+                    parts.append(self._extract_array_type(child))
+                elif child.data == "pointer_type":
+                    parts.append(f"POINTER TO {self._extract_type_spec(child)}")
+                elif child.data == "reference_type":
+                    parts.append(f"REFERENCE TO {self._extract_type_spec(child)}")
+                elif child.data == "user_type":
+                    # User-defined type is just an IDENTIFIER
+                    for token in child.children:
+                        if isinstance(token, Token) and token.type == "IDENTIFIER":
+                            parts.append(str(token))
+                elif child.data == "type_spec":
+                    # Nested type spec (for POINTER TO, REFERENCE TO)
+                    parts.append(self._extract_type_spec(child))
+
+        return " ".join(parts) if parts else "UNKNOWN"
+
+    def _extract_string_type(self, string_type: Tree) -> str:
+        """Extract STRING(n) or WSTRING[n] type."""
+        type_name = "STRING"
+        size: str | None = None
+
+        for child in string_type.children:
+            if isinstance(child, Token):
+                if child.type == "STRING_TYPE":
+                    type_name = "STRING"
+                elif child.type == "WSTRING":
+                    type_name = "WSTRING"
+                elif child.type == "INTEGER":
+                    size = str(child)
+
+        if size:
+            return f"{type_name}({size})"
+        return type_name
+
+    def _extract_array_type(self, array_type: Tree) -> str:
+        """Extract ARRAY[...] OF type."""
+        ranges: list[str] = []
+        element_type = "UNKNOWN"
+
+        for child in array_type.children:
+            if isinstance(child, Tree):
+                if child.data == "array_range":
+                    ranges.append(self._extract_array_range(child))
+                elif child.data == "type_spec":
+                    element_type = self._extract_type_spec(child)
+
+        return f"ARRAY[{', '.join(ranges)}] OF {element_type}"
+
+    def _extract_array_range(self, array_range: Tree) -> str:
+        """Extract array range like 0..9 or 1..MAX_SIZE."""
+        bounds: list[str] = []
+
+        for child in array_range.children:
+            if isinstance(child, Tree):
+                if child.data == "array_bound":
+                    bounds.append(self._extract_array_bound(child))
+                elif child.data == "integer_value":
+                    bounds.append(self._extract_integer_value(child))
+            elif isinstance(child, Token):
+                if child.type == "IDENTIFIER":
+                    bounds.append(str(child))
+
+        return "..".join(bounds)
+
+    def _extract_array_bound(self, bound: Tree) -> str:
+        """Extract a single array bound."""
+        for child in bound.children:
+            if isinstance(child, Token):
+                if child.type == "IDENTIFIER":
+                    return str(child)
+            elif isinstance(child, Tree):
+                if child.data == "integer_value":
+                    return self._extract_integer_value(child)
+
+        return "0"
+
+    def _extract_integer_value(self, int_val: Tree) -> str:
+        """Extract integer value (may include sign)."""
+        parts: list[str] = []
+
+        for child in int_val.children:
+            if isinstance(child, Token):
+                parts.append(str(child))
+
+        return "".join(parts)
+
+    def _adjust_line_number(
+        self, line: int, location: SourceLocation | None
+    ) -> int:
+        """Adjust line number from CDATA-relative to XML-absolute."""
+        if location is None:
+            return line
+        return line + (location.line - 1)
+
+    def _validate_chunk_positions(
+        self,
+        chunks: list[UniversalChunk],
+        raw_content: str,
+    ) -> None:
+        """Validate that chunk line numbers match the source file.
+
+        For each chunk, verifies that:
+        - The first line of chunk content is a substring of file's start_line
+        - The last line of chunk content is a substring of file's end_line
+
+        Logs warnings for mismatches but does not modify or filter chunks.
+
+        Args:
+            chunks: List of UniversalChunk objects to validate
+            raw_content: The raw TcPOU XML file content
+        """
+        file_lines = raw_content.splitlines()
+
+        for chunk in chunks:
+            # Skip validation for synthesized content that won't match source
+            skip_types = ("lark_var_declaration", "lark_type_reference")
+            if chunk.language_node_type in skip_types:
+                continue
+
+            chunk_lines = chunk.content.splitlines()
+            if not chunk_lines:
+                continue
+
+            # Get first and last content lines (stripped for comparison)
+            first_content_line = chunk_lines[0].strip()
+            last_content_line = chunk_lines[-1].strip()
+
+            # Convert 1-based line numbers to 0-based array indices
+            # start_line=1 means first line of file, which is index 0
+            start_idx = chunk.start_line - 1
+            end_idx = chunk.end_line - 1
+
+            # Bounds check
+            chunk_info = f"{chunk.name} ({chunk.concept.value})"
+            if start_idx < 0 or start_idx >= len(file_lines):
+                logger.warning(
+                    f"Chunk {chunk_info} start_line {chunk.start_line} "
+                    f"out of bounds (file has {len(file_lines)} lines)"
+                )
+                continue
+            if end_idx < 0 or end_idx >= len(file_lines):
+                logger.warning(
+                    f"Chunk {chunk_info} end_line {chunk.end_line} "
+                    f"out of bounds (file has {len(file_lines)} lines)"
+                )
+                continue
+
+            file_start_line = file_lines[start_idx]
+            file_end_line = file_lines[end_idx]
+
+            # Validate first line
+            if first_content_line and first_content_line not in file_start_line:
+                logger.warning(
+                    f"Chunk {chunk_info} first line mismatch at {chunk.start_line}:\n"
+                    f"  Expected: {first_content_line!r}\n"
+                    f"  File: {file_start_line!r}"
+                )
+
+            # Validate last line (with off-by-one tolerance)
+            if last_content_line:
+                found_at_end = last_content_line in file_end_line
+                found_at_prev = False
+                if not found_at_end and end_idx - 1 >= 0:
+                    found_at_prev = last_content_line in file_lines[end_idx - 1]
+
+                if not found_at_end and not found_at_prev:
+                    msg = (
+                        f"Chunk {chunk_info} last line mismatch at {chunk.end_line}:\n"
+                        f"  Expected: {last_content_line!r}"
+                    )
+                    if end_idx - 1 >= 0:
+                        prev_line = file_lines[end_idx - 1]
+                        msg += f"\n  Line {chunk.end_line - 1}: {prev_line!r}"
+                    msg += f"\n  Line {chunk.end_line}: {file_end_line!r}"
+
+                    logger.warning(msg)
+
+    @staticmethod
+    def _build_fqn(
+        pou_name: str,
+        element_name: str,
+        method_name: str | None = None,
+        action_name: str | None = None,
+    ) -> str:
+        """Build a fully qualified name for a chunk symbol.
+
+        FQN hierarchy: POUName[.MethodName|.ActionName].ElementName
+        """
+        if method_name:
+            return f"{pou_name}.{method_name}.{element_name}"
+        elif action_name:
+            return f"{pou_name}.{action_name}.{element_name}"
+        return f"{pou_name}.{element_name}"
+
+    def _find_nodes(self, tree: Tree, rule_name: str) -> list[Tree]:
+        """Recursively find all nodes with given rule name."""
+        results: list[Tree] = []
+        if isinstance(tree, Tree):
+            if tree.data == rule_name:
+                results.append(tree)
+            for child in tree.children:
+                if isinstance(child, Tree):
+                    results.extend(self._find_nodes(child, rule_name))
+        return results
+
+    def _get_token_value(self, tree: Tree, token_type: str) -> str | None:
+        """Find first token of given type in tree's children."""
+        for child in tree.children:
+            if isinstance(child, Token) and child.type == token_type:
+                return str(child)
+        return None
+
+    # =========================================================================
+    # Implementation Block Extraction (Tier 4 - Control Flow Blocks)
+    # =========================================================================
+
+    # Statement type to metadata kind mapping
+    _STATEMENT_KIND_MAP = {
+        "if_stmt": "if_block",
+        "case_stmt": "case_block",
+        "for_stmt": "for_loop",
+        "while_stmt": "while_loop",
+        "repeat_stmt": "repeat_loop",
+    }
+
+    def _find_statement_nodes(self, tree: Tree) -> list[Tree]:
+        """Recursively find all control flow statement nodes in parse tree.
+
+        Finds: if_stmt, case_stmt, for_stmt, while_stmt, repeat_stmt
+        """
+        results: list[Tree] = []
+
+        if isinstance(tree, Tree):
+            if tree.data in self._STATEMENT_KIND_MAP:
+                results.append(tree)
+            # Recurse into children to find nested statements
+            for child in tree.children:
+                if isinstance(child, Tree):
+                    results.extend(self._find_statement_nodes(child))
+
+        return results
+
+    def _reconstruct_code_from_lines(
+        self, source: str, start_line: int, end_line: int
+    ) -> str:
+        """Extract code substring using line numbers.
+
+        Args:
+            source: Full source code string
+            start_line: 1-based start line number
+            end_line: 1-based end line number (inclusive)
+
+        Returns:
+            Code substring spanning the specified lines
+        """
+        lines = source.splitlines()
+
+        # Convert to 0-based indices
+        start_idx = max(0, start_line - 1)
+        end_idx = min(len(lines), end_line)
+
+        return "\n".join(lines[start_idx:end_idx])
+
+    def _clean_st_comment(self, text: str) -> str:
+        """Strip ST comment markers (* *) and //.
+
+        Args:
+            text: Raw comment text with markers
+
+        Returns:
+            Cleaned comment text without markers
+        """
+        cleaned = text.strip()
+        if cleaned.startswith("(*") and cleaned.endswith("*)"):
+            cleaned = cleaned[2:-2].strip()
+        elif cleaned.startswith("//"):
+            cleaned = cleaned[2:].strip()
+        return cleaned
+
+    # =========================================================================
+    # Import Extraction (Tier 5 - Dependencies)
+    # =========================================================================
+
+    # Primitive types to skip when extracting type references
+    _PRIMITIVE_TYPES = frozenset({
+        "BOOL", "BYTE", "WORD", "DWORD", "LWORD",
+        "SINT", "USINT", "INT", "UINT", "DINT", "UDINT", "LINT", "ULINT",
+        "REAL", "LREAL", "TIME", "DATE", "TIME_OF_DAY", "DATE_AND_TIME",
+        "STRING", "WSTRING", "TOD", "DT",
+    })
+
+    def extract_import_chunks(
+        self,
+        content: str,
+    ) -> list[UniversalChunk]:
+        """Extract import-like constructs as UniversalChunks.
+
+        Public method for efficient import-only extraction.
+
+        Extracts:
+        - VAR_EXTERNAL references to global variables
+        - EXTENDS inheritance clauses
+        - IMPLEMENTS interface implementations
+        - User-defined type references in variable declarations
+
+        Args:
+            content: TcPOU XML content string
+
+        Returns:
+            List of UniversalChunk objects representing imports
+        """
+        pou_content = self._extractor.extract_string(content)
+        return self._extract_import_universal_chunks_from_pou(pou_content)
+
+    def _extract_import_universal_chunks_from_pou(
+        self,
+        content: POUContent,
+    ) -> list[UniversalChunk]:
+        """Extract import-like constructs as UniversalChunks.
+
+        Extracts:
+        - VAR_EXTERNAL references to global variables
+        - EXTENDS inheritance clauses
+        - IMPLEMENTS interface implementations
+        - User-defined type references in variable declarations
+        """
+        chunks: list[UniversalChunk] = []
+
+        # Parse declaration section
+        if not content.declaration or not content.declaration.strip():
+            return chunks
+
+        try:
+            decl_tree = self.decl_parser.parse(content.declaration)
+        except LarkError:
+            # Parse errors already logged in main extraction
+            return chunks
+
+        # 1. Extract VAR_EXTERNAL imports
+        var_external_chunks = self._extract_var_external_imports(decl_tree, content)
+        chunks.extend(var_external_chunks)
+
+        # 2. Extract EXTENDS/IMPLEMENTS from pou_header
+        inheritance_chunks = self._extract_inheritance_imports(decl_tree, content)
+        chunks.extend(inheritance_chunks)
+
+        # 3. Extract user-defined type references
+        type_ref_chunks = self._extract_type_reference_imports(decl_tree, content)
+        chunks.extend(type_ref_chunks)
+
+        return chunks
+
+    def _extract_var_external_imports(
+        self,
+        tree: Tree,
+        content: POUContent,
+    ) -> list[UniversalChunk]:
+        """Extract VAR_EXTERNAL declarations as import chunks."""
+        chunks: list[UniversalChunk] = []
+
+        # Find all var_block nodes
+        var_blocks = self._find_nodes(tree, "var_block")
+
+        for var_block in var_blocks:
+            # Check if this is a VAR_EXTERNAL block
+            is_external = False
+            for child in var_block.children:
+                if isinstance(child, Tree) and child.data == "var_block_start":
+                    for token in child.children:
+                        if isinstance(token, Token) and token.type == "VAR_EXTERNAL":
+                            is_external = True
+                            break
+                    break
+
+            if not is_external:
+                continue
+
+            # Extract variable declarations from this VAR_EXTERNAL block
+            for child in var_block.children:
+                if isinstance(child, Tree) and child.data == "var_declaration":
+                    chunk = self._create_var_external_import_chunk(child, content)
+                    if chunk:
+                        chunks.append(chunk)
+
+        return chunks
+
+    def _create_var_external_import_chunk(
+        self,
+        var_decl: Tree,
+        content: POUContent,
+    ) -> UniversalChunk | None:
+        """Create import chunk for a VAR_EXTERNAL declaration."""
+        # Extract variable name and type
+        var_names: list[str] = []
+        data_type: str | None = None
+
+        for child in var_decl.children:
+            if isinstance(child, Token) and child.type == "IDENTIFIER":
+                if data_type is None:  # Names come before the type
+                    var_names.append(str(child))
+            elif isinstance(child, Tree) and child.data == "type_spec":
+                data_type = self._extract_type_spec(child)
+
+        if not var_names:
+            return None
+
+        # Use first variable name for the chunk
+        var_name = var_names[0]
+
+        # Get line number
+        line = var_decl.meta.line if hasattr(var_decl, "meta") and var_decl.meta else 1
+        adjusted_line = self._adjust_line_number(line, content.declaration_location)
+
+        # Build FQN
+        fqn = f"{content.name}.{var_name}"
+
+        # Reconstruct declaration code
+        code = f"{', '.join(var_names)} : {data_type or 'UNKNOWN'};"
+
+        metadata: dict[str, Any] = {
+            "kind": "import",
+            "import_type": "var_external",
+            "var_name": var_name,
+            "data_type": data_type,
+            "var_class": "external",
+            "pou_name": content.name,
+            "pou_type": content.pou_type.upper(),
+        }
+
+        return UniversalChunk(
+            concept=UniversalConcept.IMPORT,
+            name=fqn,
+            content=code,
+            start_line=adjusted_line,
+            end_line=adjusted_line,
+            metadata=metadata,
+            language_node_type="lark_var_external",
+        )
+
+    def _extract_inheritance_imports(
+        self,
+        tree: Tree,
+        content: POUContent,
+    ) -> list[UniversalChunk]:
+        """Extract EXTENDS and IMPLEMENTS clauses as import chunks."""
+        chunks: list[UniversalChunk] = []
+
+        # Find pou_header node
+        pou_headers = self._find_nodes(tree, "pou_header")
+        if not pou_headers:
+            return chunks
+
+        pou_header = pou_headers[0]
+
+        # Extract extends_clause
+        extends_clauses = self._find_nodes(pou_header, "extends_clause")
+        for extends_clause in extends_clauses:
+            chunk = self._create_extends_import_chunk(extends_clause, content)
+            if chunk:
+                chunks.append(chunk)
+
+        # Extract implements_clause
+        implements_clauses = self._find_nodes(pou_header, "implements_clause")
+        for implements_clause in implements_clauses:
+            impl_chunks = self._create_implements_import_chunks(
+                implements_clause, content
+            )
+            chunks.extend(impl_chunks)
+
+        return chunks
+
+    def _create_extends_import_chunk(
+        self,
+        extends_clause: Tree,
+        content: POUContent,
+    ) -> UniversalChunk | None:
+        """Create import chunk for EXTENDS clause."""
+        # Extract base type identifier
+        base_type: str | None = None
+        for child in extends_clause.children:
+            if isinstance(child, Token) and child.type == "IDENTIFIER":
+                base_type = str(child)
+                break
+
+        if not base_type:
+            return None
+
+        # Get line number
+        line = (
+            extends_clause.meta.line
+            if hasattr(extends_clause, "meta") and extends_clause.meta
+            else 1
+        )
+        adjusted_line = self._adjust_line_number(line, content.declaration_location)
+
+        # Build FQN
+        fqn = f"{content.name}:extends:{base_type}"
+
+        metadata: dict[str, Any] = {
+            "kind": "import",
+            "import_type": "extends",
+            "base_type": base_type,
+            "target_type": content.name,
+            "pou_name": content.name,
+            "pou_type": content.pou_type.upper(),
+        }
+
+        return UniversalChunk(
+            concept=UniversalConcept.IMPORT,
+            name=fqn,
+            content=f"EXTENDS {base_type}",
+            start_line=adjusted_line,
+            end_line=adjusted_line,
+            metadata=metadata,
+            language_node_type="lark_extends",
+        )
+
+    def _create_implements_import_chunks(
+        self,
+        implements_clause: Tree,
+        content: POUContent,
+    ) -> list[UniversalChunk]:
+        """Create import chunks for IMPLEMENTS clause (multiple interfaces)."""
+        chunks: list[UniversalChunk] = []
+
+        # Get line number
+        line = (
+            implements_clause.meta.line
+            if hasattr(implements_clause, "meta") and implements_clause.meta
+            else 1
+        )
+        adjusted_line = self._adjust_line_number(line, content.declaration_location)
+
+        # Extract all interface identifiers
+        for child in implements_clause.children:
+            if isinstance(child, Token) and child.type == "IDENTIFIER":
+                interface_name = str(child)
+
+                # Build FQN
+                fqn = f"{content.name}:implements:{interface_name}"
+
+                metadata: dict[str, Any] = {
+                    "kind": "import",
+                    "import_type": "implements",
+                    "interface_name": interface_name,
+                    "implementing_type": content.name,
+                    "pou_name": content.name,
+                    "pou_type": content.pou_type.upper(),
+                }
+
+                chunk = UniversalChunk(
+                    concept=UniversalConcept.IMPORT,
+                    name=fqn,
+                    content=f"IMPLEMENTS {interface_name}",
+                    start_line=adjusted_line,
+                    end_line=adjusted_line,
+                    metadata=metadata,
+                    language_node_type="lark_implements",
+                )
+                chunks.append(chunk)
+
+        return chunks
+
+    def _extract_type_reference_imports(
+        self,
+        tree: Tree,
+        content: POUContent,
+    ) -> list[UniversalChunk]:
+        """Extract user-defined type references as import chunks.
+
+        Scans all variable declarations for non-primitive type usage:
+        - Direct: fbMotor : FB_Motor
+        - Arrays: ARRAY[...] OF FB_Type
+        - Pointers: POINTER TO FB_Type
+        - References: REFERENCE TO FB_Type
+        """
+        chunks: list[UniversalChunk] = []
+        seen_types: set[str] = set()  # Deduplicate type references
+
+        # Find all var_declaration nodes
+        var_decls = self._find_nodes(tree, "var_declaration")
+
+        for var_decl in var_decls:
+            # Get variable name(s) for context
+            var_names: list[str] = []
+            for child in var_decl.children:
+                if isinstance(child, Token) and child.type == "IDENTIFIER":
+                    var_names.append(str(child))
+                elif isinstance(child, Tree) and child.data == "type_spec":
+                    break  # Stop at type_spec
+
+            # Find type_spec and extract user-defined types
+            for child in var_decl.children:
+                if isinstance(child, Tree) and child.data == "type_spec":
+                    user_types = self._extract_user_types_from_type_spec(child)
+                    for user_type in user_types:
+                        # Skip if already seen
+                        if user_type in seen_types:
+                            continue
+                        seen_types.add(user_type)
+
+                        # Create import chunk
+                        chunk = self._create_type_reference_import_chunk(
+                            var_decl,
+                            user_type,
+                            var_names,
+                            content,
+                        )
+                        if chunk:
+                            chunks.append(chunk)
+
+        return chunks
+
+    def _extract_user_types_from_type_spec(self, type_spec: Tree) -> list[str]:
+        """Recursively extract user-defined type names from type_spec."""
+        user_types: list[str] = []
+
+        for child in type_spec.children:
+            if isinstance(child, Tree):
+                if child.data == "user_type":
+                    # Direct user type
+                    for token in child.children:
+                        if isinstance(token, Token) and token.type == "IDENTIFIER":
+                            type_name = str(token).upper()
+                            if type_name not in self._PRIMITIVE_TYPES:
+                                user_types.append(str(token))
+                elif child.data in ("array_type", "pointer_type", "reference_type"):
+                    # Recurse into nested type_spec
+                    nested_type_specs = self._find_nodes(child, "type_spec")
+                    for nested in nested_type_specs:
+                        user_types.extend(
+                            self._extract_user_types_from_type_spec(nested)
+                        )
+                elif child.data == "type_spec":
+                    # Direct nested type_spec
+                    user_types.extend(self._extract_user_types_from_type_spec(child))
+
+        return user_types
+
+    def _create_type_reference_import_chunk(
+        self,
+        var_decl: Tree,
+        referenced_type: str,
+        var_names: list[str],
+        content: POUContent,
+    ) -> UniversalChunk | None:
+        """Create import chunk for a user-defined type reference."""
+        # Get line number
+        line = var_decl.meta.line if hasattr(var_decl, "meta") and var_decl.meta else 1
+        adjusted_line = self._adjust_line_number(line, content.declaration_location)
+
+        # Build FQN
+        fqn = f"{content.name}:type_ref:{referenced_type}"
+
+        # Determine usage context
+        var_name = var_names[0] if var_names else "unknown"
+
+        metadata: dict[str, Any] = {
+            "kind": "import",
+            "import_type": "type_reference",
+            "referenced_type": referenced_type,
+            "var_name": var_name,
+            "usage_context": "declaration",
+            "pou_name": content.name,
+            "pou_type": content.pou_type.upper(),
+        }
+
+        return UniversalChunk(
+            concept=UniversalConcept.IMPORT,
+            name=fqn,
+            content=f"type reference: {referenced_type}",
+            start_line=adjusted_line,
+            end_line=adjusted_line,
+            metadata=metadata,
+            language_node_type="lark_type_reference",
+        )

--- a/chunkhound/parsers/twincat/twincat_parser.py
+++ b/chunkhound/parsers/twincat/twincat_parser.py
@@ -25,7 +25,6 @@ from chunkhound.parsers.twincat.xml_extractor import (
     TcPOUExtractor,
 )
 from chunkhound.parsers.universal_engine import UniversalChunk, UniversalConcept
-from chunkhound.parsers.universal_parser import CASTConfig
 
 # Regex patterns for comment extraction
 # Block comments: (* ... *)
@@ -53,12 +52,11 @@ class TwinCATParser:
     AST transformation to extract semantic chunks.
     """
 
-    def __init__(self, cast_config: CASTConfig | None = None) -> None:
+    def __init__(self) -> None:
         self._grammar_dir = Path(__file__).parent
         self._decl_parser: Lark | None = None
         self._impl_parser: Lark | None = None
         self._extractor = TcPOUExtractor()
-        self.cast_config = cast_config or CASTConfig()
         self._parse_errors: list[str] = []
 
     @property

--- a/chunkhound/parsers/twincat/xml_extractor.py
+++ b/chunkhound/parsers/twincat/xml_extractor.py
@@ -1,0 +1,570 @@
+"""Extract ST code from TcPOU XML files."""
+
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+
+from .exceptions import XMLExtractionError
+
+
+@dataclass
+class SourceLocation:
+    """Position of extracted content in the original XML file."""
+
+    line: int  # 1-indexed line where content starts
+    column: int  # 1-indexed column where content starts
+    pos: int  # 0-indexed character offset where content starts
+
+
+@dataclass
+class ActionContent:
+    """Content extracted from an Action element."""
+
+    name: str
+    id: str
+    declaration: str | None
+    implementation: str
+    declaration_location: SourceLocation | None = None
+    implementation_location: SourceLocation | None = None
+
+
+@dataclass
+class MethodContent:
+    """Content extracted from a Method element."""
+
+    name: str
+    id: str
+    declaration: str
+    implementation: str
+    declaration_location: SourceLocation | None = None
+    implementation_location: SourceLocation | None = None
+
+
+@dataclass
+class PropertyContent:
+    """Content extracted from a Property element."""
+
+    name: str
+    id: str
+    declaration: str
+    get: MethodContent | None = None
+    set: MethodContent | None = None
+    declaration_location: SourceLocation | None = None
+
+
+@dataclass
+class POUContent:
+    """Content extracted from a TcPOU file."""
+
+    name: str
+    id: str
+    pou_type: str  # PROGRAM, FUNCTION_BLOCK, FUNCTION
+    declaration: str
+    implementation: str
+    actions: list[ActionContent]
+    methods: list[MethodContent]
+    properties: list[PropertyContent]
+    declaration_location: SourceLocation | None = None
+    implementation_location: SourceLocation | None = None
+
+
+class TcPOUExtractor:
+    """Extract ST code sections from TcPOU XML files."""
+
+    def extract_file(self, path: str | Path) -> POUContent:
+        """Extract all ST content from a TcPOU file.
+
+        Args:
+            path: Path to the TcPOU XML file
+
+        Returns:
+            POUContent with declaration, implementation, and actions
+
+        Raises:
+            XMLExtractionError: If the file cannot be parsed or is invalid
+        """
+        path = Path(path)
+        if not path.exists():
+            raise XMLExtractionError(f"File not found: {path}")
+
+        # Read file as text first for position tracking
+        xml_text = path.read_text()
+
+        try:
+            root = ET.fromstring(xml_text)
+        except ET.ParseError as e:
+            raise XMLExtractionError(f"Invalid XML in {path}: {e}")
+
+        return self._extract_from_element(root, str(path), xml_text)
+
+    def extract_string(self, xml_content: str, source: str = "<string>") -> POUContent:
+        """Extract all ST content from XML string.
+
+        Args:
+            xml_content: TcPOU XML as string
+            source: Source identifier for error messages
+
+        Returns:
+            POUContent with declaration, implementation, and actions
+        """
+        try:
+            root = ET.fromstring(xml_content)
+        except ET.ParseError as e:
+            raise XMLExtractionError(f"Invalid XML in {source}: {e}")
+
+        return self._extract_from_element(root, source, xml_content)
+
+    def _find_cdata_content_start(
+        self, xml_text: str, search_start: int, element_path: list[str]
+    ) -> SourceLocation | None:
+        """Find the position where CDATA content starts for a given element path.
+
+        Args:
+            xml_text: The full XML text
+            search_start: Position to start searching from
+            element_path: List of element names to find
+                (e.g., ["Declaration"] or ["Implementation", "ST"])
+
+        Returns:
+            SourceLocation with line, column, and pos of content start,
+            or None if not found
+        """
+        pos = search_start
+
+        # Navigate through each element in the path
+        for element_name in element_path:
+            # Find the opening tag for this element
+            # Pattern matches <ElementName or <ElementName> or <ElementName ...>
+            tag_pattern = rf"<{element_name}(?:\s[^>]*)?>|<{element_name}>"
+            match = re.search(tag_pattern, xml_text[pos:])
+            if not match:
+                return None
+            pos += match.end()
+
+        # Now find the CDATA marker after the last element tag
+        cdata_marker = "<![CDATA["
+        cdata_pos = xml_text.find(cdata_marker, pos)
+        if cdata_pos == -1:
+            return None
+
+        # Content starts right after the CDATA marker
+        content_start = cdata_pos + len(cdata_marker)
+
+        # Calculate line and column
+        # Count newlines before content_start
+        text_before = xml_text[:content_start]
+        line = text_before.count("\n") + 1
+
+        # Find position of last newline before content_start
+        last_newline = text_before.rfind("\n")
+        if last_newline == -1:
+            column = content_start + 1  # No newline, column is pos + 1 (1-indexed)
+        else:
+            column = content_start - last_newline  # Distance from last newline
+
+        return SourceLocation(line=line, column=column, pos=content_start)
+
+    def _extract_from_element(
+        self, root: ET.Element, source: str, xml_text: str | None = None
+    ) -> POUContent:
+        """Extract content from parsed XML element."""
+        # Find POU element
+        pou = root.find("POU")
+        if pou is None:
+            raise XMLExtractionError(f"No POU element found in {source}")
+
+        name = pou.get("Name")
+        if not name:
+            raise XMLExtractionError(f"POU missing Name attribute in {source}")
+
+        pou_id = pou.get("Id", "")
+
+        # Find POU start position in XML for location tracking
+        pou_search_start = 0
+        if xml_text:
+            # Find the POU element in the XML text
+            pou_match = re.search(rf'<POU\s+Name="{re.escape(name)}"', xml_text)
+            if pou_match:
+                pou_search_start = pou_match.start()
+
+        # Extract declaration
+        decl_elem = pou.find("Declaration")
+        if decl_elem is None:
+            raise XMLExtractionError(f"No Declaration element found in {source}")
+        declaration = decl_elem.text if decl_elem.text is not None else ""
+
+        # Find declaration location
+        declaration_location = None
+        if xml_text and declaration:
+            declaration_location = self._find_cdata_content_start(
+                xml_text, pou_search_start, ["Declaration"]
+            )
+
+        # Determine POU type from declaration
+        pou_type = self._detect_pou_type(declaration)
+
+        # Extract implementation
+        impl_elem = pou.find("Implementation")
+        if impl_elem is None:
+            raise XMLExtractionError(f"No Implementation element found in {source}")
+
+        st_elem = impl_elem.find("ST")
+        if st_elem is None or st_elem.text is None:
+            implementation = ""
+        else:
+            implementation = st_elem.text
+
+        # Find implementation location
+        implementation_location = None
+        if xml_text and implementation:
+            implementation_location = self._find_cdata_content_start(
+                xml_text, pou_search_start, ["Implementation", "ST"]
+            )
+
+        # Extract actions
+        actions = []
+        # Track position for finding action elements
+        action_search_start = pou_search_start
+        for action_elem in pou.findall("Action"):
+            action = self._extract_action(
+                action_elem, source, xml_text, action_search_start
+            )
+            if action:
+                actions.append(action)
+                # Move search start past this action for the next one
+                if xml_text and action.name:
+                    action_match = re.search(
+                        rf'<Action\s+Name="{re.escape(action.name)}"',
+                        xml_text[action_search_start:],
+                    )
+                    if action_match:
+                        action_search_start += action_match.end()
+
+        # Extract methods
+        methods = []
+        method_search_start = pou_search_start
+        for method_elem in pou.findall("Method"):
+            method = self._extract_method(
+                method_elem, source, xml_text, method_search_start
+            )
+            if method:
+                methods.append(method)
+                # Move search start past this method for the next one
+                if xml_text and method.name:
+                    method_match = re.search(
+                        rf'<Method\s+Name="{re.escape(method.name)}"',
+                        xml_text[method_search_start:],
+                    )
+                    if method_match:
+                        method_search_start += method_match.end()
+
+        # Extract properties
+        properties = []
+        property_search_start = pou_search_start
+        for property_elem in pou.findall("Property"):
+            prop = self._extract_property(
+                property_elem, source, xml_text, property_search_start
+            )
+            if prop:
+                properties.append(prop)
+                # Move search start past this property for the next one
+                if xml_text and prop.name:
+                    property_match = re.search(
+                        rf'<Property\s+Name="{re.escape(prop.name)}"',
+                        xml_text[property_search_start:],
+                    )
+                    if property_match:
+                        property_search_start += property_match.end()
+
+        return POUContent(
+            name=name,
+            id=pou_id,
+            pou_type=pou_type,
+            declaration=declaration,
+            implementation=implementation,
+            actions=actions,
+            methods=methods,
+            properties=properties,
+            declaration_location=declaration_location,
+            implementation_location=implementation_location,
+        )
+
+    def _extract_action(
+        self,
+        action_elem: ET.Element,
+        source: str,
+        xml_text: str | None = None,
+        search_start: int = 0,
+    ) -> ActionContent | None:
+        """Extract content from an Action element."""
+        name = action_elem.get("Name")
+        if not name:
+            return None
+
+        action_id = action_elem.get("Id", "")
+
+        # Find action start position in XML for location tracking
+        action_search_start = search_start
+        if xml_text:
+            action_match = re.search(
+                rf'<Action\s+Name="{re.escape(name)}"', xml_text[search_start:]
+            )
+            if action_match:
+                action_search_start = search_start + action_match.start()
+
+        # Actions may have their own Declaration
+        decl_elem = action_elem.find("Declaration")
+        declaration = (
+            decl_elem.text if decl_elem is not None and decl_elem.text else None
+        )
+
+        # Find action declaration location
+        declaration_location = None
+        if xml_text and declaration:
+            declaration_location = self._find_cdata_content_start(
+                xml_text, action_search_start, ["Declaration"]
+            )
+
+        # Extract implementation
+        impl_elem = action_elem.find("Implementation")
+        if impl_elem is None:
+            return None
+
+        st_elem = impl_elem.find("ST")
+        if st_elem is None or st_elem.text is None:
+            implementation = ""
+        else:
+            implementation = st_elem.text
+
+        # Find action implementation location
+        implementation_location = None
+        if xml_text and implementation:
+            implementation_location = self._find_cdata_content_start(
+                xml_text, action_search_start, ["Implementation", "ST"]
+            )
+
+        return ActionContent(
+            name=name,
+            id=action_id,
+            declaration=declaration,
+            implementation=implementation,
+            declaration_location=declaration_location,
+            implementation_location=implementation_location,
+        )
+
+    def _extract_method(
+        self,
+        method_elem: ET.Element,
+        source: str,
+        xml_text: str | None = None,
+        search_start: int = 0,
+    ) -> MethodContent | None:
+        """Extract content from a Method element."""
+        name = method_elem.get("Name")
+        if not name:
+            return None
+
+        method_id = method_elem.get("Id", "")
+
+        # Find method start position in XML for location tracking
+        method_search_start = search_start
+        if xml_text:
+            method_match = re.search(
+                rf'<Method\s+Name="{re.escape(name)}"', xml_text[search_start:]
+            )
+            if method_match:
+                method_search_start = search_start + method_match.start()
+
+        # Extract declaration
+        decl_elem = method_elem.find("Declaration")
+        declaration = decl_elem.text if decl_elem is not None and decl_elem.text else ""
+
+        # Find method declaration location
+        declaration_location = None
+        if xml_text and declaration:
+            declaration_location = self._find_cdata_content_start(
+                xml_text, method_search_start, ["Declaration"]
+            )
+
+        # Extract implementation
+        impl_elem = method_elem.find("Implementation")
+        if impl_elem is None:
+            implementation = ""
+        else:
+            st_elem = impl_elem.find("ST")
+            implementation = ""
+            if st_elem is not None and st_elem.text:
+                implementation = st_elem.text
+
+        # Find method implementation location
+        implementation_location = None
+        if xml_text and implementation:
+            implementation_location = self._find_cdata_content_start(
+                xml_text, method_search_start, ["Implementation", "ST"]
+            )
+
+        return MethodContent(
+            name=name,
+            id=method_id,
+            declaration=declaration,
+            implementation=implementation,
+            declaration_location=declaration_location,
+            implementation_location=implementation_location,
+        )
+
+    def _extract_property(
+        self,
+        property_elem: ET.Element,
+        source: str,
+        xml_text: str | None = None,
+        search_start: int = 0,
+    ) -> PropertyContent | None:
+        """Extract content from a Property element."""
+        name = property_elem.get("Name")
+        if not name:
+            return None
+
+        property_id = property_elem.get("Id", "")
+
+        # Find property start position in XML for location tracking
+        property_search_start = search_start
+        if xml_text:
+            property_match = re.search(
+                rf'<Property\s+Name="{re.escape(name)}"', xml_text[search_start:]
+            )
+            if property_match:
+                property_search_start = search_start + property_match.start()
+
+        # Extract declaration
+        decl_elem = property_elem.find("Declaration")
+        declaration = decl_elem.text if decl_elem is not None and decl_elem.text else ""
+
+        # Find declaration location
+        declaration_location = None
+        if xml_text and declaration:
+            declaration_location = self._find_cdata_content_start(
+                xml_text, property_search_start, ["Declaration"]
+            )
+
+        # Extract Get accessor
+        get_accessor = None
+        get_elem = property_elem.find("Get")
+        if get_elem is not None:
+            get_accessor = self._extract_property_accessor(
+                get_elem, "Get", source, xml_text, property_search_start
+            )
+
+        # Extract Set accessor
+        set_accessor = None
+        set_elem = property_elem.find("Set")
+        if set_elem is not None:
+            set_accessor = self._extract_property_accessor(
+                set_elem, "Set", source, xml_text, property_search_start
+            )
+
+        return PropertyContent(
+            name=name,
+            id=property_id,
+            declaration=declaration,
+            get=get_accessor,
+            set=set_accessor,
+            declaration_location=declaration_location,
+        )
+
+    def _extract_property_accessor(
+        self,
+        accessor_elem: ET.Element,
+        accessor_name: str,
+        source: str,
+        xml_text: str | None = None,
+        search_start: int = 0,
+    ) -> MethodContent:
+        """Extract content from a Get or Set accessor element."""
+        accessor_id = accessor_elem.get("Id", "")
+
+        # Find accessor start position
+        accessor_search_start = search_start
+        if xml_text:
+            accessor_match = re.search(
+                rf"<{accessor_name}(?:\s|>)", xml_text[search_start:]
+            )
+            if accessor_match:
+                accessor_search_start = search_start + accessor_match.start()
+
+        # Extract declaration
+        decl_elem = accessor_elem.find("Declaration")
+        declaration = decl_elem.text if decl_elem is not None and decl_elem.text else ""
+
+        # Find declaration location
+        declaration_location = None
+        if xml_text and declaration:
+            declaration_location = self._find_cdata_content_start(
+                xml_text, accessor_search_start, ["Declaration"]
+            )
+
+        # Extract implementation
+        impl_elem = accessor_elem.find("Implementation")
+        if impl_elem is None:
+            implementation = ""
+        else:
+            st_elem = impl_elem.find("ST")
+            implementation = ""
+            if st_elem is not None and st_elem.text:
+                implementation = st_elem.text
+
+        # Find implementation location
+        implementation_location = None
+        if xml_text and implementation:
+            implementation_location = self._find_cdata_content_start(
+                xml_text, accessor_search_start, ["Implementation", "ST"]
+            )
+
+        return MethodContent(
+            name=accessor_name,
+            id=accessor_id,
+            declaration=declaration,
+            implementation=implementation,
+            declaration_location=declaration_location,
+            implementation_location=implementation_location,
+        )
+
+    def _detect_pou_type(self, declaration: str) -> str:
+        """Detect POU type from declaration header.
+
+        Skips comments (// and (* ... *)) to find the actual POU keyword.
+        """
+        # Remove line comments and block comments to find the POU keyword
+        cleaned = declaration
+        # Remove block comments (* ... *)
+        while "(*" in cleaned:
+            start = cleaned.find("(*")
+            end = cleaned.find("*)", start)
+            if end == -1:
+                # Unclosed block comment, just remove to end
+                cleaned = cleaned[:start]
+            else:
+                cleaned = cleaned[:start] + cleaned[end + 2 :]
+        # Remove line comments
+        lines = cleaned.split("\n")
+        non_comment_lines = []
+        for line in lines:
+            # Remove // comments
+            comment_pos = line.find("//")
+            if comment_pos != -1:
+                line = line[:comment_pos]
+            if line.strip():
+                non_comment_lines.append(line.strip())
+
+        # Find the first non-empty line after removing comments
+        cleaned_text = " ".join(non_comment_lines).upper().lstrip()
+
+        if cleaned_text.startswith("PROGRAM"):
+            return "PROGRAM"
+        elif cleaned_text.startswith("FUNCTION_BLOCK"):
+            return "FUNCTION_BLOCK"
+        elif cleaned_text.startswith("FUNCTION"):
+            return "FUNCTION"
+        else:
+            # Default to UNKNOWN if not detected
+            return "UNKNOWN"

--- a/chunkhound/parsers/twincat/xml_extractor.py
+++ b/chunkhound/parsers/twincat/xml_extractor.py
@@ -89,7 +89,7 @@ class TcPOUExtractor:
             raise XMLExtractionError(f"File not found: {path}")
 
         # Read file as text first for position tracking
-        xml_text = path.read_text()
+        xml_text = path.read_text(encoding="utf-8", errors="replace")
 
         try:
             root = ET.fromstring(xml_text)

--- a/chunkhound/parsers/universal_parser.py
+++ b/chunkhound/parsers/universal_parser.py
@@ -913,10 +913,6 @@ class UniversalParser:
                 return ChunkType.FUNCTION_BLOCK
             elif kind == "action":
                 return ChunkType.ACTION
-            elif kind == "transition":
-                return ChunkType.FUNCTION
-            elif kind in {"sfc_step", "sfc_initial_step"}:
-                return ChunkType.BLOCK
             elif kind == "namespace" or "namespace" in node_type:
                 return ChunkType.NAMESPACE
             elif kind == "property" or "property" in node_type:

--- a/chunkhound/parsers/universal_parser.py
+++ b/chunkhound/parsers/universal_parser.py
@@ -237,31 +237,13 @@ class UniversalParser:
                 universal_chunks = self.base_mapping.extract_universal_chunks(
                     content, file_path
                 )
-
-                # Filter out whitespace-only chunks as safety measure
-                filtered_chunks = []
-                for chunk in universal_chunks:
-                    normalized_code = normalize_content(chunk.content)
-                    if normalized_code:
-                        chunk = replace(chunk, content=normalized_code)
-                        filtered_chunks.append(chunk)
-                universal_chunks = filtered_chunks
-
-                # Apply cAST algorithm for optimal chunking
-                # Note: We pass None for ast_tree since Lark parsers don't use tree-sitter
-                optimized_chunks = self._apply_cast_algorithm(
-                    universal_chunks, None, content
+                # Pass None for ast_tree since Lark parsers don't use tree-sitter
+                chunks = self._apply_cast_and_convert(
+                    universal_chunks, None, content, file_path, file_id
                 )
-
-                # Convert to standard Chunk format
-                chunks = self._convert_to_chunks(
-                    optimized_chunks, content, file_path, file_id
-                )
-
                 # Update statistics
                 self._total_files_parsed += 1
                 self._total_chunks_created += len(chunks)
-
                 return chunks
 
             return self._parse_text_content(content, file_path, file_id)
@@ -277,23 +259,9 @@ class UniversalParser:
             ast_tree.root_node, content_bytes
         )
 
-        # Filter out whitespace-only chunks as secondary safety measure
-        filtered_chunks = []
-        for chunk in universal_chunks:
-            normalized_code = normalize_content(chunk.content)
-            if normalized_code:
-                # Update chunk with normalized content
-                chunk = replace(chunk, content=normalized_code)
-                filtered_chunks.append(chunk)
-        universal_chunks = filtered_chunks
-
-        # Apply cAST algorithm for optimal chunking
-        optimized_chunks = self._apply_cast_algorithm(
-            universal_chunks, ast_tree, content
+        chunks = self._apply_cast_and_convert(
+            universal_chunks, ast_tree, content, file_path, file_id
         )
-
-        # Convert to standard Chunk format
-        chunks = self._convert_to_chunks(optimized_chunks, content, file_path, file_id)
 
         # Detect embedded SQL if enabled
         if self.sql_detector and ast_tree:
@@ -305,7 +273,6 @@ class UniversalParser:
         # Update statistics
         self._total_files_parsed += 1
         self._total_chunks_created += len(chunks)
-
         return chunks
 
     def parse_with_result(self, file_path: Path, file_id: FileId) -> ParseResult:
@@ -360,6 +327,28 @@ class UniversalParser:
                 metadata={"parser_type": "universal_cast", "error": str(e)},
             )
 
+    def _apply_cast_and_convert(
+        self,
+        universal_chunks: list[UniversalChunk],
+        ast_tree: Tree | None,
+        content: str,
+        file_path: Path | None,
+        file_id: FileId | None,
+    ) -> list[Chunk]:
+        """Normalize, apply cAST algorithm, and convert to Chunk format."""
+        # Filter out whitespace-only chunks as safety measure
+        normalized = []
+        for chunk in universal_chunks:
+            normalized_content = normalize_content(chunk.content)
+            if normalized_content:
+                normalized.append(replace(chunk, content=normalized_content))
+
+        # Apply cAST algorithm for optimal chunking
+        optimized = self._apply_cast_algorithm(normalized, ast_tree, content)
+
+        # Convert to standard Chunk format
+        return self._convert_to_chunks(optimized, content, file_path, file_id)
+
     def _apply_cast_algorithm(
         self,
         universal_chunks: list[UniversalChunk],
@@ -378,7 +367,7 @@ class UniversalParser:
 
         Args:
             universal_chunks: Initial chunks extracted from concepts
-            ast_tree: Full AST tree of the source code (None for non-tree-sitter parsers)
+            ast_tree: Full AST tree of the source code (None for Lark parsers)
             content: Original source content
 
         Returns:

--- a/chunkhound/parsers/universal_parser.py
+++ b/chunkhound/parsers/universal_parser.py
@@ -209,7 +209,7 @@ class UniversalParser:
         if not content.strip():
             return []
 
-        # Special handling for text files (no tree-sitter parsing)
+        # Special handling for non-tree-sitter parsers (no tree-sitter parsing)
         if self.engine is None:
             # Check if this is PDF content by looking at language mapping
             if (
@@ -229,6 +229,41 @@ class UniversalParser:
                     f"PDF parsing requires parse_pdf_content method, "
                     f"got {type(self.base_mapping)}"
                 )
+
+            # Special handling for Lark-based parsers (e.g., TwinCAT)
+            # These provide extract_universal_chunks() to produce UniversalChunk objects
+            # which then flow through the normal cAST pipeline
+            if hasattr(self.base_mapping, "extract_universal_chunks"):
+                universal_chunks = self.base_mapping.extract_universal_chunks(
+                    content, file_path
+                )
+
+                # Filter out whitespace-only chunks as safety measure
+                filtered_chunks = []
+                for chunk in universal_chunks:
+                    normalized_code = normalize_content(chunk.content)
+                    if normalized_code:
+                        chunk = replace(chunk, content=normalized_code)
+                        filtered_chunks.append(chunk)
+                universal_chunks = filtered_chunks
+
+                # Apply cAST algorithm for optimal chunking
+                # Note: We pass None for ast_tree since Lark parsers don't use tree-sitter
+                optimized_chunks = self._apply_cast_algorithm(
+                    universal_chunks, None, content
+                )
+
+                # Convert to standard Chunk format
+                chunks = self._convert_to_chunks(
+                    optimized_chunks, content, file_path, file_id
+                )
+
+                # Update statistics
+                self._total_files_parsed += 1
+                self._total_chunks_created += len(chunks)
+
+                return chunks
+
             return self._parse_text_content(content, file_path, file_id)
 
         # Parse to AST using TreeSitterEngine
@@ -326,7 +361,10 @@ class UniversalParser:
             )
 
     def _apply_cast_algorithm(
-        self, universal_chunks: list[UniversalChunk], ast_tree: Tree, content: str
+        self,
+        universal_chunks: list[UniversalChunk],
+        ast_tree: Tree | None,
+        content: str,
     ) -> list[UniversalChunk]:
         """Apply cAST (Code AST) algorithm for optimal semantic chunking.
 
@@ -340,7 +378,7 @@ class UniversalParser:
 
         Args:
             universal_chunks: Initial chunks extracted from concepts
-            ast_tree: Full AST tree of the source code
+            ast_tree: Full AST tree of the source code (None for non-tree-sitter parsers)
             content: Original source content
 
         Returns:
@@ -879,6 +917,17 @@ class UniversalParser:
                 return ChunkType.INTERFACE
             elif kind == "trait" or "trait" in node_type:
                 return ChunkType.TRAIT
+            # IEC 61131-3 / TwinCAT PLC types
+            elif kind == "program":
+                return ChunkType.PROGRAM
+            elif kind == "function_block":
+                return ChunkType.FUNCTION_BLOCK
+            elif kind == "action":
+                return ChunkType.ACTION
+            elif kind == "transition":
+                return ChunkType.FUNCTION
+            elif kind in {"sfc_step", "sfc_initial_step"}:
+                return ChunkType.BLOCK
             elif kind == "namespace" or "namespace" in node_type:
                 return ChunkType.NAMESPACE
             elif kind == "property" or "property" in node_type:

--- a/chunkhound/services/indexing_coordinator.py
+++ b/chunkhound/services/indexing_coordinator.py
@@ -2292,9 +2292,7 @@ class IndexingCoordinator(BaseService):
         except Exception:
             pass
 
-        logger.debug(
-            f"Discovery backend resolved: {_resolved} (reasons: {_reasons})"
-        )
+        logger.debug(f"Discovery backend resolved: {_resolved} (reasons: {_reasons})")
 
         use_git_backend = _resolved in ("git", "git_only")
         git_only_mode = _resolved == "git_only"

--- a/chunkhound/services/research/shared/__init__.py
+++ b/chunkhound/services/research/shared/__init__.py
@@ -58,6 +58,15 @@ _LAZY_IMPORTS: dict[str, tuple[str, str | None]] = {
         "chunkhound.services.research.shared.unified_search",
         None,
     ),
+    # Boundary expansion
+    "expand_to_natural_boundaries": (
+        "chunkhound.services.research.shared.chunk_range",
+        None,
+    ),
+    "get_chunk_expanded_range": (
+        "chunkhound.services.research.shared.chunk_range",
+        None,
+    ),
     # Chunk deduplication
     "deduplicate_chunks": (
         "chunkhound.services.research.shared.chunk_dedup",
@@ -378,6 +387,9 @@ __all__ = [
     "ImportResolverService",
     "QueryExpander",
     "UnifiedSearch",
+    # Boundary expansion
+    "expand_to_natural_boundaries",
+    "get_chunk_expanded_range",
     # Utilities
     "build_output_guidance",
     "find_elbow_kneedle",

--- a/chunkhound/services/research/shared/chunk_range.py
+++ b/chunkhound/services/research/shared/chunk_range.py
@@ -1,0 +1,254 @@
+"""Chunk line-range resolution using natural code boundaries.
+
+Expands raw start/end lines to encompass complete language constructs
+(functions, classes, blocks) using indentation heuristics for Python
+and brace-matching for C-family languages.
+"""
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    from chunkhound.database_factory import DatabaseServices
+
+from chunkhound.services.research.shared.models import (
+    ENABLE_SMART_BOUNDARIES,
+    EXTRA_CONTEXT_TOKENS,
+    MAX_BOUNDARY_EXPANSION_LINES,
+)
+
+
+def expand_to_natural_boundaries(
+    lines: list[str],
+    start_line: int,
+    end_line: int,
+    chunk: dict[str, Any],
+    file_path: str,
+) -> tuple[int, int]:
+    """Expand chunk boundaries to complete function/class definitions.
+
+    Uses existing chunk metadata (symbol, kind) and language-specific heuristics
+    to detect natural code boundaries instead of using fixed 50-line windows.
+
+    Args:
+        lines: File content split by lines
+        start_line: Original chunk start line (1-indexed)
+        end_line: Original chunk end line (1-indexed)
+        chunk: Chunk metadata with symbol, kind fields
+        file_path: File path for language detection
+
+    Returns:
+        Tuple of (expanded_start_line, expanded_end_line) in 1-indexed format.
+        Returns (0, 0) if inputs are invalid (out-of-bounds or start > end).
+    """
+    if start_line < 1 or start_line > end_line or end_line > len(lines):
+        return (0, 0)
+
+    if not ENABLE_SMART_BOUNDARIES:
+        # Fallback to legacy fixed-window behavior
+        context_lines = EXTRA_CONTEXT_TOKENS // 20  # ~50 lines
+        start_idx = max(1, start_line - context_lines)
+        end_idx = min(len(lines), end_line + context_lines)
+        return start_idx, end_idx
+
+    # Check if chunk metadata indicates this is already a complete unit
+    metadata = chunk.get("metadata", {})
+    chunk_kind = metadata.get("kind") or chunk.get("symbol_type", "")
+
+    # If this chunk is marked as a complete function/class/method, use its exact boundaries
+    if chunk_kind in (
+        "function",
+        "method",
+        "class",
+        "interface",
+        "struct",
+        "enum",
+        # TwinCAT kinds (parser produces complete units)
+        "program",
+        "function_block",
+        "action",
+        "property",
+    ):
+        # Chunk is already a complete unit - just add small padding for context
+        padding = 3  # A few lines for docstrings/decorators/comments
+        start_idx = max(1, start_line - padding)
+        end_idx = min(len(lines), end_line + padding)
+        logger.debug(
+            f"Using complete {chunk_kind} boundaries: {file_path}:{start_idx}-{end_idx}"
+        )
+        return start_idx, end_idx
+
+    # For non-complete chunks, expand to natural boundaries
+    # Detect language from file extension for language-specific logic
+    file_path_lower = file_path.lower()
+    is_python = file_path_lower.endswith((".py", ".pyw"))
+    is_brace_lang = file_path_lower.endswith(
+        (
+            ".c",
+            ".cpp",
+            ".cc",
+            ".cxx",
+            ".h",
+            ".hpp",
+            ".rs",
+            ".go",
+            ".java",
+            ".js",
+            ".ts",
+            ".tsx",
+            ".jsx",
+            ".cs",
+            ".swift",
+            ".kt",
+            ".scala",
+        )
+    )
+
+    # Convert to 0-indexed for array access
+    start_idx = max(0, start_line - 1)
+    end_idx = min(len(lines) - 1, end_line - 1)
+
+    # Expand backward to find function/class start
+    expanded_start = start_idx
+    if is_python:
+        # Look for def/class keywords at start of line with proper indentation
+        for i in range(start_idx - 1, max(0, start_idx - 200), -1):
+            line = lines[i].strip()
+            if line.startswith(("def ", "class ", "async def ")):
+                expanded_start = i
+                break
+            # Stop at empty lines followed by significant dedents (module boundary)
+            if not line and i > 0:
+                next_line = lines[i + 1].lstrip() if i + 1 < len(lines) else ""
+                if next_line and not next_line.startswith((" ", "\t")):
+                    break
+    elif is_brace_lang:
+        # Look for opening braces and function signatures
+        brace_depth = 0
+        for i in range(start_idx, max(0, start_idx - 200), -1):
+            line = lines[i]
+            # Count braces
+            open_braces = line.count("{")
+            close_braces = line.count("}")
+            brace_depth += close_braces - open_braces
+
+            # Found matching opening brace
+            if brace_depth > 0 and "{" in line:
+                # Look backward for function signature
+                for j in range(i, max(0, i - 10), -1):
+                    sig_line = lines[j].strip()
+                    # Heuristic: function signatures often have (...) or start with keywords
+                    if "(" in sig_line and (")" in sig_line or j < i):
+                        expanded_start = j
+                        break
+                if expanded_start != start_idx:
+                    break
+
+    # Expand forward to find function/class end
+    expanded_end = end_idx
+    if is_python:
+        # Find end by detecting dedentation back to original level
+        if expanded_start < len(lines):
+            start_indent = len(lines[expanded_start]) - len(
+                lines[expanded_start].lstrip()
+            )
+            for i in range(end_idx + 1, min(len(lines), end_idx + 200)):
+                line = lines[i]
+                if line.strip():  # Non-empty line
+                    line_indent = len(line) - len(line.lstrip())
+                    # Dedented to same or less indentation = end of block
+                    if line_indent <= start_indent:
+                        expanded_end = i - 1
+                        break
+            else:
+                # Reached search limit, use current position
+                expanded_end = min(len(lines) - 1, end_idx + 50)
+    elif is_brace_lang:
+        # Find matching closing brace
+        brace_depth = 0
+        for i in range(expanded_start, min(len(lines), end_idx + 200)):
+            line = lines[i]
+            open_braces = line.count("{")
+            close_braces = line.count("}")
+            brace_depth += open_braces - close_braces
+
+            # Found matching closing brace
+            if brace_depth == 0 and i > expanded_start and "}" in line:
+                expanded_end = i
+                break
+
+    # Safety: Don't expand beyond max limit
+    if expanded_end - expanded_start > MAX_BOUNDARY_EXPANSION_LINES:
+        logger.debug(
+            f"Boundary expansion too large ({expanded_end - expanded_start} lines), "
+            f"limiting to {MAX_BOUNDARY_EXPANSION_LINES}"
+        )
+        expanded_end = expanded_start + MAX_BOUNDARY_EXPANSION_LINES
+
+    # Convert back to 1-indexed
+    final_start = expanded_start + 1
+    final_end = expanded_end + 1
+
+    logger.debug(
+        f"Expanded boundaries: {file_path}:{start_line}-{end_line} -> "
+        f"{final_start}-{final_end} ({final_end - final_start} lines)"
+    )
+
+    return final_start, final_end
+
+
+def get_chunk_expanded_range(
+    chunk: dict[str, Any],
+    db_services: "DatabaseServices",
+) -> tuple[int, int]:
+    """Get expanded line range for chunk.
+
+    If expansion already computed and stored in chunk, return it.
+    Otherwise, re-compute using expand_to_natural_boundaries().
+
+    Args:
+        chunk: Chunk dictionary with metadata
+        db_services: Database services bundle for accessing file paths
+
+    Returns:
+        Tuple of (expanded_start_line, expanded_end_line) in 1-indexed format
+    """
+    # Check if already stored (after enhancement in read_files_with_budget)
+    if "expanded_start_line" in chunk and "expanded_end_line" in chunk:
+        return (chunk["expanded_start_line"], chunk["expanded_end_line"])
+
+    # Re-compute (fallback)
+    file_path = chunk.get("file_path")
+    start_line = chunk.get("start_line", 0)
+    end_line = chunk.get("end_line", 0)
+
+    if not file_path or not start_line or not end_line:
+        return (start_line, end_line)
+
+    # Read file lines
+    try:
+        base_dir = db_services.provider.get_base_directory()
+        if Path(file_path).is_absolute():
+            path = Path(file_path)
+        else:
+            path = base_dir / file_path
+
+        with open(path, encoding="utf-8", errors="replace") as f:
+            lines = f.readlines()
+    except Exception as e:
+        logger.debug(f"Could not re-read file for expansion: {file_path}: {e}")
+        return (start_line, end_line)
+
+    expanded_start, expanded_end = expand_to_natural_boundaries(
+        lines, start_line, end_line, chunk, file_path
+    )
+
+    if expanded_start == 0 and expanded_end == 0:
+        logger.warning(
+            f"Boundary expansion failed for {file_path}, using original range"
+        )
+        return (start_line, end_line)
+
+    return (expanded_start, expanded_end)

--- a/chunkhound/services/research/shared/file_reader.py
+++ b/chunkhound/services/research/shared/file_reader.py
@@ -20,6 +20,7 @@ from chunkhound.database_factory import DatabaseServices
 from chunkhound.services.research.shared.models import (
     ENABLE_SMART_BOUNDARIES,
     EXTRA_CONTEXT_TOKENS,
+    FILE_CONTENT_TOKENS_MAX,
     MAX_BOUNDARY_EXPANSION_LINES,
     TOKEN_BUDGET_PER_FILE,
 )
@@ -93,9 +94,10 @@ class FileReader:
                     logger.warning(f"File not found (expected at {path}): {file_path}")
                     continue
 
-                # Calculate token budget for this file
+                # Calculate token budget for this file (capped to prevent bloat)
                 num_chunks = len(file_chunks)
-                budget = TOKEN_BUDGET_PER_FILE * num_chunks
+                raw_budget = TOKEN_BUDGET_PER_FILE * num_chunks
+                budget = min(raw_budget, FILE_CONTENT_TOKENS_MAX)
 
                 # Read file
                 content = path.read_text(encoding="utf-8", errors="ignore")
@@ -229,7 +231,11 @@ class FileReader:
         chunk_kind = metadata.get("kind") or chunk.get("symbol_type", "")
 
         # If this chunk is marked as a complete function/class/method, use its exact boundaries
-        if chunk_kind in ("function", "method", "class", "interface", "struct", "enum"):
+        if chunk_kind in (
+            "function", "method", "class", "interface", "struct", "enum",
+            # TwinCAT kinds (parser produces complete units)
+            "program", "function_block", "action", "property",
+        ):
             # Chunk is already a complete unit - just add small padding for context
             padding = 3  # A few lines for docstrings/decorators/comments
             start_idx = max(1, start_line - padding)

--- a/chunkhound/services/research/shared/file_reader.py
+++ b/chunkhound/services/research/shared/file_reader.py
@@ -17,11 +17,12 @@ from typing import Any
 from loguru import logger
 
 from chunkhound.database_factory import DatabaseServices
+from chunkhound.services.research.shared.chunk_range import (
+    expand_to_natural_boundaries,
+    get_chunk_expanded_range,
+)
 from chunkhound.services.research.shared.models import (
-    ENABLE_SMART_BOUNDARIES,
-    EXTRA_CONTEXT_TOKENS,
     FILE_CONTENT_TOKENS_MAX,
-    MAX_BOUNDARY_EXPANSION_LINES,
     TOKEN_BUDGET_PER_FILE,
 )
 
@@ -132,10 +133,18 @@ class FileReader:
 
                         # Use smart boundary detection to expand to complete functions/classes
                         expanded_start, expanded_end = (
-                            self.expand_to_natural_boundaries(
+                            expand_to_natural_boundaries(
                                 lines, start_line, end_line, chunk, file_path
                             )
                         )
+
+                        if expanded_start == 0 and expanded_end == 0:
+                            logger.warning(
+                                f"Skipping chunk with invalid boundaries in {file_path}: "
+                                f"start_line={start_line}, end_line={end_line} "
+                                f"(file has {len(lines)} lines)"
+                            )
+                            continue  # (0,0) = out-of-bounds chunk; skip rather than emit garbled slice
 
                         # Store expanded range in chunk for later deduplication
                         chunk["expanded_start_line"] = expanded_start
@@ -196,181 +205,6 @@ class FileReader:
         )
         return file_contents
 
-    def expand_to_natural_boundaries(
-        self,
-        lines: list[str],
-        start_line: int,
-        end_line: int,
-        chunk: dict[str, Any],
-        file_path: str,
-    ) -> tuple[int, int]:
-        """Expand chunk boundaries to complete function/class definitions.
-
-        Uses existing chunk metadata (symbol, kind) and language-specific heuristics
-        to detect natural code boundaries instead of using fixed 50-line windows.
-
-        Args:
-            lines: File content split by lines
-            start_line: Original chunk start line (1-indexed)
-            end_line: Original chunk end line (1-indexed)
-            chunk: Chunk metadata with symbol, kind fields
-            file_path: File path for language detection
-
-        Returns:
-            Tuple of (expanded_start_line, expanded_end_line) in 1-indexed format
-        """
-        if not ENABLE_SMART_BOUNDARIES:
-            # Fallback to legacy fixed-window behavior
-            context_lines = EXTRA_CONTEXT_TOKENS // 20  # ~50 lines
-            start_idx = max(1, start_line - context_lines)
-            end_idx = min(len(lines), end_line + context_lines)
-            return start_idx, end_idx
-
-        # Check if chunk metadata indicates this is already a complete unit
-        metadata = chunk.get("metadata", {})
-        chunk_kind = metadata.get("kind") or chunk.get("symbol_type", "")
-
-        # If this chunk is marked as a complete function/class/method, use its exact boundaries
-        if chunk_kind in (
-            "function",
-            "method",
-            "class",
-            "interface",
-            "struct",
-            "enum",
-            # TwinCAT kinds (parser produces complete units)
-            "program",
-            "function_block",
-            "action",
-            "property",
-        ):
-            # Chunk is already a complete unit - just add small padding for context
-            padding = 3  # A few lines for docstrings/decorators/comments
-            start_idx = max(1, start_line - padding)
-            end_idx = min(len(lines), end_line + padding)
-            logger.debug(
-                f"Using complete {chunk_kind} boundaries: {file_path}:{start_idx}-{end_idx}"
-            )
-            return start_idx, end_idx
-
-        # For non-complete chunks, expand to natural boundaries
-        # Detect language from file extension for language-specific logic
-        file_path_lower = file_path.lower()
-        is_python = file_path_lower.endswith((".py", ".pyw"))
-        is_brace_lang = file_path_lower.endswith(
-            (
-                ".c",
-                ".cpp",
-                ".cc",
-                ".cxx",
-                ".h",
-                ".hpp",
-                ".rs",
-                ".go",
-                ".java",
-                ".js",
-                ".ts",
-                ".tsx",
-                ".jsx",
-                ".cs",
-                ".swift",
-                ".kt",
-                ".scala",
-            )
-        )
-
-        # Convert to 0-indexed for array access
-        start_idx = max(0, start_line - 1)
-        end_idx = min(len(lines) - 1, end_line - 1)
-
-        # Expand backward to find function/class start
-        expanded_start = start_idx
-        if is_python:
-            # Look for def/class keywords at start of line with proper indentation
-            for i in range(start_idx - 1, max(0, start_idx - 200), -1):
-                line = lines[i].strip()
-                if line.startswith(("def ", "class ", "async def ")):
-                    expanded_start = i
-                    break
-                # Stop at empty lines followed by significant dedents (module boundary)
-                if not line and i > 0:
-                    next_line = lines[i + 1].lstrip() if i + 1 < len(lines) else ""
-                    if next_line and not next_line.startswith((" ", "\t")):
-                        break
-        elif is_brace_lang:
-            # Look for opening braces and function signatures
-            brace_depth = 0
-            for i in range(start_idx, max(0, start_idx - 200), -1):
-                line = lines[i]
-                # Count braces
-                open_braces = line.count("{")
-                close_braces = line.count("}")
-                brace_depth += close_braces - open_braces
-
-                # Found matching opening brace
-                if brace_depth > 0 and "{" in line:
-                    # Look backward for function signature
-                    for j in range(i, max(0, i - 10), -1):
-                        sig_line = lines[j].strip()
-                        # Heuristic: function signatures often have (...) or start with keywords
-                        if "(" in sig_line and (")" in sig_line or j < i):
-                            expanded_start = j
-                            break
-                    if expanded_start != start_idx:
-                        break
-
-        # Expand forward to find function/class end
-        expanded_end = end_idx
-        if is_python:
-            # Find end by detecting dedentation back to original level
-            if expanded_start < len(lines):
-                start_indent = len(lines[expanded_start]) - len(
-                    lines[expanded_start].lstrip()
-                )
-                for i in range(end_idx + 1, min(len(lines), end_idx + 200)):
-                    line = lines[i]
-                    if line.strip():  # Non-empty line
-                        line_indent = len(line) - len(line.lstrip())
-                        # Dedented to same or less indentation = end of block
-                        if line_indent <= start_indent:
-                            expanded_end = i - 1
-                            break
-                else:
-                    # Reached search limit, use current position
-                    expanded_end = min(len(lines) - 1, end_idx + 50)
-        elif is_brace_lang:
-            # Find matching closing brace
-            brace_depth = 0
-            for i in range(expanded_start, min(len(lines), end_idx + 200)):
-                line = lines[i]
-                open_braces = line.count("{")
-                close_braces = line.count("}")
-                brace_depth += open_braces - close_braces
-
-                # Found matching closing brace
-                if brace_depth == 0 and i > expanded_start and "}" in line:
-                    expanded_end = i
-                    break
-
-        # Safety: Don't expand beyond max limit
-        if expanded_end - expanded_start > MAX_BOUNDARY_EXPANSION_LINES:
-            logger.debug(
-                f"Boundary expansion too large ({expanded_end - expanded_start} lines), "
-                f"limiting to {MAX_BOUNDARY_EXPANSION_LINES}"
-            )
-            expanded_end = expanded_start + MAX_BOUNDARY_EXPANSION_LINES
-
-        # Convert back to 1-indexed
-        final_start = expanded_start + 1
-        final_end = expanded_end + 1
-
-        logger.debug(
-            f"Expanded boundaries: {file_path}:{start_line}-{end_line} -> "
-            f"{final_start}-{final_end} ({final_end - final_start} lines)"
-        )
-
-        return final_start, final_end
-
     def is_file_fully_read(self, file_content: str) -> bool:
         """Detect if file_content is full file vs partial chunks.
 
@@ -385,45 +219,5 @@ class FileReader:
         return "\n\n...\n\n" not in file_content
 
     def get_chunk_expanded_range(self, chunk: dict[str, Any]) -> tuple[int, int]:
-        """Get expanded line range for chunk.
-
-        If expansion already computed and stored in chunk, return it.
-        Otherwise, re-compute using expand_to_natural_boundaries().
-
-        Args:
-            chunk: Chunk dictionary with metadata
-
-        Returns:
-            Tuple of (expanded_start_line, expanded_end_line) in 1-indexed format
-        """
-        # Check if already stored (after enhancement in read_files_with_budget)
-        if "expanded_start_line" in chunk and "expanded_end_line" in chunk:
-            return (chunk["expanded_start_line"], chunk["expanded_end_line"])
-
-        # Re-compute (fallback)
-        file_path = chunk.get("file_path")
-        start_line = chunk.get("start_line", 0)
-        end_line = chunk.get("end_line", 0)
-
-        if not file_path or not start_line or not end_line:
-            return (start_line, end_line)
-
-        # Read file lines
-        try:
-            base_dir = self._db_services.provider.get_base_directory()
-            if Path(file_path).is_absolute():
-                path = Path(file_path)
-            else:
-                path = base_dir / file_path
-
-            with open(path, encoding="utf-8", errors="replace") as f:
-                lines = f.readlines()
-        except Exception as e:
-            logger.debug(f"Could not re-read file for expansion: {file_path}: {e}")
-            return (start_line, end_line)
-
-        expanded_start, expanded_end = self.expand_to_natural_boundaries(
-            lines, start_line, end_line, chunk, file_path
-        )
-
-        return (expanded_start, expanded_end)
+        """Delegate to shared chunk_range.get_chunk_expanded_range."""
+        return get_chunk_expanded_range(chunk, self._db_services)

--- a/chunkhound/services/research/shared/file_reader.py
+++ b/chunkhound/services/research/shared/file_reader.py
@@ -232,9 +232,17 @@ class FileReader:
 
         # If this chunk is marked as a complete function/class/method, use its exact boundaries
         if chunk_kind in (
-            "function", "method", "class", "interface", "struct", "enum",
+            "function",
+            "method",
+            "class",
+            "interface",
+            "struct",
+            "enum",
             # TwinCAT kinds (parser produces complete units)
-            "program", "function_block", "action", "property",
+            "program",
+            "function_block",
+            "action",
+            "property",
         ):
             # Chunk is already a complete unit - just add small padding for context
             padding = 3  # A few lines for docstrings/decorators/comments

--- a/chunkhound/services/research/shared/import_context.py
+++ b/chunkhound/services/research/shared/import_context.py
@@ -67,8 +67,19 @@ class ImportContextService:
         # Create parser for this file
         parser: Any = self._parser_factory.create_parser_for_file(Path(file_path))
 
+        # Handle TwinCAT (Lark-based parser with engine=None)
+        if (
+            hasattr(parser, "base_mapping")
+            and hasattr(parser.base_mapping, "extract_imports")
+        ):
+            return self._extract_lark_imports(file_path, content, parser)
+
         # Check if parser has required attributes (engine, extractor)
-        if not hasattr(parser, "engine") or not hasattr(parser, "extractor"):
+        if (
+            not hasattr(parser, "engine")
+            or parser.engine is None
+            or not hasattr(parser, "extractor")
+        ):
             logger.debug(f"Parser lacks required attributes: {file_path}")
             return []
 
@@ -94,6 +105,29 @@ class ImportContextService:
             logger.debug(f"Extracted {len(import_lines)} imports from {file_path}")
             return import_lines
 
+        except Exception as e:
+            logger.warning(f"Failed to extract imports from {file_path}: {e}")
+            return []
+
+    def _extract_lark_imports(
+        self, file_path: str, content: str, parser: Any
+    ) -> list[str]:
+        """Extract imports from Lark-based parsers (e.g., TwinCAT).
+
+        Args:
+            file_path: File path for caching
+            content: File content to parse
+            parser: Parser instance with base_mapping.extract_imports()
+
+        Returns:
+            List of import statement strings
+        """
+        try:
+            import_chunks = parser.base_mapping.extract_imports(content)
+            import_lines = [chunk.content for chunk in import_chunks]
+            self._import_cache[file_path] = import_lines
+            logger.debug(f"Extracted {len(import_lines)} imports from {file_path}")
+            return import_lines
         except Exception as e:
             logger.warning(f"Failed to extract imports from {file_path}: {e}")
             return []

--- a/chunkhound/services/research/shared/import_context.py
+++ b/chunkhound/services/research/shared/import_context.py
@@ -68,9 +68,8 @@ class ImportContextService:
         parser: Any = self._parser_factory.create_parser_for_file(Path(file_path))
 
         # Handle TwinCAT (Lark-based parser with engine=None)
-        if (
-            hasattr(parser, "base_mapping")
-            and hasattr(parser.base_mapping, "extract_imports")
+        if hasattr(parser, "base_mapping") and hasattr(
+            parser.base_mapping, "extract_imports"
         ):
             return self._extract_lark_imports(file_path, content, parser)
 

--- a/chunkhound/services/research/v1/pluggable_research_service.py
+++ b/chunkhound/services/research/v1/pluggable_research_service.py
@@ -660,7 +660,11 @@ class PluggableResearchService:
         chunk_kind = metadata.get("kind") or chunk.get("symbol_type", "")
 
         # If this chunk is marked as a complete function/class/method, use its exact boundaries
-        if chunk_kind in ("function", "method", "class", "interface", "struct", "enum"):
+        if chunk_kind in (
+            "function", "method", "class", "interface", "struct", "enum",
+            # TwinCAT kinds (parser produces complete units)
+            "program", "function_block", "action", "property",
+        ):
             # Chunk is already a complete unit - just add small padding for context
             padding = 3  # A few lines for docstrings/decorators/comments
             start_idx = max(1, start_line - padding)

--- a/chunkhound/services/research/v1/pluggable_research_service.py
+++ b/chunkhound/services/research/v1/pluggable_research_service.py
@@ -22,6 +22,10 @@ from chunkhound.embeddings import EmbeddingManager
 from chunkhound.llm_manager import LLMManager
 from chunkhound.services import prompts
 from chunkhound.services.clustering_service import ClusterGroup
+from chunkhound.services.research.shared.chunk_range import (
+    expand_to_natural_boundaries,
+    get_chunk_expanded_range,
+)
 from chunkhound.services.research.shared.chunk_dedup import get_chunk_id
 from chunkhound.services.research.shared.citation_manager import CitationManager
 from chunkhound.services.research.shared.evidence_ledger import (
@@ -30,9 +34,6 @@ from chunkhound.services.research.shared.evidence_ledger import (
 )
 from chunkhound.services.research.shared.exploration import ExplorationStrategy
 from chunkhound.services.research.shared.models import (
-    ENABLE_SMART_BOUNDARIES,
-    EXTRA_CONTEXT_TOKENS,
-    MAX_BOUNDARY_EXPANSION_LINES,
     MAX_FILE_CONTENT_TOKENS,
     NUM_LLM_EXPANDED_QUERIES,
     OUTPUT_TOKENS_WITH_REASONING,
@@ -614,192 +615,6 @@ class PluggableResearchService:
             path_filter=self._path_filter,
         )
 
-    def _expand_to_natural_boundaries(
-        self,
-        lines: list[str],
-        start_line: int,
-        end_line: int,
-        chunk: dict[str, Any],
-        file_path: str,
-    ) -> tuple[int, int]:
-        """Expand chunk boundaries to complete function/class definitions.
-
-        Uses existing chunk metadata (symbol, kind) and language-specific heuristics
-        to detect natural code boundaries instead of using fixed 50-line windows.
-
-        Args:
-            lines: File content split by lines
-            start_line: Original chunk start line (1-indexed)
-            end_line: Original chunk end line (1-indexed)
-            chunk: Chunk metadata with symbol, kind fields
-            file_path: File path for language detection
-
-        Returns:
-            Tuple of (expanded_start_line, expanded_end_line) in 1-indexed format,
-            or (0, 0) if inputs are invalid.
-        """
-        # Validate 1-indexed inputs
-        if (
-            start_line < 1
-            or end_line < 1
-            or start_line > end_line
-            or start_line > len(lines)
-            or end_line > len(lines)
-        ):
-            return (0, 0)
-
-        if not ENABLE_SMART_BOUNDARIES:
-            # Fallback to legacy fixed-window behavior
-            context_lines = EXTRA_CONTEXT_TOKENS // 20  # ~50 lines
-            start_idx = max(1, start_line - context_lines)
-            end_idx = min(len(lines), end_line + context_lines)
-            return start_idx, end_idx
-
-        # Check if chunk metadata indicates this is already a complete unit
-        metadata = chunk.get("metadata", {})
-        chunk_kind = metadata.get("kind") or chunk.get("symbol_type", "")
-
-        # If this chunk is marked as a complete function/class/method, use its exact boundaries
-        if chunk_kind in (
-            "function",
-            "method",
-            "class",
-            "interface",
-            "struct",
-            "enum",
-            # TwinCAT kinds (parser produces complete units)
-            "program",
-            "function_block",
-            "action",
-            "property",
-        ):
-            # Chunk is already a complete unit - just add small padding for context
-            padding = 3  # A few lines for docstrings/decorators/comments
-            start_idx = max(1, start_line - padding)
-            end_idx = min(len(lines), end_line + padding)
-            logger.debug(
-                f"Using complete {chunk_kind} boundaries: {file_path}:{start_idx}-{end_idx}"
-            )
-            return start_idx, end_idx
-
-        # For non-complete chunks, expand to natural boundaries
-        # Detect language from file extension for language-specific logic
-        file_path_lower = file_path.lower()
-        is_python = file_path_lower.endswith((".py", ".pyw"))
-        is_brace_lang = file_path_lower.endswith(
-            (
-                ".c",
-                ".cpp",
-                ".cc",
-                ".cxx",
-                ".h",
-                ".hpp",
-                ".rs",
-                ".go",
-                ".java",
-                ".js",
-                ".ts",
-                ".tsx",
-                ".jsx",
-                ".cs",
-                ".swift",
-                ".kt",
-                ".scala",
-            )
-        )
-
-        # Convert to 0-indexed for array access
-        start_idx = max(0, start_line - 1)
-        end_idx = min(len(lines) - 1, end_line - 1)
-
-        # Expand backward to find function/class start
-        expanded_start = start_idx
-        if is_python:
-            # Look for def/class keywords at start of line with proper indentation
-            for i in range(start_idx - 1, max(0, start_idx - 200), -1):
-                line = lines[i].strip()
-                if line.startswith(("def ", "class ", "async def ")):
-                    expanded_start = i
-                    break
-                # Stop at empty lines followed by significant dedents (module boundary)
-                if not line and i > 0:
-                    next_line = lines[i + 1].lstrip() if i + 1 < len(lines) else ""
-                    if next_line and not next_line.startswith((" ", "\t")):
-                        break
-        elif is_brace_lang:
-            # Look for opening braces and function signatures
-            brace_depth = 0
-            for i in range(start_idx, max(0, start_idx - 200), -1):
-                line = lines[i]
-                # Count braces
-                open_braces = line.count("{")
-                close_braces = line.count("}")
-                brace_depth += close_braces - open_braces
-
-                # Found matching opening brace
-                if brace_depth > 0 and "{" in line:
-                    # Look backward for function signature
-                    for j in range(i, max(0, i - 10), -1):
-                        sig_line = lines[j].strip()
-                        # Heuristic: function signatures often have (...) or start with keywords
-                        if "(" in sig_line and (")" in sig_line or j < i):
-                            expanded_start = j
-                            break
-                    if expanded_start != start_idx:
-                        break
-
-        # Expand forward to find function/class end
-        expanded_end = end_idx
-        if is_python:
-            # Find end by detecting dedentation back to original level
-            if expanded_start < len(lines):
-                start_indent = len(lines[expanded_start]) - len(
-                    lines[expanded_start].lstrip()
-                )
-                for i in range(end_idx + 1, min(len(lines), end_idx + 200)):
-                    line = lines[i]
-                    if line.strip():  # Non-empty line
-                        line_indent = len(line) - len(line.lstrip())
-                        # Dedented to same or less indentation = end of block
-                        if line_indent <= start_indent:
-                            expanded_end = i - 1
-                            break
-                else:
-                    # Reached search limit, use current position
-                    expanded_end = min(len(lines) - 1, end_idx + 50)
-        elif is_brace_lang:
-            # Find matching closing brace
-            brace_depth = 0
-            for i in range(expanded_start, min(len(lines), end_idx + 200)):
-                line = lines[i]
-                open_braces = line.count("{")
-                close_braces = line.count("}")
-                brace_depth += open_braces - close_braces
-
-                # Found matching closing brace
-                if brace_depth == 0 and i > expanded_start and "}" in line:
-                    expanded_end = i
-                    break
-
-        # Safety: Don't expand beyond max limit
-        if expanded_end - expanded_start > MAX_BOUNDARY_EXPANSION_LINES:
-            logger.debug(
-                f"Boundary expansion too large ({expanded_end - expanded_start} lines), "
-                f"limiting to {MAX_BOUNDARY_EXPANSION_LINES}"
-            )
-            expanded_end = expanded_start + MAX_BOUNDARY_EXPANSION_LINES
-
-        # Convert back to 1-indexed
-        final_start = expanded_start + 1
-        final_end = expanded_end + 1
-
-        logger.debug(
-            f"Expanded boundaries: {file_path}:{start_line}-{end_line} -> "
-            f"{final_start}-{final_end} ({final_end - final_start} lines)"
-        )
-
-        return final_start, final_end
-
     async def _read_files_with_budget(
         self, chunks: list[dict[str, Any]], max_tokens: int | None = None
     ) -> dict[str, str]:
@@ -887,7 +702,7 @@ class PluggableResearchService:
 
                         # Use smart boundary detection to expand to complete functions/classes
                         expanded_start, expanded_end = (
-                            self._expand_to_natural_boundaries(
+                            expand_to_natural_boundaries(
                                 lines, start_line, end_line, chunk, file_path
                             )
                         )
@@ -898,7 +713,7 @@ class PluggableResearchService:
                                 f"Skipping chunk with invalid boundaries: "
                                 f"{file_path}:{start_line}-{end_line}"
                             )
-                            continue
+                            continue  # (0,0) = out-of-bounds chunk; skip rather than pass bad slice to LLM
 
                         # Store expanded range in chunk for later deduplication
                         chunk["expanded_start_line"] = expanded_start
@@ -966,55 +781,8 @@ class PluggableResearchService:
         return "\n\n...\n\n" not in file_content
 
     def _get_chunk_expanded_range(self, chunk: dict[str, Any]) -> tuple[int, int]:
-        """Get expanded line range for chunk.
-
-        If expansion already computed and stored in chunk, return it.
-        Otherwise, re-compute using _expand_to_natural_boundaries().
-
-        Args:
-            chunk: Chunk dictionary with metadata
-
-        Returns:
-            Tuple of (expanded_start_line, expanded_end_line) in 1-indexed format
-        """
-        # Check if already stored (after enhancement in _read_files_with_budget)
-        if "expanded_start_line" in chunk and "expanded_end_line" in chunk:
-            return (chunk["expanded_start_line"], chunk["expanded_end_line"])
-
-        # Re-compute (fallback)
-        file_path = chunk.get("file_path")
-        start_line = chunk.get("start_line", 0)
-        end_line = chunk.get("end_line", 0)
-
-        if not file_path or not start_line or not end_line:
-            return (start_line, end_line)
-
-        # Read file lines
-        try:
-            base_dir = self._db_services.provider.get_base_directory()
-            if Path(file_path).is_absolute():
-                path = Path(file_path)
-            else:
-                path = base_dir / file_path
-
-            with open(path, encoding="utf-8", errors="replace") as f:
-                lines = f.readlines()
-        except Exception as e:
-            logger.debug(f"Could not re-read file for expansion: {file_path}: {e}")
-            return (start_line, end_line)
-
-        expanded_start, expanded_end = self._expand_to_natural_boundaries(
-            lines, start_line, end_line, chunk, file_path
-        )
-
-        # Fallback to original range if expansion fails
-        if expanded_start == 0 and expanded_end == 0:
-            logger.warning(
-                f"Boundary expansion failed for {file_path}, using original range"
-            )
-            return (start_line, end_line)
-
-        return (expanded_start, expanded_end)
+        """Delegate to shared chunk_range.get_chunk_expanded_range."""
+        return get_chunk_expanded_range(chunk, self._db_services)
 
     def _aggregate_all_findings(
         self, chunks: list[dict[str, Any]], file_contents: dict[str, str]

--- a/chunkhound/services/research/v1/pluggable_research_service.py
+++ b/chunkhound/services/research/v1/pluggable_research_service.py
@@ -661,9 +661,17 @@ class PluggableResearchService:
 
         # If this chunk is marked as a complete function/class/method, use its exact boundaries
         if chunk_kind in (
-            "function", "method", "class", "interface", "struct", "enum",
+            "function",
+            "method",
+            "class",
+            "interface",
+            "struct",
+            "enum",
             # TwinCAT kinds (parser produces complete units)
-            "program", "function_block", "action", "property",
+            "program",
+            "function_block",
+            "action",
+            "property",
         ):
             # Chunk is already a complete unit - just add small padding for context
             padding = 3  # A few lines for docstrings/decorators/comments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ dependencies = [
     "anthropic>=0.75.0",
     "msgpack>=1.0",
     "tomli>=2.0.0; python_version < '3.11'",
+    "lark>=1.1.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/fixtures/twincat/example_comprehensive.TcPOU
+++ b/tests/fixtures/twincat/example_comprehensive.TcPOU
@@ -1,0 +1,606 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_ComprehensiveExample" Id="{12345678-1234-1234-1234-123456789abc}" SpecialFunc="None">
+    <Declaration><![CDATA[// Comprehensive example demonstrating all supported parser constructs
+// This file exercises the declarations.lark and implementation.lark grammars
+
+FUNCTION_BLOCK FB_ComprehensiveExample
+
+// ============================================================================
+// VAR_INPUT - Input parameters
+// ============================================================================
+VAR_INPUT
+    // Primitive types
+    bEnable : BOOL;
+    nInputValue : INT := 100;
+    fSetpoint : REAL := 3.14159;
+    sCommand : STRING(80) := 'default';
+
+    // Arrays
+    anInputArray : ARRAY[0..9] OF INT;
+    afMatrix : ARRAY[1..3, 1..3] OF REAL;
+END_VAR
+
+// ============================================================================
+// VAR_OUTPUT - Output parameters
+// ============================================================================
+VAR_OUTPUT
+    bDone : BOOL := FALSE;
+    bError : BOOL;
+    nErrorCode : DINT;
+    sStatus : STRING(255);
+    anResults : ARRAY[0..4] OF DINT;
+END_VAR
+
+// ============================================================================
+// VAR_IN_OUT - In/Out parameters (passed by reference)
+// ============================================================================
+VAR_IN_OUT
+    refCounter : DINT;
+    aBuffer : ARRAY[0..1023] OF BYTE;
+END_VAR
+
+// ============================================================================
+// VAR - Local variables
+// ============================================================================
+VAR
+    // Boolean types
+    bFlag1 : BOOL := TRUE;
+    bFlag2, bFlag3 : BOOL;
+
+    // Integer types - various sizes
+    nSint : SINT := -128;
+    nUsint : USINT := 255;
+    nInt : INT := -32768;
+    nUint : UINT := 65535;
+    nDint : DINT := -2147483648;
+    nUdint : UDINT := 16#FFFFFFFF;
+    nLint : LINT;
+    nUlint : ULINT;
+
+    // Floating point types
+    fReal : REAL := 1.5e-3;
+    fLreal : LREAL := 2.718281828;
+
+    // Bit types
+    nByte : BYTE := 16#FF;
+    nWord : WORD := 2#1010101010101010;
+    nDword : DWORD := 8#77777777;
+    nLword : LWORD;
+
+    // String types
+    sName : STRING(50);
+    sDescription : STRING := 'Hello World';
+    wsUnicode : WSTRING(100);
+
+    // Time and date types
+    tDuration : TIME := T#5s;
+    tLongDuration : TIME := T#5400s;
+    dtTimestamp : DATE;
+    todTime : TIME_OF_DAY;
+    dtDateTime : DATE_AND_TIME;
+
+    // Array types - single dimension
+    anSimpleArray : ARRAY[0..9] OF INT := [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    abFlags : ARRAY[1..4] OF BOOL := [TRUE, FALSE, TRUE, FALSE];
+
+    // Array types - multi-dimensional
+    afMatrix2D : ARRAY[0..2, 0..2] OF REAL;
+    anCube : ARRAY[0..1, 0..1, 0..1] OF INT;
+
+    // Array with repetition initializer
+    anZeros : ARRAY[0..99] OF INT := [100(0)];
+
+    // User-defined types (structs, enums, FBs)
+    stData : ST_DataRecord;
+    eState : E_MachineState;
+    fbTimer : TON;
+    fbCounter : CTU;
+
+    // Pointers and references
+    pnValue : POINTER TO INT;
+    pstRecord : POINTER TO ST_DataRecord;
+    refValue : REFERENCE TO DINT;
+
+    // Struct initializer
+    stConfig : ST_Configuration := (nId := 1, sName := 'Config1', bEnabled := TRUE);
+
+    // SIZEOF usage
+    nBufferSize : UDINT := SIZEOF(aBuffer);
+    nIntSize : UDINT := SIZEOF(INT);
+
+    // Loop counters
+    i, j, k : INT;
+    nLoopCount : INT;
+END_VAR
+
+// ============================================================================
+// VAR_STAT - Static variables (retain value between calls)
+// ============================================================================
+VAR_STAT
+    nCallCount : UDINT := 0;
+    fAccumulator : LREAL := 0.0;
+END_VAR
+
+// ============================================================================
+// VAR_TEMP - Temporary variables
+// ============================================================================
+VAR_TEMP
+    nTempValue : INT;
+    fTempResult : REAL;
+END_VAR
+
+// ============================================================================
+// VAR with qualifiers
+// ============================================================================
+VAR CONSTANT
+    c_nMaxItems : INT := 100;
+    c_fPi : REAL := 3.14159265;
+    c_sVersion : STRING := '1.0.0';
+END_VAR
+
+VAR RETAIN
+    nRetainedCounter : DINT;
+    bRetainedFlag : BOOL;
+END_VAR
+
+VAR PERSISTENT
+    nPersistentValue : DINT;
+END_VAR
+
+VAR RETAIN PERSISTENT
+    stSavedState : ST_PersistentData;
+END_VAR
+
+// ============================================================================
+// Hardware-mapped variables (AT directive)
+// ============================================================================
+VAR
+    bDigitalInput AT %I* : BOOL;
+    nAnalogInput AT %IW100 : INT;
+    bDigitalOutput AT %Q* : BOOL;
+    nAnalogOutput AT %QW50 : INT;
+    nMemoryWord AT %MW200 : WORD;
+    bMemoryBit AT %MX100.0 : BOOL;
+END_VAR
+
+// ============================================================================
+// Attribute pragmas
+// ============================================================================
+{attribute 'OPC.UA.DA' := '1'}
+VAR
+    fOpcValue : REAL;
+END_VAR
+
+{attribute 'pack_mode' := '1'}
+VAR
+    {attribute 'hide'}
+    nHiddenVar : INT;
+END_VAR
+
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[// ============================================================================
+// IMPLEMENTATION - Demonstrates all statement and expression types
+// ============================================================================
+
+// Increment static call counter
+nCallCount := nCallCount + 1;
+
+// ============================================================================
+// Simple assignments with various operators
+// ============================================================================
+
+// Arithmetic operators
+nInt := 10 + 5;           // Addition
+nInt := nInt - 3;         // Subtraction
+nInt := nInt * 2;         // Multiplication
+nInt := nInt / 4;         // Division
+nInt := 17 MOD 5;         // Modulo
+fReal := 2.0 EXPT 3.0;    // Exponentiation with EXPT keyword
+fReal := 2.0 ** 3.0;      // Exponentiation with ** operator
+
+// Negation and precedence: -2 EXPT 2 = -(2^2) = -4
+fReal := -2.0 EXPT 2.0;
+
+// Logical operators
+bFlag1 := TRUE AND FALSE;
+bFlag2 := TRUE OR FALSE;
+bFlag3 := TRUE XOR FALSE;
+bFlag1 := NOT bFlag2;
+
+// Short-circuit operators
+bFlag1 := bFlag2 AND_THEN bFlag3;  // Only evaluates bFlag3 if bFlag2 is TRUE
+bFlag2 := bFlag1 OR_ELSE bFlag3;   // Only evaluates bFlag3 if bFlag1 is FALSE
+
+// Relational operators
+bFlag1 := nInt < 100;
+bFlag2 := nInt > 50;
+bFlag3 := nInt <= 75;
+bFlag1 := nInt >= 25;
+bFlag2 := nInt = 42;
+bFlag3 := nInt <> 0;
+
+// Compound expressions with precedence
+nDint := (10 + 5) * 3 - 2;
+bFlag1 := (nInt > 0) AND (nInt < 100) OR bFlag2;
+
+// ============================================================================
+// Numeric literals in various bases
+// ============================================================================
+
+nInt := 42;                // Decimal
+nByte := 16#FF;            // Hexadecimal
+nWord := 2#10101010;       // Binary
+nDword := 8#755;           // Octal
+fReal := 1.5;              // Float
+fReal := 3.14159;          // Float with decimals
+fReal := 1.0e-6;           // Scientific notation
+fReal := 2E10;             // Scientific without decimal
+
+// ============================================================================
+// String literals
+// ============================================================================
+
+sName := 'Single quoted string';
+sDescription := "Double quoted string";
+
+// ============================================================================
+// Time literals
+// ============================================================================
+
+tDuration := T#100ms;
+tDuration := T#5s;
+tDuration := T#150s;
+tDuration := T#3600s;
+tDuration := T#93784005ms;
+tDuration := T#500ms;
+tDuration := T#-10s;       // Negative time
+
+// ============================================================================
+// Variable access patterns
+// ============================================================================
+
+// Simple variable access
+nInt := nInputValue;
+
+// Member access (struct fields)
+nDint := stData.nValue;
+sName := stConfig.sName;
+
+// Chained member access
+fReal := stData.stNested.fValue;
+
+// Array access - single dimension
+nInt := anSimpleArray[0];
+nInt := anInputArray[i];
+
+// Array access - multi-dimensional
+fReal := afMatrix[1, 2];
+fReal := afMatrix2D[i, j];
+
+// Bit access on integers
+bFlag1 := nWord.0;         // Access bit 0
+bFlag2 := nDword.15;       // Access bit 15
+
+// Combined access patterns
+nInt := stData.anArray[i];
+bFlag1 := stData.nFlags.3;
+fReal := aStructArray[i].fValue;
+
+// ============================================================================
+// IF / ELSIF / ELSE / END_IF
+// ============================================================================
+
+IF bEnable THEN
+    bDone := TRUE;
+    nErrorCode := 0;
+END_IF;
+
+IF nInt > 100 THEN
+    nInt := 100;
+ELSIF nInt < 0 THEN
+    nInt := 0;
+ELSE
+    nInt := nInt + 1;
+END_IF;
+
+// Nested IF statements
+IF bFlag1 THEN
+    IF bFlag2 THEN
+        nInt := 1;
+    ELSE
+        nInt := 2;
+    END_IF;
+END_IF;
+
+// Complex condition
+IF (nInt > 0 AND nInt < 100) OR bEnable THEN
+    bFlag1 := TRUE;
+END_IF;
+
+// ============================================================================
+// CASE statement
+// ============================================================================
+
+CASE nInt OF
+    0:
+        sStatus := 'Zero';
+    1:
+        sStatus := 'One';
+    2, 3, 4:
+        sStatus := 'Two to Four';
+    5..10:
+        sStatus := 'Five to Ten';
+    100..200:
+        sStatus := 'Hundred range';
+        bFlag1 := TRUE;
+ELSE
+    sStatus := 'Other';
+END_CASE;
+
+// CASE with numeric constants
+CASE nInt OF
+    20:
+        bDone := FALSE;
+    21:
+        bDone := FALSE;
+    22:
+        bDone := TRUE;
+END_CASE;
+
+// ============================================================================
+// FOR loop
+// ============================================================================
+
+// Basic FOR loop
+FOR i := 0 TO 9 DO
+    anSimpleArray[i] := i * 2;
+END_FOR;
+
+// FOR loop with BY clause (step)
+FOR i := 0 TO 100 BY 10 DO
+    nInt := nInt + i;
+END_FOR;
+
+// FOR loop with negative step
+FOR i := 10 TO 0 BY -1 DO
+    anSimpleArray[i] := 0;
+END_FOR;
+
+// Nested FOR loops
+FOR i := 0 TO 2 DO
+    FOR j := 0 TO 2 DO
+        afMatrix2D[i, j] := DINT_TO_REAL(i * 3 + j);
+    END_FOR;
+END_FOR;
+
+// FOR with parenthesized assignment (alternative syntax)
+FOR (i := 0) TO 9 DO
+    nInt := nInt + 1;
+END_FOR;
+
+// ============================================================================
+// WHILE loop
+// ============================================================================
+
+nLoopCount := 0;
+WHILE nLoopCount < 10 DO
+    nLoopCount := nLoopCount + 1;
+    anSimpleArray[nLoopCount - 1] := nLoopCount;
+END_WHILE;
+
+// WHILE with complex condition
+WHILE bEnable AND (nLoopCount > 0) DO
+    nLoopCount := nLoopCount - 1;
+END_WHILE;
+
+// ============================================================================
+// REPEAT / UNTIL loop
+// ============================================================================
+
+nLoopCount := 0;
+REPEAT
+    nLoopCount := nLoopCount + 1;
+UNTIL nLoopCount >= 10
+END_REPEAT;
+
+// ============================================================================
+// Function calls
+// ============================================================================
+
+// Simple function call with positional arguments
+nInt := ABS(-42);
+fReal := SQRT(16.0);
+nInt := MAX(nInt, 100);
+nInt := MIN(nInt, 0);
+
+// Type conversion functions
+fReal := INT_TO_REAL(nInt);
+nInt := REAL_TO_INT(fReal);
+nDint := INT_TO_DINT(nInt);
+sName := DINT_TO_STRING(nDint);
+
+// Function call with named arguments
+fbTimer(IN := bEnable, PT := T#5s);
+
+// Function call with output arguments using =>
+fbTimer(IN := bEnable, PT := T#1s, Q => bDone, ET => tDuration);
+
+// Function block invocation
+fbCounter(CU := bFlag1, RESET := bFlag2, PV := 100);
+
+// Method call on function block
+fbTimer.Reset();
+
+// Method calls on nested objects
+stData.stNested.GetResult();
+
+// EXPT as function call
+fReal := EXPT(2.0, 8.0);
+
+// ============================================================================
+// Jump statements
+// ============================================================================
+
+// EXIT - break out of loop
+FOR i := 0 TO 100 DO
+    IF i > 50 THEN
+        EXIT;
+    END_IF;
+    nInt := i;
+END_FOR;
+
+// CONTINUE - skip to next iteration
+FOR i := 0 TO 9 DO
+    IF i MOD 2 = 0 THEN
+        CONTINUE;
+    END_IF;
+    anSimpleArray[i] := i;
+END_FOR;
+
+// RETURN - early return from function block
+IF bError THEN
+    RETURN;
+END_IF;
+
+// ============================================================================
+// Empty statement
+// ============================================================================
+
+;  // Empty statement is valid
+
+// ============================================================================
+// Comments
+// ============================================================================
+
+// This is a line comment
+nInt := 42;  // Inline comment
+
+(* This is a block comment *)
+
+(*
+   Multi-line
+   block comment
+*)
+
+nInt := (* inline block comment *) 100;
+
+// ============================================================================
+// Expression statement (standalone variable access)
+// ============================================================================
+
+stData.nCounter;  // Expression statement - accesses but discards result
+
+]]></ST>
+    </Implementation>
+    <Action Name="ProcessData" Id="{aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee}">
+      <Declaration><![CDATA[// Action: ProcessData
+// Demonstrates local variables in action declaration
+
+VAR
+    nLocalIndex : INT;
+    fLocalSum : REAL := 0.0;
+    bLocalFlag : BOOL;
+    anLocalBuffer : ARRAY[0..9] OF DINT;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[// ProcessData action implementation
+// Demonstrates data processing with loops and conditionals
+
+// Initialize local buffer
+FOR nLocalIndex := 0 TO 9 DO
+    anLocalBuffer[nLocalIndex] := 0;
+END_FOR;
+
+// Process input array with accumulation
+fLocalSum := 0.0;
+FOR nLocalIndex := 0 TO 9 DO
+    IF anInputArray[nLocalIndex] > 0 THEN
+        fLocalSum := fLocalSum + INT_TO_REAL(anInputArray[nLocalIndex]);
+        anLocalBuffer[nLocalIndex] := INT_TO_DINT(anInputArray[nLocalIndex]) * 2;
+    ELSE
+        anLocalBuffer[nLocalIndex] := 0;
+    END_IF;
+END_FOR;
+
+// Copy results to output
+FOR nLocalIndex := 0 TO 4 DO
+    anResults[nLocalIndex] := anLocalBuffer[nLocalIndex];
+END_FOR;
+
+// Set status based on processing
+IF fLocalSum > 1000.0 THEN
+    sStatus := 'High sum detected';
+    bLocalFlag := TRUE;
+ELSIF fLocalSum > 100.0 THEN
+    sStatus := 'Normal processing';
+    bLocalFlag := FALSE;
+ELSE
+    sStatus := 'Low values';
+    bLocalFlag := FALSE;
+END_IF;
+
+// Update accumulator
+fAccumulator := fAccumulator + fLocalSum;
+
+]]></ST>
+      </Implementation>
+    </Action>
+    <Action Name="ResetState" Id="{11111111-2222-3333-4444-555555555555}">
+      <Declaration><![CDATA[// Action: ResetState
+// Demonstrates state reset logic
+
+VAR
+    nResetIndex : INT;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[// ResetState action implementation
+// Clears all state variables and outputs
+
+// Reset outputs
+bDone := FALSE;
+bError := FALSE;
+nErrorCode := 0;
+sStatus := '';
+
+// Clear output array
+FOR nResetIndex := 0 TO 4 DO
+    anResults[nResetIndex] := 0;
+END_FOR;
+
+// Reset internal state
+bFlag1 := FALSE;
+bFlag2 := FALSE;
+bFlag3 := FALSE;
+nInt := 0;
+fReal := 0.0;
+
+// Reset static accumulator
+fAccumulator := 0.0;
+
+// Reset timers and counters using method calls
+fbTimer(IN := FALSE);
+fbCounter(RESET := TRUE);
+
+// Clear arrays using nested loops
+FOR i := 0 TO 9 DO
+    anSimpleArray[i] := 0;
+END_FOR;
+
+FOR i := 0 TO 2 DO
+    FOR j := 0 TO 2 DO
+        afMatrix2D[i, j] := 0.0;
+    END_FOR;
+END_FOR;
+
+// Signal completion
+sStatus := 'Reset complete';
+
+]]></ST>
+      </Implementation>
+    </Action>
+  </POU>
+</TcPlcObject>

--- a/tests/fixtures/twincat/example_function.TcPOU
+++ b/tests/fixtures/twincat/example_function.TcPOU
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_Add" Id="{22222222-2222-2222-2222-222222222222}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_Add : DINT
+VAR_INPUT
+    nA : DINT;
+    nB : DINT;
+END_VAR
+VAR
+    nResult : DINT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[nResult := nA + nB;
+FC_Add := nResult;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/tests/fixtures/twincat/example_function_block_with_methods.TcPOU
+++ b/tests/fixtures/twincat/example_function_block_with_methods.TcPOU
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_WithMethods" Id="{aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee}" SpecialFunc="None">
+    <Declaration><![CDATA[// Function block with methods demonstrating TwinCAT 3 OOP features
+
+FUNCTION_BLOCK FB_WithMethods
+
+VAR_INPUT
+    bEnable : BOOL;
+END_VAR
+
+VAR_OUTPUT
+    bDone : BOOL;
+    nStatus : INT;
+END_VAR
+
+VAR
+    nInternalState : INT := 0;
+    fValue : REAL := 0.0;
+END_VAR
+
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[// Main execution logic
+IF bEnable THEN
+    nInternalState := nInternalState + 1;
+END_IF;
+]]></ST>
+    </Implementation>
+    <Method Name="Initialize" Id="{11111111-2222-3333-4444-555555555555}">
+      <Declaration><![CDATA[// Method: Initialize
+// Initializes the function block state
+
+METHOD Initialize : BOOL
+
+VAR_INPUT
+    bReset : BOOL := FALSE;
+    nInitValue : INT := 0;
+END_VAR
+
+VAR
+    bLocalFlag : BOOL;
+END_VAR
+
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[// Initialize method implementation
+IF bReset THEN
+    nInternalState := nInitValue;
+    fValue := 0.0;
+    bLocalFlag := TRUE;
+END_IF;
+
+Initialize := bLocalFlag;
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="GetStatus" Id="{22222222-3333-4444-5555-666666666666}">
+      <Declaration><![CDATA[// Method: GetStatus
+// Returns the current status
+
+METHOD PUBLIC GetStatus : INT
+
+VAR_INPUT
+    bDetailed : BOOL := FALSE;
+END_VAR
+
+VAR
+    nTempStatus : INT;
+END_VAR
+
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[// GetStatus method implementation
+nTempStatus := nInternalState;
+
+IF bDetailed AND nInternalState > 0 THEN
+    nTempStatus := nTempStatus * 10;
+END_IF;
+
+GetStatus := nTempStatus;
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="ProcessData" Id="{33333333-4444-5555-6666-777777777777}">
+      <Declaration><![CDATA[// Method: ProcessData
+// Processes data with loops
+
+METHOD PRIVATE ProcessData : REAL
+
+VAR_INPUT
+    anData : ARRAY[0..9] OF INT;
+END_VAR
+
+VAR
+    i : INT;
+    fSum : REAL := 0.0;
+END_VAR
+
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[// ProcessData method with FOR loop
+FOR i := 0 TO 9 DO
+    fSum := fSum + INT_TO_REAL(anData[i]);
+END_FOR;
+
+ProcessData := fSum;
+]]></ST>
+      </Implementation>
+    </Method>
+  </POU>
+</TcPlcObject>

--- a/tests/fixtures/twincat/example_function_block_with_properties.TcPOU
+++ b/tests/fixtures/twincat/example_function_block_with_properties.TcPOU
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_WithProperties" Id="{bbbbbbbb-cccc-dddd-eeee-ffffffffffff}" SpecialFunc="None">
+    <Declaration><![CDATA[// Function block with properties demonstrating TwinCAT 3 OOP features
+
+FUNCTION_BLOCK FB_WithProperties
+
+VAR
+    nInternal : INT := 0;
+    fInternalValue : REAL := 0.0;
+    sInternalName : STRING(50) := '';
+END_VAR
+
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[// Main execution - no-op for property demo
+]]></ST>
+    </Implementation>
+    <Property Name="Value" Id="{44444444-5555-6666-7777-888888888888}">
+      <Declaration><![CDATA[// Property: Value
+// Gets or sets the internal integer value
+
+PROPERTY Value : INT
+
+]]></Declaration>
+      <Get Name="Get" Id="{44444444-5555-6666-7777-888888888889}">
+        <Declaration><![CDATA[// Getter for Value property
+
+VAR
+END_VAR
+
+]]></Declaration>
+        <Implementation>
+          <ST><![CDATA[Value := nInternal;
+]]></ST>
+        </Implementation>
+      </Get>
+      <Set Name="Set" Id="{44444444-5555-6666-7777-88888888888a}">
+        <Declaration><![CDATA[// Setter for Value property
+
+VAR
+END_VAR
+
+]]></Declaration>
+        <Implementation>
+          <ST><![CDATA[nInternal := Value;
+]]></ST>
+        </Implementation>
+      </Set>
+    </Property>
+    <Property Name="ReadOnlyStatus" Id="{55555555-6666-7777-8888-999999999999}">
+      <Declaration><![CDATA[// Property: ReadOnlyStatus
+// Read-only property returning calculated status
+
+PROPERTY ReadOnlyStatus : INT
+
+]]></Declaration>
+      <Get Name="Get" Id="{55555555-6666-7777-8888-99999999999a}">
+        <Declaration><![CDATA[// Getter for ReadOnlyStatus property
+
+VAR
+    nCalcStatus : INT;
+END_VAR
+
+]]></Declaration>
+        <Implementation>
+          <ST><![CDATA[nCalcStatus := nInternal * 2;
+ReadOnlyStatus := nCalcStatus;
+]]></ST>
+        </Implementation>
+      </Get>
+    </Property>
+    <Property Name="Name" Id="{66666666-7777-8888-9999-aaaaaaaaaaaa}">
+      <Declaration><![CDATA[// Property: Name
+// Gets or sets the internal name string
+
+PROPERTY Name : STRING(50)
+
+]]></Declaration>
+      <Get Name="Get" Id="{66666666-7777-8888-9999-aaaaaaaaaa0b}">
+        <Declaration><![CDATA[// Getter for Name property
+
+VAR
+END_VAR
+
+]]></Declaration>
+        <Implementation>
+          <ST><![CDATA[Name := sInternalName;
+]]></ST>
+        </Implementation>
+      </Get>
+      <Set Name="Set" Id="{66666666-7777-8888-9999-aaaaaaaaaa0c}">
+        <Declaration><![CDATA[// Setter for Name property
+
+VAR
+END_VAR
+
+]]></Declaration>
+        <Implementation>
+          <ST><![CDATA[sInternalName := Name;
+]]></ST>
+        </Implementation>
+      </Set>
+    </Property>
+  </POU>
+</TcPlcObject>

--- a/tests/fixtures/twincat/example_function_if.TcPOU
+++ b/tests/fixtures/twincat/example_function_if.TcPOU
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_ProcessValue" Id="{33333333-3333-3333-3333-333333333333}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_ProcessValue : DINT
+VAR_INPUT
+    nValue : DINT;
+    bEnabled : BOOL;
+END_VAR
+VAR
+    nResult : DINT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[nResult := 0;
+
+IF bEnabled THEN
+    IF nValue > 100 THEN
+        nResult := 100;
+    ELSIF nValue < 0 THEN
+        nResult := 0;
+    ELSE
+        nResult := nValue;
+    END_IF;
+END_IF;
+
+FC_ProcessValue := nResult;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/tests/fixtures/twincat/example_function_loops.TcPOU
+++ b/tests/fixtures/twincat/example_function_loops.TcPOU
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_LoopDemo" Id="{44444444-4444-4444-4444-444444444444}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_LoopDemo : DINT
+VAR_INPUT
+    nCount : INT;
+    nMode : INT;
+END_VAR
+VAR
+    nSum : DINT;
+    i : INT;
+    bDone : BOOL;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[nSum := 0;
+bDone := FALSE;
+
+CASE nMode OF
+    1:
+        FOR i := 0 TO nCount DO
+            nSum := nSum + i;
+        END_FOR;
+    2:
+        i := 0;
+        WHILE i < nCount DO
+            nSum := nSum + i;
+            i := i + 1;
+        END_WHILE;
+    3:
+        i := 0;
+        REPEAT
+            nSum := nSum + i;
+            i := i + 1;
+        UNTIL i >= nCount
+        END_REPEAT;
+ELSE
+    nSum := -1;
+END_CASE;
+
+FC_LoopDemo := nSum;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/tests/fixtures/twincat/example_function_with_action.TcPOU
+++ b/tests/fixtures/twincat/example_function_with_action.TcPOU
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_WithAction" Id="{55555555-5555-5555-5555-555555555555}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_WithAction : DINT
+VAR_INPUT
+    nInput : DINT;
+    bProcess : BOOL;
+END_VAR
+VAR
+    nResult : DINT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[nResult := nInput;
+
+IF bProcess THEN
+    nResult := nResult * 2;
+END_IF;
+
+FC_WithAction := nResult;
+]]></ST>
+    </Implementation>
+    <Action Name="ProcessArray" Id="{aaaaaaaa-1111-2222-3333-444444444444}">
+      <Declaration><![CDATA[VAR
+    i : INT;
+    nLocalSum : DINT;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[nLocalSum := 0;
+
+FOR i := 0 TO 9 DO
+    IF i MOD 2 = 0 THEN
+        nLocalSum := nLocalSum + i;
+    END_IF;
+END_FOR;
+
+WHILE nLocalSum > 100 DO
+    nLocalSum := nLocalSum - 10;
+END_WHILE;
+
+nResult := nLocalSum;
+]]></ST>
+      </Implementation>
+    </Action>
+  </POU>
+</TcPlcObject>

--- a/tests/fixtures/twincat/example_program.TcPOU
+++ b/tests/fixtures/twincat/example_program.TcPOU
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="PRG_Example" Id="{11111111-1111-1111-1111-111111111111}" SpecialFunc="None">
+    <Declaration><![CDATA[PROGRAM PRG_Example
+VAR_INPUT
+    bStart : BOOL;
+END_VAR
+VAR_OUTPUT
+    bRunning : BOOL;
+END_VAR
+VAR
+    nCycleCount : DINT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[IF bStart THEN
+    bRunning := TRUE;
+    nCycleCount := nCycleCount + 1;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/tests/fixtures/twincat/example_with_comments.TcPOU
+++ b/tests/fixtures/twincat/example_with_comments.TcPOU
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_CommentExample" Id="{44444444-4444-4444-4444-444444444444}" SpecialFunc="None">
+    <Declaration><![CDATA[(* This is a block comment in the declaration *)
+FUNCTION_BLOCK FB_CommentExample
+VAR_INPUT
+    nInput : DINT;  // Input parameter comment
+END_VAR
+VAR
+    (* Multi-line
+       block comment
+       in VAR section *)
+    nCounter : DINT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[(* Implementation block comment *)
+// Line comment before assignment
+nCounter := nCounter + nInput;
+
+(* Another block comment
+   spanning multiple lines *)
+// Final line comment
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/tests/test_e2e_chunk_size_constraints.py
+++ b/tests/test_e2e_chunk_size_constraints.py
@@ -397,6 +397,23 @@ LARGE_LANGUAGE_SAMPLES: dict[Language, tuple[str, str, str]] = {
         # Normal
         "Unknown file type content line one.\nSecond line of unknown content.",
     ),
+    Language.TWINCAT: (
+        ".TcPOU",
+        # Large FUNCTION_BLOCK - triggers line-based split
+        '<?xml version="1.0" encoding="utf-8"?>\n'
+        '<TcPlcObject Version="1.1.0.1">\n'
+        '  <POU Name="FB_Large" Id="{00000000-0000-0000-0000-000000000001}" SpecialFunc="None">\n'
+        "    <Declaration><![CDATA[FUNCTION_BLOCK FB_Large\nVAR\nEND_VAR\n]]></Declaration>\n"
+        "    <Implementation>\n      <ST><![CDATA["
+        + _make_large_statements("    nX := nX + 1;")
+        + "]]></ST>\n    </Implementation>\n  </POU>\n</TcPlcObject>",
+        # Normal - small FUNCTION_BLOCK, no over-splitting
+        '<?xml version="1.0" encoding="utf-8"?>\n'
+        '<TcPlcObject Version="1.1.0.1">\n'
+        '  <POU Name="FB_Greet" Id="{00000000-0000-0000-0000-000000000002}" SpecialFunc="None">\n'
+        "    <Declaration><![CDATA[FUNCTION_BLOCK FB_Greet\nVAR\nEND_VAR\n]]></Declaration>\n"
+        "    <Implementation>\n      <ST><![CDATA[nX := 1;\n]]></ST>\n    </Implementation>\n  </POU>\n</TcPlcObject>",
+    ),
 }
 
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -45,6 +45,7 @@ LANGUAGE_SAMPLES = {
     Language.LUA: "function hello() print('world') end",
     Language.SQL: "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100));\nCREATE VIEW active_users AS SELECT * FROM users;\nCREATE FUNCTION get_user_count() RETURNS INT BEGIN RETURN 0; END;\nCREATE TRIGGER audit_insert AFTER INSERT ON users FOR EACH ROW BEGIN INSERT INTO audit_log VALUES (NEW.id); END;\nCREATE INDEX idx_users_name ON users (name);",
     Language.ELIXIR: "defmodule Hello do\n  def world, do: :ok\nend",
+    Language.TWINCAT: '<?xml version="1.0" encoding="utf-8"?>\n<TcPlcObject Version="1.1.0.1">\n  <POU Name="PRG_Main" Id="{00000000-0000-0000-0000-000000000000}" SpecialFunc="None">\n    <Declaration><![CDATA[PROGRAM PRG_Main\nVAR\n    x : INT;\nEND_VAR\n]]></Declaration>\n    <Implementation>\n      <ST><![CDATA[x := 1;\n]]></ST>\n    </Implementation>\n  </POU>\n</TcPlcObject>',
 }
 
 

--- a/tests/test_qa_deterministic.py
+++ b/tests/test_qa_deterministic.py
@@ -405,6 +405,7 @@ function qaTestFunction() {
             Language.PDF: None,  # PDF is binary, skip content template
             Language.SQL: '-- SQL QA test\nCREATE TABLE qa_test (\n    id INTEGER PRIMARY KEY,\n    content TEXT DEFAULT \'sql_qa_unique\'\n);',
             Language.ELIXIR: 'defmodule QATest do\n  # Elixir QA test\n  def test, do: "elixir_qa_unique"\nend',
+            Language.TWINCAT: '<?xml version="1.0" encoding="utf-8"?>\n<TcPlcObject Version="1.1.0.1">\n  <POU Name="QA_TEST" Id="{00000000-0000-0000-0000-000000000001}">\n    <Declaration><![CDATA[PROGRAM QA_TEST\nVAR\n  bFlag : BOOL := TRUE;\nEND_VAR]]></Declaration>\n    <Implementation>\n      <ST><![CDATA[IF bFlag THEN\n  (* twincat_qa_unique *)\nEND_IF]]></ST>\n    </Implementation>\n  </POU>\n</TcPlcObject>',
         }
 
         # Create extension mapping for file creation
@@ -445,6 +446,7 @@ function qaTestFunction() {
             Language.PDF: ".pdf",
             Language.SQL: ".sql",
             Language.ELIXIR: ".ex",
+            Language.TWINCAT: ".tcpou",
         }
 
         # Validate ALL languages have test coverage (fail explicitly for new languages)

--- a/tests/test_twincat_parser.py
+++ b/tests/test_twincat_parser.py
@@ -1,0 +1,4571 @@
+"""Tests for TwinCAT Structured Text parser.
+
+Tests the TwinCAT parser (`chunkhound/parsers/twincat/`) which handles
+TcPOU XML files containing IEC 61131-3 Structured Text code.
+
+These tests use the UniversalChunk API (extract_universal_chunks) which
+produces language-agnostic chunks suitable for the universal parser pipeline.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from chunkhound.core.types.common import ChunkType, Language
+from chunkhound.parsers.parser_factory import ParserFactory
+from chunkhound.parsers.twincat.twincat_parser import TwinCATParser
+from chunkhound.parsers.universal_engine import UniversalChunk, UniversalConcept
+
+# =============================================================================
+# Test Helpers
+# =============================================================================
+
+# Mapping from ChunkType to (UniversalConcept, metadata["kind"]) for filtering
+_CHUNK_TYPE_MAPPING = {
+    ChunkType.PROGRAM: (UniversalConcept.DEFINITION, "program"),
+    ChunkType.FUNCTION_BLOCK: (UniversalConcept.DEFINITION, "function_block"),
+    ChunkType.FUNCTION: (UniversalConcept.DEFINITION, "function"),
+    ChunkType.METHOD: (UniversalConcept.DEFINITION, "method"),
+    ChunkType.ACTION: (UniversalConcept.DEFINITION, "action"),
+    ChunkType.PROPERTY: (UniversalConcept.DEFINITION, "property"),
+    ChunkType.FIELD: (UniversalConcept.DEFINITION, "field"),
+    ChunkType.VARIABLE: (UniversalConcept.DEFINITION, "variable"),
+    ChunkType.BLOCK: (UniversalConcept.BLOCK, None),  # kind varies
+    ChunkType.COMMENT: (UniversalConcept.COMMENT, "comment"),
+}
+
+
+def find_by_symbol(chunks, symbol):
+    """Filter chunks by symbol/name."""
+    return [c for c in chunks if c.name == symbol]
+
+
+def find_by_type(chunks, chunk_type):
+    """Filter chunks by ChunkType via metadata['kind'] or concept.
+
+    Maps ChunkType to the equivalent UniversalConcept + metadata['kind'].
+    """
+    mapping = _CHUNK_TYPE_MAPPING.get(chunk_type)
+    if mapping is None:
+        return []
+    concept, kind = mapping
+    if kind is None:
+        # For BLOCK, just filter by concept
+        return [c for c in chunks if c.concept == concept]
+    return [
+        c for c in chunks if c.concept == concept and c.metadata.get("kind") == kind
+    ]
+
+
+def find_by_metadata(chunks, key, value):
+    """Filter chunks by metadata key-value pair."""
+    return [c for c in chunks if c.metadata and c.metadata.get(key) == value]
+
+
+def assert_no_parse_errors(parser: TwinCATParser) -> None:
+    """Assert that parser has no parse errors. Call after parsing."""
+    assert parser.parse_errors == [], (
+        f"Parser encountered errors: {parser.parse_errors}"
+    )
+
+
+def extract_chunks_from_file(
+    parser: TwinCATParser, file_path: Path
+) -> list[UniversalChunk]:
+    """Extract UniversalChunks from a TcPOU file."""
+    return parser.extract_universal_chunks(file_path.read_text(), file_path)
+
+
+# =============================================================================
+# Pytest Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def twincat_parser():
+    """Create TwinCAT parser instance."""
+    return TwinCATParser()
+
+
+@pytest.fixture
+def comprehensive_fixture():
+    """Load the comprehensive test fixture."""
+    fixture_path = (
+        Path(__file__).parent / "fixtures" / "twincat" / "example_comprehensive.TcPOU"
+    )
+    if not fixture_path.exists():
+        pytest.skip("Comprehensive fixture not found")
+    return fixture_path
+
+
+@pytest.fixture
+def program_fixture():
+    """Load the PROGRAM test fixture."""
+    fixture_path = (
+        Path(__file__).parent / "fixtures" / "twincat" / "example_program.TcPOU"
+    )
+    if not fixture_path.exists():
+        pytest.skip("PROGRAM fixture not found")
+    return fixture_path
+
+
+@pytest.fixture
+def function_fixture():
+    """Load the FUNCTION test fixture."""
+    fixture_path = (
+        Path(__file__).parent / "fixtures" / "twincat" / "example_function.TcPOU"
+    )
+    if not fixture_path.exists():
+        pytest.skip("FUNCTION fixture not found")
+    return fixture_path
+
+
+# =============================================================================
+# TestTwinCATParserAvailability
+# =============================================================================
+
+
+class TestTwinCATParserAvailability:
+    """Test parser availability and file detection."""
+
+    def test_twincat_parser_instantiation(self):
+        """Test that TwinCATParser can be instantiated directly."""
+        parser = TwinCATParser()
+        assert parser is not None
+
+    def test_twincat_file_detection(self):
+        """Test that factory detects .TcPOU extension correctly."""
+        factory = ParserFactory()
+        detected = factory.detect_language(Path("test.TcPOU"))
+        assert detected == Language.TWINCAT
+
+    def test_twincat_file_detection_lowercase(self):
+        """Test that factory detects .tcpou extension (lowercase)."""
+        factory = ParserFactory()
+        detected = factory.detect_language(Path("test.tcpou"))
+        assert detected == Language.TWINCAT
+
+
+# =============================================================================
+# TestPOUTypes
+# =============================================================================
+
+
+class TestPOUTypes:
+    """Test PROGRAM and FUNCTION POU types."""
+
+    # --- PROGRAM Tests ---
+
+    def test_program_chunk_type(self, twincat_parser, program_fixture):
+        """Test PROGRAM creates separate declaration/implementation chunks."""
+        chunks = extract_chunks_from_file(twincat_parser, program_fixture)
+        assert_no_parse_errors(twincat_parser)
+        program_chunks = find_by_type(chunks, ChunkType.PROGRAM)
+        # Now 2 chunks: declaration + implementation
+        assert len(program_chunks) == 2
+        chunk_names = {c.name for c in program_chunks}
+        assert chunk_names == {"PRG_Example.declaration", "PRG_Example.implementation"}
+
+    def test_program_metadata(self, twincat_parser, program_fixture):
+        """Test PROGRAM metadata includes kind, pou_type, section."""
+        chunks = extract_chunks_from_file(twincat_parser, program_fixture)
+        assert_no_parse_errors(twincat_parser)
+        program_chunks = find_by_type(chunks, ChunkType.PROGRAM)
+        assert len(program_chunks) == 2
+        # Check declaration chunk
+        decl = [c for c in program_chunks if c.name == "PRG_Example.declaration"][0]
+        assert decl.metadata["kind"] == "program"
+        assert decl.metadata["pou_type"] == "PROGRAM"
+        assert decl.metadata["pou_name"] == "PRG_Example"
+        assert decl.metadata["pou_id"] == "{11111111-1111-1111-1111-111111111111}"
+        assert decl.metadata["section"] == "declaration"
+
+    def test_program_variables(self, twincat_parser, program_fixture):
+        """Test PROGRAM extracts VAR_INPUT, VAR_OUTPUT, and VAR blocks."""
+        chunks = extract_chunks_from_file(twincat_parser, program_fixture)
+        assert_no_parse_errors(twincat_parser)
+
+        # VAR_INPUT: bStart
+        input_vars = find_by_metadata(chunks, "var_class", "input")
+        assert len(input_vars) == 1
+        assert input_vars[0].name == "PRG_Example.bStart"
+        assert input_vars[0].metadata["data_type"] == "BOOL"
+
+        # VAR_OUTPUT: bRunning
+        output_vars = find_by_metadata(chunks, "var_class", "output")
+        assert len(output_vars) == 1
+        assert output_vars[0].name == "PRG_Example.bRunning"
+        assert output_vars[0].metadata["data_type"] == "BOOL"
+
+        # VAR (local): nCycleCount
+        local_vars = find_by_metadata(chunks, "var_class", "local")
+        assert len(local_vars) == 1
+        assert local_vars[0].name == "PRG_Example.nCycleCount"
+        assert local_vars[0].metadata["data_type"] == "DINT"
+
+    # --- FUNCTION Tests ---
+
+    def test_function_chunk_type(self, twincat_parser, function_fixture):
+        """Test FUNCTION creates separate declaration/implementation chunks."""
+        chunks = extract_chunks_from_file(twincat_parser, function_fixture)
+        assert_no_parse_errors(twincat_parser)
+        function_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        # Now 2 chunks: declaration + implementation
+        assert len(function_chunks) == 2
+        chunk_names = {c.name for c in function_chunks}
+        assert chunk_names == {"FC_Add.declaration", "FC_Add.implementation"}
+
+    def test_function_metadata(self, twincat_parser, function_fixture):
+        """Test FUNCTION metadata includes kind, pou_type, section."""
+        chunks = extract_chunks_from_file(twincat_parser, function_fixture)
+        assert_no_parse_errors(twincat_parser)
+        function_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(function_chunks) == 2
+        # Check declaration chunk
+        decl = [c for c in function_chunks if c.name == "FC_Add.declaration"][0]
+        assert decl.metadata["kind"] == "function"
+        assert decl.metadata["pou_type"] == "FUNCTION"
+        assert decl.metadata["pou_name"] == "FC_Add"
+        assert decl.metadata["pou_id"] == "{22222222-2222-2222-2222-222222222222}"
+        assert decl.metadata["section"] == "declaration"
+
+    def test_function_variables(self, twincat_parser, function_fixture):
+        """Test FUNCTION extracts VAR_INPUT and VAR blocks."""
+        chunks = extract_chunks_from_file(twincat_parser, function_fixture)
+        assert_no_parse_errors(twincat_parser)
+
+        # VAR_INPUT: nA, nB
+        input_vars = find_by_metadata(chunks, "var_class", "input")
+        assert len(input_vars) == 2
+        input_names = {c.name for c in input_vars}
+        assert input_names == {"FC_Add.nA", "FC_Add.nB"}
+        for var in input_vars:
+            assert var.metadata["data_type"] == "DINT"
+
+        # VAR (local): nResult
+        local_vars = find_by_metadata(chunks, "var_class", "local")
+        assert len(local_vars) == 1
+        assert local_vars[0].name == "FC_Add.nResult"
+        assert local_vars[0].metadata["data_type"] == "DINT"
+
+
+# =============================================================================
+# TestPOUChunkCreation
+# =============================================================================
+
+
+class TestPOUChunkCreation:
+    """Test POU (Program Organization Unit) chunk creation."""
+
+    def test_function_block_chunk(self, twincat_parser):
+        """Test FUNCTION_BLOCK creates separate declaration/implementation chunks."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{12345678-1234-1234-1234-123456789abc}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    nValue : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[nValue := 42;]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        pou_chunks = find_by_type(chunks, ChunkType.FUNCTION_BLOCK)
+        # Now 2 chunks: declaration + implementation
+        assert len(pou_chunks) == 2
+        chunk_names = {c.name for c in pou_chunks}
+        assert chunk_names == {"FB_Test.declaration", "FB_Test.implementation"}
+
+    def test_pou_metadata(self, twincat_parser):
+        """Test POU metadata includes pou_type, pou_name, pou_id, kind, section."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{aaaa-bbbb-cccc-dddd}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    nValue : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        pou_chunks = find_by_type(chunks, ChunkType.FUNCTION_BLOCK)
+        # Only declaration (empty implementation)
+        assert len(pou_chunks) == 1
+        metadata = pou_chunks[0].metadata
+        assert metadata["kind"] == "function_block"
+        assert metadata["pou_type"] == "FUNCTION_BLOCK"
+        assert metadata["pou_name"] == "FB_Test"
+        assert metadata["pou_id"] == "{aaaa-bbbb-cccc-dddd}"
+        assert metadata["section"] == "declaration"
+
+
+# =============================================================================
+# TestVariableClassification
+# =============================================================================
+
+
+class TestVariableClassification:
+    """Test VAR block classification to VARIABLE vs FIELD chunk types."""
+
+    def test_var_input_is_field(self, twincat_parser):
+        """Test VAR_INPUT creates FIELD chunk with var_class='input'."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR_INPUT
+    bEnable : BOOL;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        var_chunks = find_by_symbol(chunks, "FB_Test.bEnable")
+        assert len(var_chunks) == 1
+        assert var_chunks[0].concept == UniversalConcept.DEFINITION
+        assert var_chunks[0].metadata["kind"] == "field"
+        assert var_chunks[0].metadata["var_class"] == "input"
+
+    def test_var_output_is_field(self, twincat_parser):
+        """Test VAR_OUTPUT creates FIELD chunk with var_class='output'."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR_OUTPUT
+    bDone : BOOL;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        var_chunks = find_by_symbol(chunks, "FB_Test.bDone")
+        assert len(var_chunks) == 1
+        assert var_chunks[0].concept == UniversalConcept.DEFINITION
+        assert var_chunks[0].metadata["kind"] == "field"
+        assert var_chunks[0].metadata["var_class"] == "output"
+
+    def test_var_in_out_is_field(self, twincat_parser):
+        """Test VAR_IN_OUT creates FIELD chunk with var_class='in_out'."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR_IN_OUT
+    refData : DINT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        var_chunks = find_by_symbol(chunks, "FB_Test.refData")
+        assert len(var_chunks) == 1
+        assert var_chunks[0].concept == UniversalConcept.DEFINITION
+        assert var_chunks[0].metadata["kind"] == "field"
+        assert var_chunks[0].metadata["var_class"] == "in_out"
+
+    def test_var_local_is_field(self, twincat_parser):
+        """Test VAR (local) creates FIELD chunk with var_class='local'."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    nLocal : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        var_chunks = find_by_symbol(chunks, "FB_Test.nLocal")
+        assert len(var_chunks) == 1
+        assert var_chunks[0].concept == UniversalConcept.DEFINITION
+        assert var_chunks[0].metadata["kind"] == "field"
+        assert var_chunks[0].metadata["var_class"] == "local"
+
+    def test_var_stat_is_field(self, twincat_parser):
+        """Test VAR_STAT creates FIELD chunk with var_class='static'."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR_STAT
+    nCounter : UDINT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        var_chunks = find_by_symbol(chunks, "FB_Test.nCounter")
+        assert len(var_chunks) == 1
+        assert var_chunks[0].concept == UniversalConcept.DEFINITION
+        assert var_chunks[0].metadata["kind"] == "field"
+        assert var_chunks[0].metadata["var_class"] == "static"
+
+    def test_var_temp_is_field(self, twincat_parser):
+        """Test VAR_TEMP creates FIELD chunk with var_class='temp'."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR_TEMP
+    nTemp : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        var_chunks = find_by_symbol(chunks, "FB_Test.nTemp")
+        assert len(var_chunks) == 1
+        assert var_chunks[0].concept == UniversalConcept.DEFINITION
+        assert var_chunks[0].metadata["kind"] == "field"
+        assert var_chunks[0].metadata["var_class"] == "temp"
+
+    def test_var_global_is_variable(self, twincat_parser):
+        """Test VAR_GLOBAL creates VARIABLE chunk with var_class='global'."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR_GLOBAL
+    gValue : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        var_chunks = find_by_symbol(chunks, "FB_Test.gValue")
+        assert len(var_chunks) == 1
+        assert var_chunks[0].concept == UniversalConcept.DEFINITION
+        assert var_chunks[0].metadata["kind"] == "variable"
+        assert var_chunks[0].metadata["var_class"] == "global"
+
+    def test_var_external_is_variable(self, twincat_parser):
+        """Test VAR_EXTERNAL creates VARIABLE chunk with var_class='external'.
+
+        Note: VAR_EXTERNAL also creates an IMPORT chunk, but this test verifies
+        the DEFINITION chunk specifically.
+        """
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR_EXTERNAL
+    extValue : DINT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        # Filter by symbol AND concept=DEFINITION (there's also an IMPORT chunk)
+        var_chunks = [
+            c
+            for c in find_by_symbol(chunks, "FB_Test.extValue")
+            if c.concept == UniversalConcept.DEFINITION
+        ]
+        assert len(var_chunks) == 1
+        assert var_chunks[0].concept == UniversalConcept.DEFINITION
+        assert var_chunks[0].metadata["kind"] == "variable"
+        assert var_chunks[0].metadata["var_class"] == "external"
+
+
+# =============================================================================
+# TestDataTypeExtraction
+# =============================================================================
+
+
+class TestDataTypeExtraction:
+    """Test data type extraction from variable declarations."""
+
+    def test_primitive_types(self, twincat_parser):
+        """Test primitive type extraction (BOOL, INT, DINT, REAL, etc.)."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    bFlag : BOOL;
+    nInt : INT;
+    nDint : DINT;
+    fReal : REAL;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+
+        bool_chunk = find_by_symbol(chunks, "FB_Test.bFlag")[0]
+        assert bool_chunk.metadata["data_type"] == "BOOL"
+
+        int_chunk = find_by_symbol(chunks, "FB_Test.nInt")[0]
+        assert int_chunk.metadata["data_type"] == "INT"
+
+        dint_chunk = find_by_symbol(chunks, "FB_Test.nDint")[0]
+        assert dint_chunk.metadata["data_type"] == "DINT"
+
+        real_chunk = find_by_symbol(chunks, "FB_Test.fReal")[0]
+        assert real_chunk.metadata["data_type"] == "REAL"
+
+    def test_string_with_size(self, twincat_parser):
+        """Test STRING(n) and WSTRING(n) type extraction."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    sName : STRING(80);
+    wsText : WSTRING(100);
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+
+        string_chunk = find_by_symbol(chunks, "FB_Test.sName")[0]
+        assert string_chunk.metadata["data_type"] == "STRING(80)"
+
+        wstring_chunk = find_by_symbol(chunks, "FB_Test.wsText")[0]
+        assert wstring_chunk.metadata["data_type"] == "WSTRING(100)"
+
+    def test_single_dimension_array(self, twincat_parser):
+        """Test ARRAY[0..9] OF INT type extraction."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    anData : ARRAY[0..9] OF INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        array_chunk = find_by_symbol(chunks, "FB_Test.anData")[0]
+        assert "ARRAY[0..9] OF INT" in array_chunk.metadata["data_type"]
+
+    def test_multi_dimension_array(self, twincat_parser):
+        """Test ARRAY[1..3, 1..3] OF REAL type extraction."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    afMatrix : ARRAY[1..3, 1..3] OF REAL;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        array_chunk = find_by_symbol(chunks, "FB_Test.afMatrix")[0]
+        data_type = array_chunk.metadata["data_type"]
+        assert "ARRAY" in data_type
+        assert "1..3" in data_type
+        assert "REAL" in data_type
+
+    def test_pointer_type(self, twincat_parser):
+        """Test POINTER TO INT type extraction."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    pnValue : POINTER TO INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        ptr_chunk = find_by_symbol(chunks, "FB_Test.pnValue")[0]
+        assert "POINTER TO" in ptr_chunk.metadata["data_type"]
+        assert "INT" in ptr_chunk.metadata["data_type"]
+
+    def test_reference_type(self, twincat_parser):
+        """Test REFERENCE TO DINT type extraction."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    refValue : REFERENCE TO DINT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        ref_chunk = find_by_symbol(chunks, "FB_Test.refValue")[0]
+        assert "REFERENCE TO" in ref_chunk.metadata["data_type"]
+        assert "DINT" in ref_chunk.metadata["data_type"]
+
+    def test_user_defined_type(self, twincat_parser):
+        """Test user-defined types (ST_DataRecord, TON, E_MachineState)."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    stData : ST_DataRecord;
+    fbTimer : TON;
+    eState : E_MachineState;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+
+        struct_chunk = find_by_symbol(chunks, "FB_Test.stData")[0]
+        assert struct_chunk.metadata["data_type"] == "ST_DataRecord"
+
+        timer_chunk = find_by_symbol(chunks, "FB_Test.fbTimer")[0]
+        assert timer_chunk.metadata["data_type"] == "TON"
+
+        enum_chunk = find_by_symbol(chunks, "FB_Test.eState")[0]
+        assert enum_chunk.metadata["data_type"] == "E_MachineState"
+
+    def test_nested_array_type(self, twincat_parser):
+        """Test ARRAY[0..1] OF ARRAY[0..2] OF INT type extraction."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    anNestedArray : ARRAY[0..1] OF ARRAY[0..2] OF INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        array_chunk = find_by_symbol(chunks, "FB_Test.anNestedArray")[0]
+        data_type = array_chunk.metadata["data_type"]
+        assert "ARRAY[0..1]" in data_type
+        assert "ARRAY[0..2]" in data_type
+        assert "INT" in data_type
+
+
+# =============================================================================
+# TestVariableQualifiers
+# =============================================================================
+
+
+class TestVariableQualifiers:
+    """Test RETAIN/PERSISTENT qualifier extraction."""
+
+    def test_retain_qualifier(self, twincat_parser):
+        """Test RETAIN qualifier sets metadata['retain'] = True."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR RETAIN
+    nRetained : DINT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        var_chunk = find_by_symbol(chunks, "FB_Test.nRetained")[0]
+        assert var_chunk.metadata["retain"] is True
+        assert var_chunk.metadata["persistent"] is False
+        assert var_chunk.metadata["constant"] is False
+
+    def test_persistent_qualifier(self, twincat_parser):
+        """Test PERSISTENT qualifier sets metadata['persistent'] = True."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR PERSISTENT
+    nPersistent : DINT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        var_chunk = find_by_symbol(chunks, "FB_Test.nPersistent")[0]
+        assert var_chunk.metadata["persistent"] is True
+        assert var_chunk.metadata["retain"] is False
+        assert var_chunk.metadata["constant"] is False
+
+    def test_retain_persistent_combined(self, twincat_parser):
+        """Test RETAIN PERSISTENT sets both qualifiers to True."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR RETAIN PERSISTENT
+    stSaved : ST_Data;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        var_chunk = find_by_symbol(chunks, "FB_Test.stSaved")[0]
+        assert var_chunk.metadata["retain"] is True
+        assert var_chunk.metadata["persistent"] is True
+        assert var_chunk.metadata["constant"] is False
+
+
+# =============================================================================
+# TestConstantQualifier
+# =============================================================================
+
+
+class TestConstantQualifier:
+    """Test CONSTANT qualifier extraction."""
+
+    def test_constant_qualifier(self, twincat_parser):
+        """Test VAR CONSTANT sets metadata['constant'] = True."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR CONSTANT
+    MAX_SIZE : INT := 100;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        var_chunk = find_by_symbol(chunks, "FB_Test.MAX_SIZE")[0]
+        assert var_chunk.metadata["constant"] is True
+        assert var_chunk.metadata["retain"] is False
+        assert var_chunk.metadata["persistent"] is False
+
+    def test_non_constant_has_false(self, twincat_parser):
+        """Test regular VAR has metadata['constant'] = False."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    nValue : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        var_chunk = find_by_symbol(chunks, "FB_Test.nValue")[0]
+        assert var_chunk.metadata["constant"] is False
+
+    def test_var_global_constant_combination(self, twincat_parser):
+        """Test VAR_GLOBAL CONSTANT sets both var_class='global' and constant=True."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR_GLOBAL CONSTANT
+    G_MAX_SIZE : INT := 1000;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        var_chunk = find_by_symbol(chunks, "FB_Test.G_MAX_SIZE")[0]
+        assert var_chunk.concept == UniversalConcept.DEFINITION
+        assert var_chunk.metadata["kind"] == "variable"  # GLOBAL → VARIABLE
+        assert var_chunk.metadata["var_class"] == "global"
+        assert var_chunk.metadata["constant"] is True
+
+
+# =============================================================================
+# TestHardwareAddressing
+# =============================================================================
+
+
+class TestHardwareAddressing:
+    """Test AT directive and hardware address extraction."""
+
+    def test_hw_address_input_wildcard(self, twincat_parser):
+        """Test AT %I* extraction."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    bDigitalInput AT %I* : BOOL;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        var_chunk = find_by_symbol(chunks, "FB_Test.bDigitalInput")[0]
+        assert var_chunk.metadata["hw_address"] == "%I*"
+
+    def test_hw_address_input_word(self, twincat_parser):
+        """Test AT %IW100 extraction."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    nAnalogInput AT %IW100 : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        var_chunk = find_by_symbol(chunks, "FB_Test.nAnalogInput")[0]
+        assert var_chunk.metadata["hw_address"] == "%IW100"
+
+    def test_hw_address_output(self, twincat_parser):
+        """Test AT %Q* and %QW50 extraction."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    bDigitalOutput AT %Q* : BOOL;
+    nAnalogOutput AT %QW50 : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+
+        digital_chunk = find_by_symbol(chunks, "FB_Test.bDigitalOutput")[0]
+        assert digital_chunk.metadata["hw_address"] == "%Q*"
+
+        analog_chunk = find_by_symbol(chunks, "FB_Test.nAnalogOutput")[0]
+        assert analog_chunk.metadata["hw_address"] == "%QW50"
+
+    def test_hw_address_memory(self, twincat_parser):
+        """Test AT %MW200 and %MX100.0 extraction."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    nMemoryWord AT %MW200 : WORD;
+    bMemoryBit AT %MX100.0 : BOOL;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+
+        word_chunk = find_by_symbol(chunks, "FB_Test.nMemoryWord")[0]
+        assert word_chunk.metadata["hw_address"] == "%MW200"
+
+        bit_chunk = find_by_symbol(chunks, "FB_Test.bMemoryBit")[0]
+        assert bit_chunk.metadata["hw_address"] == "%MX100.0"
+
+
+# =============================================================================
+# TestMultipleVariablesDeclaration
+# =============================================================================
+
+
+class TestMultipleVariablesDeclaration:
+    """Test comma-separated variable declarations."""
+
+    def test_comma_separated_variables(self, twincat_parser):
+        """Test that bFlag1, bFlag2, bFlag3 : BOOL; creates 3 separate chunks."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    bFlag1, bFlag2, bFlag3 : BOOL;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+
+        flag_chunks = [
+            c
+            for c in chunks
+            if c.name in ("FB_Test.bFlag1", "FB_Test.bFlag2", "FB_Test.bFlag3")
+        ]
+        assert len(flag_chunks) == 3
+
+        # All should have BOOL data type
+        for chunk in flag_chunks:
+            assert chunk.metadata["data_type"] == "BOOL"
+            assert chunk.concept == UniversalConcept.DEFINITION
+            assert chunk.metadata["kind"] == "field"
+
+
+# =============================================================================
+# TestActionChunks
+# =============================================================================
+
+
+class TestActionChunks:
+    """Test ACTION chunk creation and metadata."""
+
+    def test_action_chunk_created(self, twincat_parser):
+        """Test ACTION creates separate declaration/implementation chunks."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    nValue : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+    <Action Name="ProcessData" Id="{action-id-1}">
+      <Declaration><![CDATA[VAR
+    nLocal : INT;
+END_VAR
+]]></Declaration>
+      <Implementation><ST><![CDATA[nValue := 42;]]></ST></Implementation>
+    </Action>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        action_chunks = find_by_type(chunks, ChunkType.ACTION)
+        # 2 chunks: declaration + implementation
+        assert len(action_chunks) == 2
+        chunk_names = {c.name for c in action_chunks}
+        assert "FB_Test.ProcessData.declaration" in chunk_names
+        assert "FB_Test.ProcessData.implementation" in chunk_names
+
+    def test_action_metadata(self, twincat_parser):
+        """Test action metadata includes kind='action', pou_name, action_id, section."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    nValue : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+    <Action Name="MyAction" Id="{action-uuid}">
+      <Declaration><![CDATA[]]></Declaration>
+      <Implementation><ST><![CDATA[nValue := 1;]]></ST></Implementation>
+    </Action>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        action_chunks = find_by_type(chunks, ChunkType.ACTION)
+        # Only implementation (empty declaration)
+        assert len(action_chunks) == 1
+        metadata = action_chunks[0].metadata
+        assert metadata["kind"] == "action"
+        assert metadata["pou_name"] == "FB_Test"
+        assert metadata["action_id"] == "{action-uuid}"
+        assert metadata["section"] == "implementation"
+
+    def test_action_local_variables_have_action_name(self, twincat_parser):
+        """Test action local variables have metadata['action_name'] set."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    nValue : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+    <Action Name="ProcessData" Id="{action-id}">
+      <Declaration><![CDATA[VAR
+    nLocalIndex : INT;
+    fLocalSum : REAL;
+END_VAR
+]]></Declaration>
+      <Implementation><ST><![CDATA[]]></ST></Implementation>
+    </Action>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        action_var_chunks = find_by_metadata(chunks, "action_name", "ProcessData")
+        assert len(action_var_chunks) == 2
+
+        for chunk in action_var_chunks:
+            assert chunk.metadata["action_name"] == "ProcessData"
+
+    def test_action_local_variables_are_fields(self, twincat_parser):
+        """Test action local variables are ChunkType.FIELD, not VARIABLE."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    nValue : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+    <Action Name="TestAction" Id="{action-id}">
+      <Declaration><![CDATA[VAR
+    nActionLocal : INT;
+END_VAR
+]]></Declaration>
+      <Implementation><ST><![CDATA[]]></ST></Implementation>
+    </Action>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        action_var = find_by_symbol(chunks, "FB_Test.TestAction.nActionLocal")[0]
+        assert action_var.concept == UniversalConcept.DEFINITION
+        assert action_var.metadata["kind"] == "field"
+        assert action_var.metadata["var_class"] == "local"
+
+    def test_multiple_actions(self, twincat_parser):
+        """Test multiple actions create separate implementation chunks."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    nValue : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+    <Action Name="ActionOne" Id="{action-1}">
+      <Declaration><![CDATA[]]></Declaration>
+      <Implementation><ST><![CDATA[nValue := 1;]]></ST></Implementation>
+    </Action>
+    <Action Name="ActionTwo" Id="{action-2}">
+      <Declaration><![CDATA[]]></Declaration>
+      <Implementation><ST><![CDATA[nValue := 2;]]></ST></Implementation>
+    </Action>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        action_chunks = find_by_type(chunks, ChunkType.ACTION)
+        # 2 implementation chunks (empty declarations skipped)
+        assert len(action_chunks) == 2
+
+        action_names = {c.name for c in action_chunks}
+        assert action_names == {
+            "FB_Test.ActionOne.implementation",
+            "FB_Test.ActionTwo.implementation",
+        }
+
+
+# =============================================================================
+# TestComprehensiveFixture
+# =============================================================================
+
+
+class TestComprehensiveFixture:
+    """Integration tests using the comprehensive fixture file."""
+
+    def test_fixture_parses_without_errors(self, twincat_parser, comprehensive_fixture):
+        """Test fixture parses without parse_errors."""
+        chunks = extract_chunks_from_file(twincat_parser, comprehensive_fixture)
+        assert len(chunks) > 0
+        assert len(twincat_parser.parse_errors) == 0
+
+    def test_fixture_main_pou(self, twincat_parser, comprehensive_fixture):
+        """Test fixture has FB_ComprehensiveExample FUNCTION_BLOCK chunks."""
+        chunks = extract_chunks_from_file(twincat_parser, comprehensive_fixture)
+        assert_no_parse_errors(twincat_parser)
+        pou_chunks = find_by_type(chunks, ChunkType.FUNCTION_BLOCK)
+        # Now 2 chunks: declaration + implementation
+        assert len(pou_chunks) == 2
+        chunk_names = {c.name for c in pou_chunks}
+        assert "FB_ComprehensiveExample.declaration" in chunk_names
+        assert "FB_ComprehensiveExample.implementation" in chunk_names
+
+    def test_fixture_var_input_variables(self, twincat_parser, comprehensive_fixture):
+        """Test fixture extracts all VAR_INPUT variables."""
+        chunks = extract_chunks_from_file(twincat_parser, comprehensive_fixture)
+        assert_no_parse_errors(twincat_parser)
+        input_vars = find_by_metadata(chunks, "var_class", "input")
+        # Fixture has: bEnable, nInputValue, fSetpoint, sCommand, anInputArray, afMatrix
+        assert len(input_vars) >= 6
+
+    def test_fixture_var_output_variables(self, twincat_parser, comprehensive_fixture):
+        """Test fixture extracts all VAR_OUTPUT variables."""
+        chunks = extract_chunks_from_file(twincat_parser, comprehensive_fixture)
+        assert_no_parse_errors(twincat_parser)
+        output_vars = find_by_metadata(chunks, "var_class", "output")
+        # From fixture: bDone, bError, nErrorCode, sStatus, anResults
+        assert len(output_vars) >= 5
+
+    def test_fixture_var_in_out_variables(self, twincat_parser, comprehensive_fixture):
+        """Test fixture extracts both VAR_IN_OUT variables."""
+        chunks = extract_chunks_from_file(twincat_parser, comprehensive_fixture)
+        assert_no_parse_errors(twincat_parser)
+        in_out_vars = find_by_metadata(chunks, "var_class", "in_out")
+        # From fixture: refCounter, aBuffer
+        assert len(in_out_vars) >= 2
+
+    def test_fixture_var_stat_variables(self, twincat_parser, comprehensive_fixture):
+        """Test fixture extracts VAR_STAT variables with var_class='static'."""
+        chunks = extract_chunks_from_file(twincat_parser, comprehensive_fixture)
+        assert_no_parse_errors(twincat_parser)
+        static_vars = find_by_metadata(chunks, "var_class", "static")
+        # From fixture: nCallCount, fAccumulator
+        assert len(static_vars) >= 2
+
+    def test_fixture_var_temp_variables(self, twincat_parser, comprehensive_fixture):
+        """Test fixture extracts VAR_TEMP variables with var_class='temp'."""
+        chunks = extract_chunks_from_file(twincat_parser, comprehensive_fixture)
+        assert_no_parse_errors(twincat_parser)
+        temp_vars = find_by_metadata(chunks, "var_class", "temp")
+        # From fixture: nTempValue, fTempResult
+        assert len(temp_vars) >= 2
+
+    def test_fixture_retain_variables(self, twincat_parser, comprehensive_fixture):
+        """Test fixture extracts RETAIN variables with retain=True."""
+        chunks = extract_chunks_from_file(twincat_parser, comprehensive_fixture)
+        assert_no_parse_errors(twincat_parser)
+        retain_vars = find_by_metadata(chunks, "retain", True)
+        # From fixture: nRetainedCounter, bRetainedFlag, stSavedState
+        assert len(retain_vars) >= 2
+
+    def test_fixture_persistent_variables(self, twincat_parser, comprehensive_fixture):
+        """Test fixture extracts PERSISTENT variables with persistent=True."""
+        chunks = extract_chunks_from_file(twincat_parser, comprehensive_fixture)
+        assert_no_parse_errors(twincat_parser)
+        persistent_vars = find_by_metadata(chunks, "persistent", True)
+        # From fixture: nPersistentValue, stSavedState
+        assert len(persistent_vars) >= 1
+
+    def test_fixture_hardware_variables(self, twincat_parser, comprehensive_fixture):
+        """Test fixture extracts AT directive variables with hw_address."""
+        chunks = extract_chunks_from_file(twincat_parser, comprehensive_fixture)
+        assert_no_parse_errors(twincat_parser)
+        hw_vars = [
+            c for c in chunks if c.metadata and c.metadata.get("hw_address") is not None
+        ]
+        # From fixture: bDigitalInput, nAnalogInput, bDigitalOutput, nAnalogOutput,
+        #               nMemoryWord, bMemoryBit
+        assert len(hw_vars) >= 6
+
+    def test_fixture_actions(self, twincat_parser, comprehensive_fixture):
+        """Test fixture extracts ProcessData and ResetState ACTION chunks."""
+        chunks = extract_chunks_from_file(twincat_parser, comprehensive_fixture)
+        assert_no_parse_errors(twincat_parser)
+        action_chunks = find_by_type(chunks, ChunkType.ACTION)
+        # Each action has declaration + implementation = 4 total
+        assert len(action_chunks) == 4
+
+        # Check implementation chunks exist
+        impl_names = {
+            c.name
+            for c in action_chunks
+            if c.metadata.get("section") == "implementation"
+        }
+        assert "FB_ComprehensiveExample.ProcessData.implementation" in impl_names
+        assert "FB_ComprehensiveExample.ResetState.implementation" in impl_names
+
+    def test_fixture_action_local_vars(self, twincat_parser, comprehensive_fixture):
+        """Test fixture extracts action-scoped variables with action_name."""
+        chunks = extract_chunks_from_file(twincat_parser, comprehensive_fixture)
+        assert_no_parse_errors(twincat_parser)
+
+        # ProcessData action vars: nLocalIndex, fLocalSum, bLocalFlag, anLocalBuffer
+        process_data_vars = find_by_metadata(chunks, "action_name", "ProcessData")
+        assert len(process_data_vars) >= 4
+
+        # ResetState action var: nResetIndex
+        reset_state_vars = find_by_metadata(chunks, "action_name", "ResetState")
+        assert len(reset_state_vars) >= 1
+
+    def test_fixture_constant_variables(self, twincat_parser, comprehensive_fixture):
+        """Test fixture extracts VAR CONSTANT variables with constant=True."""
+        chunks = extract_chunks_from_file(twincat_parser, comprehensive_fixture)
+        assert_no_parse_errors(twincat_parser)
+        constant_vars = find_by_metadata(chunks, "constant", True)
+        # From fixture: c_nMaxItems, c_fPi, c_sVersion
+        assert len(constant_vars) >= 3
+
+    def test_fixture_control_flow_blocks(self, twincat_parser, comprehensive_fixture):
+        """Test fixture extracts BLOCK chunks for control flow in implementation."""
+        chunks = extract_chunks_from_file(twincat_parser, comprehensive_fixture)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        # Fixture has: multiple IF, CASE, FOR, WHILE, REPEAT blocks
+        assert len(block_chunks) >= 5
+
+        # Verify all control flow types are represented
+        block_kinds = {b.metadata["kind"] for b in block_chunks}
+        assert "if_block" in block_kinds
+        assert "case_block" in block_kinds
+        assert "for_loop" in block_kinds
+        assert "while_loop" in block_kinds
+        assert "repeat_loop" in block_kinds
+
+    def test_fixture_all_chunks_have_language_node_type(
+        self, twincat_parser, comprehensive_fixture
+    ):
+        """Test all chunks have language_node_type set (indicates TwinCAT/Lark origin)."""
+        chunks = extract_chunks_from_file(twincat_parser, comprehensive_fixture)
+        assert_no_parse_errors(twincat_parser)
+        for chunk in chunks:
+            # UniversalChunk is language-agnostic but tracks origin via language_node_type
+            assert chunk.language_node_type is not None
+            assert chunk.language_node_type.startswith("lark_")
+
+
+# =============================================================================
+# TestMetadataCompleteness
+# =============================================================================
+
+
+class TestMetadataCompleteness:
+    """Test that all required metadata fields are present."""
+
+    def test_pou_metadata_fields(self, twincat_parser):
+        """Test POU chunks have all required metadata fields."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{uuid-here}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        pou_chunk = find_by_type(chunks, ChunkType.FUNCTION_BLOCK)[0]
+
+        required_fields = ["kind", "pou_type", "pou_name", "pou_id"]
+        for field in required_fields:
+            assert field in pou_chunk.metadata, f"Missing field: {field}"
+
+    def test_variable_metadata_fields(self, twincat_parser):
+        """Test variable chunks have all expected metadata fields."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR RETAIN
+    nValue AT %MW100 : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        var_chunk = find_by_symbol(chunks, "FB_Test.nValue")[0]
+
+        expected_fields = [
+            "kind",
+            "pou_type",
+            "pou_name",
+            "var_class",
+            "data_type",
+            "hw_address",
+            "retain",
+            "persistent",
+        ]
+        for field in expected_fields:
+            assert field in var_chunk.metadata, f"Missing field: {field}"
+
+    def test_action_metadata_fields(self, twincat_parser):
+        """Test action chunks have all required metadata fields."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+    <Action Name="MyAction" Id="{action-uuid}">
+      <Declaration><![CDATA[]]></Declaration>
+      <Implementation><ST><![CDATA[n := 1;]]></ST></Implementation>
+    </Action>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        action_chunk = find_by_type(chunks, ChunkType.ACTION)[0]
+
+        required_fields = ["kind", "pou_type", "pou_name", "action_id"]
+        for field in required_fields:
+            assert field in action_chunk.metadata, f"Missing field: {field}"
+
+
+# =============================================================================
+# TestParseErrorHandling
+# =============================================================================
+
+
+# =============================================================================
+# TestTwinCATLineNumbers
+# =============================================================================
+
+
+class TestTwinCATLineNumbers:
+    """Test that line numbers are absolute (relative to XML file, not CDATA)."""
+
+    def test_pou_chunk_has_absolute_start_line(self, twincat_parser, program_fixture):
+        """Test POU declaration chunk start_line equals CDATA start (line 4)."""
+        chunks = extract_chunks_from_file(twincat_parser, program_fixture)
+        assert_no_parse_errors(twincat_parser)
+        pou_chunks = find_by_type(chunks, ChunkType.PROGRAM)
+        assert len(pou_chunks) == 2
+        # Declaration CDATA starts at line 4 in example_program.TcPOU
+        decl_chunk = [
+            c for c in pou_chunks if c.metadata.get("section") == "declaration"
+        ][0]
+        assert decl_chunk.start_line == 4
+
+    def test_pou_chunk_end_line_spans_content(self, twincat_parser, program_fixture):
+        """Test POU implementation end_line (line 20)."""
+        chunks = extract_chunks_from_file(twincat_parser, program_fixture)
+        assert_no_parse_errors(twincat_parser)
+        pou_chunks = find_by_type(chunks, ChunkType.PROGRAM)
+        assert len(pou_chunks) == 2
+        # Implementation CDATA content spans lines 16-20
+        impl_chunk = [
+            c for c in pou_chunks if c.metadata.get("section") == "implementation"
+        ][0]
+        assert impl_chunk.end_line == 20
+
+    def test_variable_chunks_have_absolute_line_numbers(
+        self, twincat_parser, program_fixture
+    ):
+        """Test that variable line numbers are > 3 (not CDATA-relative starting at 1)."""
+        chunks = extract_chunks_from_file(twincat_parser, program_fixture)
+        assert_no_parse_errors(twincat_parser)
+        var_chunks = find_by_type(chunks, ChunkType.FIELD)
+        assert len(var_chunks) >= 3  # bStart, bRunning, nCycleCount
+
+        for chunk in var_chunks:
+            # CDATA-relative would start at 1; absolute must be > 3
+            assert chunk.start_line > 3, (
+                f"Variable {chunk.name} has line {chunk.start_line}, "
+                "which appears to be CDATA-relative, not XML-absolute"
+            )
+
+    def test_variable_line_numbers_match_xml_positions(
+        self, twincat_parser, program_fixture
+    ):
+        """Test specific variable line numbers: bStart=6, bRunning=9, nCycleCount=12."""
+        chunks = extract_chunks_from_file(twincat_parser, program_fixture)
+        assert_no_parse_errors(twincat_parser)
+
+        # bStart is on line 6
+        bstart_chunks = find_by_symbol(chunks, "PRG_Example.bStart")
+        assert len(bstart_chunks) == 1
+        assert bstart_chunks[0].start_line == 6
+
+        # bRunning is on line 9
+        brunning_chunks = find_by_symbol(chunks, "PRG_Example.bRunning")
+        assert len(brunning_chunks) == 1
+        assert brunning_chunks[0].start_line == 9
+
+        # nCycleCount is on line 12
+        ncycle_chunks = find_by_symbol(chunks, "PRG_Example.nCycleCount")
+        assert len(ncycle_chunks) == 1
+        assert ncycle_chunks[0].start_line == 12
+
+    def test_line_numbers_are_not_cdata_relative(self, twincat_parser, program_fixture):
+        """Verify line numbers are > 3 (XML-absolute, not CDATA-relative starting at 1)."""
+        chunks = extract_chunks_from_file(twincat_parser, program_fixture)
+        assert_no_parse_errors(twincat_parser)
+
+        for chunk in chunks:
+            # All chunks should have line numbers > 3 because:
+            # - Line 1: XML declaration
+            # - Line 2: TcPlcObject
+            # - Line 3: POU element
+            # - Line 4+: actual content in CDATA
+            assert chunk.start_line > 3, (
+                f"Chunk {chunk.name} has start_line={chunk.start_line}, "
+                "which suggests CDATA-relative numbering"
+            )
+            assert chunk.end_line >= chunk.start_line, (
+                f"Chunk {chunk.name} has invalid end_line={chunk.end_line} "
+                f"< start_line={chunk.start_line}"
+            )
+
+
+# =============================================================================
+# TestParseErrorHandling
+# =============================================================================
+
+
+class TestParseErrorHandling:
+    """Test that parse_errors is properly populated on grammar errors."""
+
+    def test_invalid_declaration_populates_parse_errors(self, twincat_parser):
+        """Test that invalid declaration syntax populates parse_errors."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    THIS IS INVALID SYNTAX !!!
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        # Should still create the POU chunk (graceful degradation)
+        pou_chunks = find_by_type(chunks, ChunkType.FUNCTION_BLOCK)
+        assert len(pou_chunks) == 1
+        # But parse_errors should be populated
+        assert len(twincat_parser.parse_errors) > 0
+        assert "parse error" in twincat_parser.parse_errors[0].lower()
+
+    def test_invalid_action_declaration_populates_parse_errors(self, twincat_parser):
+        """Test that invalid action declaration populates parse_errors."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    nValue : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+    <Action Name="BadAction" Id="{action-id}">
+      <Declaration><![CDATA[VAR
+    INVALID DECLARATION GARBAGE @#$%
+END_VAR
+]]></Declaration>
+      <Implementation><ST><![CDATA[]]></ST></Implementation>
+    </Action>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        # Main POU and action should still be created
+        pou_chunks = find_by_type(chunks, ChunkType.FUNCTION_BLOCK)
+        action_chunks = find_by_type(chunks, ChunkType.ACTION)
+        assert len(pou_chunks) == 1
+        assert len(action_chunks) == 1
+        # But parse_errors should be populated with action error
+        assert len(twincat_parser.parse_errors) > 0
+        assert "BadAction" in twincat_parser.parse_errors[0]
+
+    def test_parse_errors_cleared_between_parses(self, twincat_parser):
+        """Test that parse_errors is cleared between parse operations."""
+        # First parse with invalid syntax
+        invalid_xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    INVALID SYNTAX @#$
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        twincat_parser.extract_universal_chunks(invalid_xml)
+        assert len(twincat_parser.parse_errors) > 0
+
+        # Second parse with valid syntax
+        valid_xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    nValue : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        twincat_parser.extract_universal_chunks(valid_xml)
+        # parse_errors should now be empty
+        assert len(twincat_parser.parse_errors) == 0
+
+
+# =============================================================================
+# TestImplementationBlockExtraction
+# =============================================================================
+
+
+class TestImplementationBlockExtraction:
+    """Test control flow BLOCK chunk extraction from FUNCTION implementations."""
+
+    # --- Pytest Fixtures ---
+
+    @pytest.fixture
+    def function_if_fixture(self):
+        """Load the FUNCTION IF test fixture."""
+        fixture_path = (
+            Path(__file__).parent / "fixtures" / "twincat" / "example_function_if.TcPOU"
+        )
+        if not fixture_path.exists():
+            pytest.skip("FUNCTION IF fixture not found")
+        return fixture_path
+
+    @pytest.fixture
+    def function_loops_fixture(self):
+        """Load the FUNCTION loops test fixture."""
+        fixture_path = (
+            Path(__file__).parent
+            / "fixtures"
+            / "twincat"
+            / "example_function_loops.TcPOU"
+        )
+        if not fixture_path.exists():
+            pytest.skip("FUNCTION loops fixture not found")
+        return fixture_path
+
+    @pytest.fixture
+    def function_action_fixture(self):
+        """Load the FUNCTION with action test fixture."""
+        fixture_path = (
+            Path(__file__).parent
+            / "fixtures"
+            / "twincat"
+            / "example_function_with_action.TcPOU"
+        )
+        if not fixture_path.exists():
+            pytest.skip("FUNCTION with action fixture not found")
+        return fixture_path
+
+    # --- POU Implementation Tests ---
+
+    def test_function_if_block(self, twincat_parser):
+        """Test that FUNCTION with IF creates BLOCK chunk with kind='if_block'."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_Test : INT
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[IF n > 0 THEN
+    FC_Test := 1;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        assert len(block_chunks) >= 1
+        if_blocks = find_by_metadata(block_chunks, "kind", "if_block")
+        assert len(if_blocks) == 1
+        assert if_blocks[0].metadata["pou_type"] == "FUNCTION"
+        assert if_blocks[0].metadata["pou_name"] == "FC_Test"
+        # Verify FQN symbol pattern: POUName.{kind}_{line}
+        assert if_blocks[0].name.startswith("FC_Test.if_block_")
+
+    def test_function_case_block(self, twincat_parser):
+        """Test that FUNCTION with CASE creates BLOCK chunk with kind='case_block'."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_Test : INT
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[CASE n OF
+    1: FC_Test := 10;
+    2: FC_Test := 20;
+ELSE
+    FC_Test := 0;
+END_CASE;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        case_blocks = find_by_metadata(block_chunks, "kind", "case_block")
+        assert len(case_blocks) == 1
+
+    def test_function_for_loop(self, twincat_parser):
+        """Test that FUNCTION with FOR creates BLOCK chunk with kind='for_loop'."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_Test : INT
+VAR
+    i : INT;
+    sum : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[sum := 0;
+FOR i := 0 TO 10 DO
+    sum := sum + i;
+END_FOR;
+FC_Test := sum;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        for_loops = find_by_metadata(block_chunks, "kind", "for_loop")
+        assert len(for_loops) == 1
+
+    def test_function_while_loop(self, twincat_parser):
+        """Test that FUNCTION with WHILE creates BLOCK chunk with kind='while_loop'."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_Test : INT
+VAR
+    i : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[i := 0;
+WHILE i < 10 DO
+    i := i + 1;
+END_WHILE;
+FC_Test := i;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        while_loops = find_by_metadata(block_chunks, "kind", "while_loop")
+        assert len(while_loops) == 1
+
+    def test_function_repeat_loop(self, twincat_parser):
+        """Test that FUNCTION with REPEAT creates BLOCK chunk with kind='repeat_loop'."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_Test : INT
+VAR
+    i : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[i := 0;
+REPEAT
+    i := i + 1;
+UNTIL i >= 10
+END_REPEAT;
+FC_Test := i;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        repeat_loops = find_by_metadata(block_chunks, "kind", "repeat_loop")
+        assert len(repeat_loops) == 1
+
+    def test_function_multiple_blocks(self, twincat_parser, function_loops_fixture):
+        """Test that multiple blocks are extracted from a single FUNCTION."""
+        chunks = extract_chunks_from_file(twincat_parser, function_loops_fixture)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        # Fixture has: 1 CASE with nested (FOR, WHILE, REPEAT) = 4 total
+        assert len(block_chunks) >= 4
+
+    def test_function_nested_blocks(self, twincat_parser, function_if_fixture):
+        """Test that nested IF blocks are both extracted."""
+        chunks = extract_chunks_from_file(twincat_parser, function_if_fixture)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        if_blocks = find_by_metadata(block_chunks, "kind", "if_block")
+        # Fixture has outer IF and nested IF
+        assert len(if_blocks) == 2
+
+    def test_function_block_metadata(self, twincat_parser):
+        """Test BLOCK chunks have correct metadata fields."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_MetadataTest" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_MetadataTest : INT
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[IF n > 0 THEN
+    FC_MetadataTest := n;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        assert len(block_chunks) == 1
+        metadata = block_chunks[0].metadata
+        assert metadata["kind"] == "if_block"
+        assert metadata["pou_type"] == "FUNCTION"
+        assert metadata["pou_name"] == "FC_MetadataTest"
+        assert "action_name" not in metadata
+
+    def test_function_block_line_numbers(self, twincat_parser):
+        """Test BLOCK chunks have XML-absolute line numbers."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_Test : INT
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[n := 1;
+IF n > 0 THEN
+    FC_Test := n;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        assert len(block_chunks) == 1
+        # IF starts at line 2 within CDATA, CDATA starts at line 10
+        # So absolute line should be > 10
+        assert block_chunks[0].start_line > 10
+        assert block_chunks[0].end_line >= block_chunks[0].start_line
+
+    # --- Action Implementation Tests ---
+
+    def test_function_action_if_block(self, twincat_parser):
+        """Test Action within FUNCTION creates BLOCK with action_name in metadata."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_Test : INT
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[FC_Test := 0;]]></ST></Implementation>
+    <Action Name="DoProcess" Id="{action-1}">
+      <Declaration><![CDATA[VAR
+    i : INT;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[IF n > 0 THEN
+    n := n - 1;
+END_IF;
+]]></ST>
+      </Implementation>
+    </Action>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        assert len(block_chunks) == 1
+        assert block_chunks[0].metadata["kind"] == "if_block"
+        assert block_chunks[0].metadata["action_name"] == "DoProcess"
+        assert block_chunks[0].metadata["pou_name"] == "FC_Test"
+        # Verify FQN symbol pattern: POUName.ActionName.{kind}_{line}
+        assert block_chunks[0].name.startswith("FC_Test.DoProcess.if_block_")
+
+    def test_function_action_multiple_blocks(
+        self, twincat_parser, function_action_fixture
+    ):
+        """Test Action with multiple control flow blocks extracts all of them."""
+        chunks = extract_chunks_from_file(twincat_parser, function_action_fixture)
+        assert_no_parse_errors(twincat_parser)
+
+        # Get action blocks only (those with action_name in metadata)
+        action_blocks = [
+            c
+            for c in chunks
+            if c.concept == UniversalConcept.BLOCK and c.metadata.get("action_name")
+        ]
+        # Action has: FOR (with nested IF), WHILE = 3 blocks
+        assert len(action_blocks) >= 3
+
+    def test_function_action_block_metadata(self, twincat_parser):
+        """Test action BLOCK chunks include action_name in metadata."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_Test : INT
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[FC_Test := 0;]]></ST></Implementation>
+    <Action Name="MyAction" Id="{action-uuid}">
+      <Declaration><![CDATA[]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[FOR n := 0 TO 5 DO
+    FC_Test := FC_Test + n;
+END_FOR;
+]]></ST>
+      </Implementation>
+    </Action>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        assert len(block_chunks) == 1
+        metadata = block_chunks[0].metadata
+        assert metadata["kind"] == "for_loop"
+        assert metadata["action_name"] == "MyAction"
+        assert metadata["pou_type"] == "FUNCTION"
+        assert metadata["pou_name"] == "FC_Test"
+
+    # --- PROGRAM and FUNCTION_BLOCK Block Extraction Tests ---
+
+    def test_program_block_extraction(self, twincat_parser, program_fixture):
+        """Test that PROGRAM extracts BLOCK chunks for control flow."""
+        chunks = extract_chunks_from_file(twincat_parser, program_fixture)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        # program_fixture contains IF/CASE/FOR/WHILE/REPEAT
+        assert len(block_chunks) >= 1
+
+    def test_function_block_block_extraction(self, twincat_parser):
+        """Test that FUNCTION_BLOCK extracts BLOCK chunks for control flow."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[IF n > 0 THEN
+    n := n - 1;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        assert len(block_chunks) == 1
+        block = block_chunks[0]
+        assert block.metadata["kind"] == "if_block"
+        assert block.metadata["pou_type"] == "FUNCTION_BLOCK"
+        assert block.metadata["pou_name"] == "FB_Test"
+
+    def test_program_action_block_extraction(self, twincat_parser):
+        """Test that PROGRAM actions extract BLOCK chunks for control flow."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="PRG_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[PROGRAM PRG_Test
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[n := 1;]]></ST></Implementation>
+    <Action Name="ProgramAction" Id="{action-1}">
+      <Declaration><![CDATA[]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[IF n > 0 THEN
+    n := 0;
+END_IF;
+]]></ST>
+      </Implementation>
+    </Action>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        assert len(block_chunks) == 1
+        block = block_chunks[0]
+        assert block.metadata["kind"] == "if_block"
+        assert block.metadata["pou_type"] == "PROGRAM"
+        assert block.metadata["action_name"] == "ProgramAction"
+
+    def test_function_block_multiple_blocks(self, twincat_parser):
+        """Test FUNCTION_BLOCK with multiple control flow blocks."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Multi" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Multi
+VAR
+    n : INT;
+    state : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[IF n > 0 THEN
+    n := n - 1;
+END_IF;
+
+CASE state OF
+1: n := 10;
+2: n := 20;
+END_CASE;
+
+FOR n := 0 TO 10 DO
+    state := state + 1;
+END_FOR;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        assert len(block_chunks) == 3
+        block_kinds = {b.metadata["kind"] for b in block_chunks}
+        assert block_kinds == {"if_block", "case_block", "for_loop"}
+
+    def test_function_block_action_block_extraction(self, twincat_parser):
+        """Test that FUNCTION_BLOCK actions extract BLOCK chunks."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_WithAction" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_WithAction
+VAR
+    counter : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[counter := 0;]]></ST></Implementation>
+    <Action Name="DoLoop" Id="{action-1}">
+      <Declaration><![CDATA[]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[WHILE counter < 10 DO
+    counter := counter + 1;
+END_WHILE;
+]]></ST>
+      </Implementation>
+    </Action>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        assert len(block_chunks) == 1
+        block = block_chunks[0]
+        assert block.metadata["kind"] == "while_loop"
+        assert block.metadata["pou_type"] == "FUNCTION_BLOCK"
+        assert block.metadata["action_name"] == "DoLoop"
+
+    # --- Edge Case Tests ---
+
+    def test_function_empty_implementation(self, twincat_parser):
+        """Test FUNCTION with empty implementation returns no BLOCK chunks."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_Empty" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_Empty : INT
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        assert len(block_chunks) == 0
+
+    def test_function_no_control_flow(self, twincat_parser):
+        """Test FUNCTION without control flow statements returns no BLOCK chunks."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_Simple" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_Simple : INT
+VAR_INPUT
+    a : INT;
+    b : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[FC_Simple := a + b;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        assert len(block_chunks) == 0
+
+    def test_function_parse_error_handling(self, twincat_parser):
+        """Test implementation parse error is logged but doesn't crash."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_BadImpl" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_BadImpl : INT
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[IF INVALID SYNTAX @#$ THEN
+    n := 1;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        # Should not raise an exception
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        # Should still create the FUNCTION chunk
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+        # Should have parse error logged
+        assert len(twincat_parser.parse_errors) > 0
+        assert "parse error" in twincat_parser.parse_errors[0].lower()
+
+
+# =============================================================================
+# TestImplementationNumericLiterals
+# =============================================================================
+
+
+class TestImplementationNumericLiterals:
+    """Verify numeric literal formats parse correctly in implementation expressions."""
+
+    def test_hex_literals_in_implementation(self, twincat_parser):
+        """Test 16#FF, 16#ABCD hex literals in assignments."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_HexLiterals" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_HexLiterals : DINT
+VAR
+    nByte : BYTE;
+    nWord : WORD;
+    nDword : DWORD;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[nByte := 16#FF;
+nWord := 16#ABCD;
+nDword := 16#12345678;
+IF nByte > 16#80 THEN
+    FC_HexLiterals := 1;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_binary_literals_in_implementation(self, twincat_parser):
+        """Test 2#10101010 binary literals in assignments."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_BinaryLiterals" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_BinaryLiterals : BYTE
+VAR
+    nByte : BYTE;
+    nMask : BYTE;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[nByte := 2#10101010;
+nMask := 2#11110000;
+IF (nByte AND nMask) = 2#10100000 THEN
+    FC_BinaryLiterals := nByte;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_octal_literals_in_implementation(self, twincat_parser):
+        """Test 8#755 octal literals in assignments."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_OctalLiterals" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_OctalLiterals : INT
+VAR
+    nPermissions : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[nPermissions := 8#755;
+IF nPermissions > 8#700 THEN
+    FC_OctalLiterals := nPermissions;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_scientific_notation_in_implementation(self, twincat_parser):
+        """Test 1.5e-3, 2E10 scientific notation in assignments."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_ScientificNotation" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_ScientificNotation : LREAL
+VAR
+    fSmall : LREAL;
+    fLarge : LREAL;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[fSmall := 1.5e-3;
+fLarge := 2E10;
+IF fSmall < 1.0E-2 THEN
+    FC_ScientificNotation := fSmall * fLarge;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_negative_numbers_in_implementation(self, twincat_parser):
+        """Test -42, -3.14 negative numbers in assignments."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_NegativeNumbers" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_NegativeNumbers : REAL
+VAR
+    nInt : INT;
+    fReal : REAL;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[nInt := -42;
+fReal := -3.14;
+IF nInt < -10 THEN
+    FC_NegativeNumbers := fReal;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+
+# =============================================================================
+# TestImplementationStringAndTimeLiterals
+# =============================================================================
+
+
+class TestImplementationStringAndTimeLiterals:
+    """Verify string and time literals parse correctly."""
+
+    def test_single_quoted_strings_in_implementation(self, twincat_parser):
+        """Test 'Hello' single-quoted strings in assignments."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_SingleQuotedStrings" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_SingleQuotedStrings : INT
+VAR
+    sMessage : STRING(80);
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[sMessage := 'Hello World';
+IF sMessage = 'Hello World' THEN
+    FC_SingleQuotedStrings := 1;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_double_quoted_strings_in_implementation(self, twincat_parser):
+        """Test "World" double-quoted strings in assignments."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_DoubleQuotedStrings" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_DoubleQuotedStrings : INT
+VAR
+    wsMessage : WSTRING(80);
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[wsMessage := "Hello Wide World";
+IF wsMessage = "Hello Wide World" THEN
+    FC_DoubleQuotedStrings := 1;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_time_literals_in_implementation(self, twincat_parser):
+        """Test T#100ms, T#5s, T#-10s time literals."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_TimeLiterals" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_TimeLiterals : INT
+VAR
+    tDelay : TIME;
+    tInterval : TIME;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[tDelay := T#100ms;
+tInterval := T#5s;
+IF tDelay < T#1s THEN
+    FC_TimeLiterals := 1;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_time_literals_in_function_calls(self, twincat_parser):
+        """Test time literals in function block calls like fbTimer(PT := T#5s)."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_TimeFunctionCalls" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_TimeFunctionCalls : BOOL
+VAR
+    fbTON : TON;
+    bDone : BOOL;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[fbTON(IN := TRUE, PT := T#5s);
+bDone := fbTON.Q;
+IF bDone THEN
+    FC_TimeFunctionCalls := TRUE;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+
+# =============================================================================
+# TestImplementationTypeConversions
+# =============================================================================
+
+
+class TestImplementationTypeConversions:
+    """Verify type conversion functions parse correctly."""
+
+    def test_int_to_real_conversion(self, twincat_parser):
+        """Test INT_TO_REAL(nInt) in expressions."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_IntToReal" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_IntToReal : REAL
+VAR
+    nInt : INT;
+    fReal : REAL;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[nInt := 42;
+fReal := INT_TO_REAL(nInt);
+FC_IntToReal := fReal;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_real_to_int_conversion(self, twincat_parser):
+        """Test REAL_TO_INT(fReal) in expressions."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_RealToInt" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_RealToInt : INT
+VAR
+    fReal : REAL;
+    nInt : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[fReal := 3.14;
+nInt := REAL_TO_INT(fReal);
+FC_RealToInt := nInt;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_dint_to_string_conversion(self, twincat_parser):
+        """Test DINT_TO_STRING(nDint) in expressions."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_DintToString" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_DintToString : INT
+VAR
+    nDint : DINT;
+    sResult : STRING(80);
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[nDint := 123456;
+sResult := DINT_TO_STRING(nDint);
+FC_DintToString := 1;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_type_conversion_in_condition(self, twincat_parser):
+        """Test IF INT_TO_REAL(n) > 0.0 THEN type conversion in conditions."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_ConversionInCondition" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_ConversionInCondition : INT
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[n := 42;
+IF INT_TO_REAL(n) > 0.0 THEN
+    FC_ConversionInCondition := 1;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_nested_type_conversions(self, twincat_parser):
+        """Test INT_TO_REAL(REAL_TO_INT(f)) nested conversions."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_NestedConversions" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_NestedConversions : REAL
+VAR
+    fInput : REAL;
+    fRounded : REAL;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[fInput := 3.7;
+fRounded := INT_TO_REAL(REAL_TO_INT(fInput));
+FC_NestedConversions := fRounded;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+
+# =============================================================================
+# TestImplementationAccessPatterns
+# =============================================================================
+
+
+class TestImplementationAccessPatterns:
+    """Verify array, member, and bit access patterns parse correctly."""
+
+    def test_single_dim_array_access(self, twincat_parser):
+        """Test arr[i] in assignments."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_ArrayAccess" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_ArrayAccess : INT
+VAR
+    arr : ARRAY[0..9] OF INT;
+    i : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[i := 5;
+arr[i] := 42;
+FC_ArrayAccess := arr[0] + arr[i];
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_multi_dim_array_access(self, twincat_parser):
+        """Test matrix[i, j] in assignments."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_MultiDimArrayAccess" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_MultiDimArrayAccess : INT
+VAR
+    matrix : ARRAY[0..2, 0..2] OF INT;
+    i, j : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[i := 1;
+j := 2;
+matrix[i, j] := 42;
+FC_MultiDimArrayAccess := matrix[0, 0] + matrix[i, j];
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_array_access_in_condition(self, twincat_parser):
+        """Test IF arr[0] > 0 THEN array access in conditions."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_ArrayCondition" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_ArrayCondition : INT
+VAR
+    arr : ARRAY[0..9] OF INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[arr[0] := 10;
+IF arr[0] > 0 THEN
+    FC_ArrayCondition := arr[0];
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_member_access(self, twincat_parser):
+        """Test stData.nValue in assignments."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_MemberAccess" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_MemberAccess : INT
+VAR
+    stData : ST_Data;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[stData.nValue := 42;
+FC_MemberAccess := stData.nValue;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_nested_member_access(self, twincat_parser):
+        """Test stData.stNested.fValue in assignments."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_NestedMemberAccess" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_NestedMemberAccess : REAL
+VAR
+    stData : ST_Outer;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[stData.stNested.fValue := 3.14;
+FC_NestedMemberAccess := stData.stNested.fValue;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_bit_access(self, twincat_parser):
+        """Test nWord.0, nDword.15 bit access."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_BitAccess" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_BitAccess : BOOL
+VAR
+    nWord : WORD;
+    nDword : DWORD;
+    bBit0 : BOOL;
+    bBit15 : BOOL;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[nWord := 16#FF01;
+nDword := 16#00008000;
+bBit0 := nWord.0;
+bBit15 := nDword.15;
+IF nWord.0 THEN
+    FC_BitAccess := TRUE;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_combined_access_patterns(self, twincat_parser):
+        """Test stData.anArray[i].nFlags.3 combined access patterns."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_CombinedAccess" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_CombinedAccess : BOOL
+VAR
+    stData : ST_Complex;
+    i : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[i := 2;
+stData.anArray[i].nFlags := 16#08;
+IF stData.anArray[i].nFlags.3 THEN
+    FC_CombinedAccess := TRUE;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+
+# =============================================================================
+# TestImplementationComplexExpressions
+# =============================================================================
+
+
+class TestImplementationComplexExpressions:
+    """Verify complex expressions and operator precedence."""
+
+    def test_operator_precedence_expt(self, twincat_parser):
+        """Test -2.0 EXPT 2.0 equals -4 (negation binds looser)."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_ExptPrecedence" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_ExptPrecedence : LREAL
+VAR
+    fResult : LREAL;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[fResult := -2.0 EXPT 2.0;
+FC_ExptPrecedence := fResult;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_complex_arithmetic_expression(self, twincat_parser):
+        """Test (10 + 5) * 3 - 2 complex arithmetic."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_ComplexArithmetic" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_ComplexArithmetic : INT
+VAR
+    nResult : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[nResult := (10 + 5) * 3 - 2;
+FC_ComplexArithmetic := nResult;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_compound_boolean_conditions(self, twincat_parser):
+        """Test (n > 0 AND n < 100) OR bFlag compound conditions."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_CompoundBoolean" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_CompoundBoolean : BOOL
+VAR
+    n : INT;
+    bFlag : BOOL;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[n := 50;
+bFlag := FALSE;
+IF (n > 0 AND n < 100) OR bFlag THEN
+    FC_CompoundBoolean := TRUE;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_short_circuit_operators(self, twincat_parser):
+        """Test AND_THEN, OR_ELSE short-circuit operators in conditions."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_ShortCircuit" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_ShortCircuit : BOOL
+VAR
+    bCondition1 : BOOL;
+    bCondition2 : BOOL;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[bCondition1 := TRUE;
+bCondition2 := FALSE;
+IF bCondition1 AND_THEN bCondition2 THEN
+    FC_ShortCircuit := TRUE;
+ELSIF bCondition1 OR_ELSE bCondition2 THEN
+    FC_ShortCircuit := TRUE;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_expt_as_function_call(self, twincat_parser):
+        """Test EXPT(2.0, 8.0) function call syntax."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_ExptFunction" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_ExptFunction : LREAL
+VAR
+    fResult : LREAL;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[fResult := EXPT(2.0, 8.0);
+FC_ExptFunction := fResult;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+
+# =============================================================================
+# TestImplementationFunctionCalls
+# =============================================================================
+
+
+class TestImplementationFunctionCalls:
+    """Verify function/FB call syntaxes parse correctly."""
+
+    def test_function_positional_args(self, twincat_parser):
+        """Test MAX(a, b), ABS(-42) function calls with positional args."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_PositionalArgs" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_PositionalArgs : INT
+VAR
+    a, b : INT;
+    nMax : INT;
+    nAbs : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[a := 10;
+b := 20;
+nMax := MAX(a, b);
+nAbs := ABS(-42);
+FC_PositionalArgs := nMax + nAbs;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_function_named_args(self, twincat_parser):
+        """Test fb(IN := bEnable, PT := T#5s) named argument calls."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_NamedArgs" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_NamedArgs : BOOL
+VAR
+    fbTON : TON;
+    bEnable : BOOL;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[bEnable := TRUE;
+fbTON(IN := bEnable, PT := T#5s);
+FC_NamedArgs := fbTON.Q;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_function_output_args(self, twincat_parser):
+        """Test fb(Q => bDone, ET => tDuration) output argument calls."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_OutputArgs" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_OutputArgs : BOOL
+VAR
+    fbTON : TON;
+    bDone : BOOL;
+    tDuration : TIME;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[fbTON(IN := TRUE, PT := T#5s, Q => bDone, ET => tDuration);
+FC_OutputArgs := bDone;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_function_mixed_args(self, twincat_parser):
+        """Test fb(a, IN := b, Q => c) mixed argument calls."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_MixedArgs" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_MixedArgs : INT
+VAR
+    fbCustom : FB_Custom;
+    nInput : INT;
+    nOutput : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[nInput := 10;
+fbCustom(nInput, bEnable := TRUE, nResult => nOutput);
+FC_MixedArgs := nOutput;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_method_call(self, twincat_parser):
+        """Test fbTimer.Reset() method calls."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_MethodCall" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_MethodCall : INT
+VAR
+    fbTimer : FB_Timer;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[fbTimer.Start();
+fbTimer.Reset();
+FC_MethodCall := 1;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_chained_method_call(self, twincat_parser):
+        """Test stData.stNested.GetResult() chained method calls."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_ChainedMethodCall" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_ChainedMethodCall : INT
+VAR
+    stData : ST_ComplexData;
+    nResult : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[nResult := stData.stNested.GetResult();
+FC_ChainedMethodCall := nResult;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+
+# =============================================================================
+# TestImplementationSpecificFeatures
+# =============================================================================
+
+
+class TestImplementationSpecificFeatures:
+    """Test features specific to implementation sections."""
+
+    def test_expression_statement(self, twincat_parser):
+        """Test stData.nCounter; standalone access expression statement."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_ExpressionStatement" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_ExpressionStatement : INT
+VAR
+    stData : ST_Data;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[stData.nCounter;
+FC_ExpressionStatement := 1;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_empty_statement(self, twincat_parser):
+        """Test ; empty statement is valid."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_EmptyStatement" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_EmptyStatement : INT
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[n := 1;
+;
+;
+FC_EmptyStatement := n;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_exit_in_loop(self, twincat_parser):
+        """Test EXIT; inside FOR/WHILE loops."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_ExitInLoop" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_ExitInLoop : INT
+VAR
+    i : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[FOR i := 0 TO 100 DO
+    IF i > 50 THEN
+        EXIT;
+    END_IF;
+END_FOR;
+FC_ExitInLoop := i;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_continue_in_loop(self, twincat_parser):
+        """Test CONTINUE; inside FOR loop."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_ContinueInLoop" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_ContinueInLoop : INT
+VAR
+    i : INT;
+    nSum : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[nSum := 0;
+FOR i := 0 TO 10 DO
+    IF i MOD 2 = 0 THEN
+        CONTINUE;
+    END_IF;
+    nSum := nSum + i;
+END_FOR;
+FC_ContinueInLoop := nSum;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_return_statement(self, twincat_parser):
+        """Test RETURN; and RETURN(value); statements."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_ReturnStatement" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_ReturnStatement : INT
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[n := 42;
+IF n > 0 THEN
+    RETURN;
+END_IF;
+FC_ReturnStatement := n;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_array_element_assignment(self, twincat_parser):
+        """Test arr[i] := value; array element assignment."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_ArrayAssignment" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_ArrayAssignment : INT
+VAR
+    arr : ARRAY[0..9] OF INT;
+    i : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[FOR i := 0 TO 9 DO
+    arr[i] := i * 10;
+END_FOR;
+FC_ArrayAssignment := arr[5];
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+    def test_member_assignment(self, twincat_parser):
+        """Test stData.nValue := 42; member assignment."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_MemberAssignment" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_MemberAssignment : INT
+VAR
+    stData : ST_Data;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[stData.nValue := 42;
+stData.sName := 'Test';
+FC_MemberAssignment := stData.nValue;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        func_chunks = find_by_type(chunks, ChunkType.FUNCTION)
+        assert len(func_chunks) == 2  # declaration + implementation
+
+
+# =============================================================================
+# TestImplementationWithComplexExpressions
+# =============================================================================
+
+
+class TestImplementationWithComplexExpressions:
+    """Verify block extraction still works with complex expressions inside."""
+
+    def test_if_with_type_conversion_condition(self, twincat_parser):
+        """Test block extracted when condition has type conversion."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_IfTypeConversion" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_IfTypeConversion : INT
+VAR
+    nInt : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[nInt := 42;
+IF INT_TO_REAL(nInt) > 10.0 THEN
+    FC_IfTypeConversion := nInt;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        if_blocks = find_by_metadata(block_chunks, "kind", "if_block")
+        assert len(if_blocks) == 1
+        assert if_blocks[0].metadata["pou_name"] == "FC_IfTypeConversion"
+
+    def test_for_with_array_access_body(self, twincat_parser):
+        """Test block extracted with array ops in body."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_ForArrayAccess" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_ForArrayAccess : INT
+VAR
+    arr : ARRAY[0..9] OF INT;
+    i : INT;
+    nSum : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[nSum := 0;
+FOR i := 0 TO 9 DO
+    arr[i] := i * 10;
+    nSum := nSum + arr[i];
+END_FOR;
+FC_ForArrayAccess := nSum;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        for_loops = find_by_metadata(block_chunks, "kind", "for_loop")
+        assert len(for_loops) == 1
+        assert for_loops[0].metadata["pou_type"] == "FUNCTION"
+
+    def test_case_with_member_access_expression(self, twincat_parser):
+        """Test block extracted with struct access in CASE expression."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_CaseMemberAccess" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_CaseMemberAccess : INT
+VAR
+    stData : ST_Data;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[stData.nMode := 2;
+CASE stData.nMode OF
+    1: FC_CaseMemberAccess := 10;
+    2: FC_CaseMemberAccess := 20;
+ELSE
+    FC_CaseMemberAccess := 0;
+END_CASE;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        case_blocks = find_by_metadata(block_chunks, "kind", "case_block")
+        assert len(case_blocks) == 1
+
+    def test_while_with_complex_condition(self, twincat_parser):
+        """Test block extracted with compound condition in WHILE."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_WhileComplex" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_WhileComplex : INT
+VAR
+    i : INT;
+    bContinue : BOOL;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[i := 0;
+bContinue := TRUE;
+WHILE (i < 100) AND bContinue DO
+    i := i + 1;
+    IF i > 50 THEN
+        bContinue := FALSE;
+    END_IF;
+END_WHILE;
+FC_WhileComplex := i;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        while_loops = find_by_metadata(block_chunks, "kind", "while_loop")
+        assert len(while_loops) == 1
+        # Also verify the nested IF is extracted
+        if_blocks = find_by_metadata(block_chunks, "kind", "if_block")
+        assert len(if_blocks) == 1
+
+
+# =============================================================================
+# TestImplementationBlockLineNumbers
+# =============================================================================
+
+
+class TestImplementationBlockLineNumbers:
+    """Verify BLOCK chunks from Implementation have correct XML-absolute line numbers."""
+
+    @pytest.fixture
+    def function_if_fixture(self):
+        """Load the FUNCTION IF test fixture."""
+        fixture_path = (
+            Path(__file__).parent / "fixtures" / "twincat" / "example_function_if.TcPOU"
+        )
+        if not fixture_path.exists():
+            pytest.skip("FUNCTION IF fixture not found")
+        return fixture_path
+
+    @pytest.fixture
+    def function_loops_fixture(self):
+        """Load the FUNCTION loops test fixture."""
+        fixture_path = (
+            Path(__file__).parent
+            / "fixtures"
+            / "twincat"
+            / "example_function_loops.TcPOU"
+        )
+        if not fixture_path.exists():
+            pytest.skip("FUNCTION loops fixture not found")
+        return fixture_path
+
+    @pytest.fixture
+    def function_action_fixture(self):
+        """Load the FUNCTION with action test fixture."""
+        fixture_path = (
+            Path(__file__).parent
+            / "fixtures"
+            / "twincat"
+            / "example_function_with_action.TcPOU"
+        )
+        if not fixture_path.exists():
+            pytest.skip("FUNCTION with action fixture not found")
+        return fixture_path
+
+    def test_if_block_start_line_is_xml_absolute(self, twincat_parser):
+        """Test IF block start_line > CDATA start (not starting at 1)."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_Test : INT
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[n := 1;
+IF n > 0 THEN
+    FC_Test := n;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        assert len(block_chunks) == 1
+        # Implementation CDATA starts at line 10, IF is on line 11
+        # Line numbers must be > 3 (XML declaration, TcPlcObject, POU elements)
+        assert block_chunks[0].start_line > 10
+
+    def test_if_block_end_line_spans_content(self, twincat_parser):
+        """Test IF block end_line includes END_IF."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_Test : INT
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[n := 1;
+IF n > 0 THEN
+    FC_Test := n;
+END_IF;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        assert len(block_chunks) == 1
+        # end_line must be >= start_line and include END_IF
+        assert block_chunks[0].end_line >= block_chunks[0].start_line
+        # IF spans 3 lines (IF, body, END_IF), so end >= start + 2
+        assert block_chunks[0].end_line >= block_chunks[0].start_line + 2
+
+    def test_for_loop_line_numbers_match_xml_positions(
+        self, twincat_parser, function_loops_fixture
+    ):
+        """Test specific FOR loop line numbers verified against known XML positions."""
+        chunks = extract_chunks_from_file(twincat_parser, function_loops_fixture)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        for_loops = find_by_metadata(block_chunks, "kind", "for_loop")
+        assert len(for_loops) >= 1
+        # FOR loop in fixture starts at line 21 (inside CASE branch 1)
+        # Implementation CDATA starts at line 16
+        for for_loop in for_loops:
+            assert for_loop.start_line > 16
+            assert for_loop.end_line >= for_loop.start_line
+
+    def test_nested_blocks_have_distinct_line_numbers(
+        self, twincat_parser, function_if_fixture
+    ):
+        """Test outer IF and nested IF have different, correct line numbers."""
+        chunks = extract_chunks_from_file(twincat_parser, function_if_fixture)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        if_blocks = find_by_metadata(block_chunks, "kind", "if_block")
+        assert len(if_blocks) == 2
+        # Sort by start_line to identify outer vs inner
+        if_blocks_sorted = sorted(if_blocks, key=lambda x: x.start_line)
+        outer_if = if_blocks_sorted[0]
+        inner_if = if_blocks_sorted[1]
+        # Nested IF must start after outer IF starts
+        assert inner_if.start_line > outer_if.start_line
+        # Nested IF must end before or at outer IF end
+        assert inner_if.end_line <= outer_if.end_line
+
+    def test_case_block_line_numbers(self, twincat_parser, function_loops_fixture):
+        """Test CASE block start/end lines are XML-absolute."""
+        chunks = extract_chunks_from_file(twincat_parser, function_loops_fixture)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        case_blocks = find_by_metadata(block_chunks, "kind", "case_block")
+        assert len(case_blocks) == 1
+        # CASE in fixture starts at line 19
+        assert case_blocks[0].start_line >= 19
+        assert case_blocks[0].end_line >= case_blocks[0].start_line
+
+    def test_while_loop_line_numbers(self, twincat_parser, function_loops_fixture):
+        """Test WHILE block line numbers are verified."""
+        chunks = extract_chunks_from_file(twincat_parser, function_loops_fixture)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        while_loops = find_by_metadata(block_chunks, "kind", "while_loop")
+        assert len(while_loops) >= 1
+        for while_loop in while_loops:
+            # Must be XML-absolute (> declaration CDATA end around line 14)
+            assert while_loop.start_line > 14
+            assert while_loop.end_line >= while_loop.start_line
+
+    def test_repeat_loop_line_numbers(self, twincat_parser, function_loops_fixture):
+        """Test REPEAT block line numbers are verified."""
+        chunks = extract_chunks_from_file(twincat_parser, function_loops_fixture)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        repeat_loops = find_by_metadata(block_chunks, "kind", "repeat_loop")
+        assert len(repeat_loops) >= 1
+        for repeat_loop in repeat_loops:
+            assert repeat_loop.start_line > 14
+            assert repeat_loop.end_line >= repeat_loop.start_line
+
+    def test_action_block_line_numbers_are_xml_absolute(
+        self, twincat_parser, function_action_fixture
+    ):
+        """Test blocks in ACTION have XML-absolute lines (not action-relative)."""
+        chunks = extract_chunks_from_file(twincat_parser, function_action_fixture)
+        assert_no_parse_errors(twincat_parser)
+        # Get action blocks only
+        action_blocks = [
+            c
+            for c in chunks
+            if c.concept == UniversalConcept.BLOCK and c.metadata.get("action_name")
+        ]
+        assert len(action_blocks) >= 1
+        for block in action_blocks:
+            # Action Implementation CDATA starts around line 30
+            # Blocks must have line numbers > this
+            assert block.start_line > 25
+            assert block.end_line >= block.start_line
+
+    def test_multiple_blocks_sequential_line_numbers(
+        self, twincat_parser, function_loops_fixture
+    ):
+        """Test multiple blocks have increasing, non-overlapping line numbers."""
+        chunks = extract_chunks_from_file(twincat_parser, function_loops_fixture)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        # Sort by start_line
+        sorted_blocks = sorted(block_chunks, key=lambda x: x.start_line)
+        # All blocks should have valid line ranges
+        for block in sorted_blocks:
+            assert block.start_line > 0
+            assert block.end_line >= block.start_line
+
+    def test_block_line_numbers_not_cdata_relative(self, twincat_parser):
+        """Test all block line numbers > 3 (XML structure takes lines 1-3)."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FC_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION FC_Test : INT
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[IF n > 0 THEN
+    n := 1;
+END_IF;
+FOR n := 0 TO 5 DO
+    n := n + 1;
+END_FOR;
+]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        block_chunks = find_by_type(chunks, ChunkType.BLOCK)
+        assert len(block_chunks) >= 2
+        for block in block_chunks:
+            # Line numbers must be > 3 because:
+            # - Line 1: XML declaration
+            # - Line 2: TcPlcObject
+            # - Line 3: POU element
+            # - Line 4+: Declaration CDATA
+            # - Line N+: Implementation CDATA (where blocks are)
+            assert block.start_line > 3, (
+                f"Block {block.metadata.get('kind')} has start_line={block.start_line}, "
+                "which suggests CDATA-relative numbering"
+            )
+
+
+# =============================================================================
+# TestMethodExtraction
+# =============================================================================
+
+
+class TestMethodExtraction:
+    """Test METHOD extraction from FUNCTION_BLOCK."""
+
+    @pytest.fixture
+    def method_fixture(self):
+        """Load the methods test fixture."""
+        fixture_path = (
+            Path(__file__).parent
+            / "fixtures"
+            / "twincat"
+            / "example_function_block_with_methods.TcPOU"
+        )
+        if not fixture_path.exists():
+            pytest.skip("Methods fixture not found")
+        return fixture_path
+
+    def test_method_chunk_created(self, twincat_parser, method_fixture):
+        """Test METHOD creates separate declaration/implementation chunks."""
+        chunks = extract_chunks_from_file(twincat_parser, method_fixture)
+        assert_no_parse_errors(twincat_parser)
+        method_chunks = find_by_type(chunks, ChunkType.METHOD)
+        # 3 methods x 2 chunks each = 6 total
+        assert len(method_chunks) == 6
+        # Check for declaration/implementation suffixes
+        decl_names = {
+            c.name for c in method_chunks if c.metadata.get("section") == "declaration"
+        }
+        impl_names = {
+            c.name
+            for c in method_chunks
+            if c.metadata.get("section") == "implementation"
+        }
+        assert "FB_WithMethods.Initialize.declaration" in decl_names
+        assert "FB_WithMethods.Initialize.implementation" in impl_names
+
+    def test_method_metadata(self, twincat_parser, method_fixture):
+        """Test METHOD metadata includes kind='method', pou_name, method_id, section."""
+        chunks = extract_chunks_from_file(twincat_parser, method_fixture)
+        assert_no_parse_errors(twincat_parser)
+        method_chunks = find_by_type(chunks, ChunkType.METHOD)
+        init_decl = [
+            c
+            for c in method_chunks
+            if c.name == "FB_WithMethods.Initialize.declaration"
+        ][0]
+
+        assert init_decl.metadata["kind"] == "method"
+        assert init_decl.metadata["pou_type"] == "FUNCTION_BLOCK"
+        assert init_decl.metadata["pou_name"] == "FB_WithMethods"
+        assert (
+            init_decl.metadata["method_id"] == "{11111111-2222-3333-4444-555555555555}"
+        )
+        assert init_decl.metadata["section"] == "declaration"
+
+    def test_method_variables_extracted(self, twincat_parser, method_fixture):
+        """Test METHOD variable declarations are extracted as FIELD chunks."""
+        chunks = extract_chunks_from_file(twincat_parser, method_fixture)
+        assert_no_parse_errors(twincat_parser)
+
+        # Variables from Initialize method: bReset, nInitValue, bLocalFlag
+        init_vars = find_by_metadata(chunks, "method_name", "Initialize")
+        assert len(init_vars) >= 3
+
+        # Check that bReset is a VAR_INPUT with proper metadata
+        breset = [c for c in init_vars if c.name == "FB_WithMethods.Initialize.bReset"]
+        assert len(breset) == 1
+        assert breset[0].concept == UniversalConcept.DEFINITION
+        assert breset[0].metadata["kind"] == "field"
+        assert breset[0].metadata["var_class"] == "input"
+        assert breset[0].metadata["data_type"] == "BOOL"
+        assert breset[0].metadata["method_name"] == "Initialize"
+
+    def test_method_blocks_extracted(self, twincat_parser, method_fixture):
+        """Test METHOD control flow blocks are extracted as BLOCK chunks."""
+        chunks = extract_chunks_from_file(twincat_parser, method_fixture)
+        assert_no_parse_errors(twincat_parser)
+
+        # Initialize method has an IF block
+        init_blocks = [
+            c
+            for c in chunks
+            if c.concept == UniversalConcept.BLOCK
+            and c.metadata.get("method_name") == "Initialize"
+        ]
+        assert len(init_blocks) >= 1
+        assert init_blocks[0].metadata["kind"] == "if_block"
+        # Verify FQN symbol pattern: POUName.MethodName.{kind}_{line}
+        assert init_blocks[0].name.startswith("FB_WithMethods.Initialize.if_block_")
+
+    def test_method_code_separate_declaration_and_implementation(
+        self, twincat_parser, method_fixture
+    ):
+        """Test METHOD has separate declaration and implementation chunks."""
+        chunks = extract_chunks_from_file(twincat_parser, method_fixture)
+        assert_no_parse_errors(twincat_parser)
+        method_chunks = find_by_type(chunks, ChunkType.METHOD)
+        init_decl = [
+            c
+            for c in method_chunks
+            if c.name == "FB_WithMethods.Initialize.declaration"
+        ][0]
+        init_impl = [
+            c
+            for c in method_chunks
+            if c.name == "FB_WithMethods.Initialize.implementation"
+        ][0]
+
+        # Declaration should include METHOD header and VAR blocks
+        assert "METHOD Initialize" in init_decl.content
+        assert "VAR_INPUT" in init_decl.content
+        assert "bReset" in init_decl.content
+
+        # Implementation should include the IF block
+        assert "IF bReset THEN" in init_impl.content
+
+    def test_multiple_methods_have_unique_ids(self, twincat_parser, method_fixture):
+        """Test each METHOD pair shares the same method_id."""
+        chunks = extract_chunks_from_file(twincat_parser, method_fixture)
+        assert_no_parse_errors(twincat_parser)
+        method_chunks = find_by_type(chunks, ChunkType.METHOD)
+        # 3 unique method_ids, each appearing twice (decl + impl)
+        method_ids = [c.metadata["method_id"] for c in method_chunks]
+        assert len(set(method_ids)) == 3
+
+    def test_method_from_xml_string(self, twincat_parser):
+        """Test METHOD extraction from inline XML."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    nState : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+    <Method Name="DoWork" Id="{method-uuid}">
+      <Declaration><![CDATA[METHOD DoWork : BOOL
+VAR_INPUT
+    nValue : INT;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[DoWork := nValue > 0;]]></ST>
+      </Implementation>
+    </Method>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+
+        method_chunks = find_by_type(chunks, ChunkType.METHOD)
+        # 2 chunks: declaration + implementation
+        assert len(method_chunks) == 2
+        chunk_names = {c.name for c in method_chunks}
+        assert chunk_names == {
+            "FB_Test.DoWork.declaration",
+            "FB_Test.DoWork.implementation",
+        }
+        # Both share same method_id
+        for c in method_chunks:
+            assert c.metadata["method_id"] == "{method-uuid}"
+
+
+# =============================================================================
+# TestPropertyExtraction
+# =============================================================================
+
+
+class TestPropertyExtraction:
+    """Test PROPERTY extraction from FUNCTION_BLOCK."""
+
+    @pytest.fixture
+    def property_fixture(self):
+        """Load the properties test fixture."""
+        fixture_path = (
+            Path(__file__).parent
+            / "fixtures"
+            / "twincat"
+            / "example_function_block_with_properties.TcPOU"
+        )
+        if not fixture_path.exists():
+            pytest.skip("Properties fixture not found")
+        return fixture_path
+
+    def test_property_chunk_created(self, twincat_parser, property_fixture):
+        """Test PROPERTY creates separate declaration/get/set chunks."""
+        chunks = extract_chunks_from_file(twincat_parser, property_fixture)
+        assert_no_parse_errors(twincat_parser)
+        property_chunks = find_by_type(chunks, ChunkType.PROPERTY)
+        # Value: decl + get + set = 3, ReadOnlyStatus: decl + get = 2, Name: decl + get + set = 3 = 8 total
+        assert len(property_chunks) >= 7
+        # Check for section suffixes
+        sections = {c.metadata.get("section") for c in property_chunks}
+        assert "declaration" in sections
+        assert "get" in sections
+
+    def test_property_metadata(self, twincat_parser, property_fixture):
+        """Test PROPERTY metadata includes kind='property', pou_name, property_id, section."""
+        chunks = extract_chunks_from_file(twincat_parser, property_fixture)
+        assert_no_parse_errors(twincat_parser)
+        property_chunks = find_by_type(chunks, ChunkType.PROPERTY)
+        value_decl = [
+            c
+            for c in property_chunks
+            if c.name == "FB_WithProperties.Value.declaration"
+        ][0]
+
+        assert value_decl.metadata["kind"] == "property"
+        assert value_decl.metadata["pou_type"] == "FUNCTION_BLOCK"
+        assert value_decl.metadata["pou_name"] == "FB_WithProperties"
+        assert (
+            value_decl.metadata["property_id"]
+            == "{44444444-5555-6666-7777-888888888888}"
+        )
+        assert value_decl.metadata["section"] == "declaration"
+
+    def test_property_separate_accessor_chunks(self, twincat_parser, property_fixture):
+        """Test PROPERTY has separate declaration, get, and set chunks."""
+        chunks = extract_chunks_from_file(twincat_parser, property_fixture)
+        assert_no_parse_errors(twincat_parser)
+        property_chunks = find_by_type(chunks, ChunkType.PROPERTY)
+        value_get = [
+            c for c in property_chunks if c.name == "FB_WithProperties.Value.get"
+        ]
+        assert len(value_get) == 1
+        assert "nInternal" in value_get[0].content
+
+    def test_property_from_xml_string(self, twincat_parser):
+        """Test PROPERTY extraction from inline XML."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    nInternal : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+    <Property Name="MyProp" Id="{prop-uuid}">
+      <Declaration><![CDATA[PROPERTY MyProp : INT
+]]></Declaration>
+      <Get Name="Get" Id="{get-uuid}">
+        <Declaration><![CDATA[VAR
+END_VAR
+]]></Declaration>
+        <Implementation>
+          <ST><![CDATA[MyProp := nInternal;]]></ST>
+        </Implementation>
+      </Get>
+      <Set Name="Set" Id="{set-uuid}">
+        <Declaration><![CDATA[VAR
+END_VAR
+]]></Declaration>
+        <Implementation>
+          <ST><![CDATA[nInternal := MyProp;]]></ST>
+        </Implementation>
+      </Set>
+    </Property>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+
+        property_chunks = find_by_type(chunks, ChunkType.PROPERTY)
+        # 3 chunks: declaration + get + set
+        assert len(property_chunks) == 3
+        chunk_names = {c.name for c in property_chunks}
+        assert chunk_names == {
+            "FB_Test.MyProp.declaration",
+            "FB_Test.MyProp.get",
+            "FB_Test.MyProp.set",
+        }
+        # All share same property_id
+        for c in property_chunks:
+            assert c.metadata["property_id"] == "{prop-uuid}"
+
+    def test_readonly_property(self, twincat_parser):
+        """Test read-only PROPERTY (GET only, no SET)."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    nInternal : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+    <Property Name="ReadOnly" Id="{prop-uuid}">
+      <Declaration><![CDATA[PROPERTY ReadOnly : INT
+]]></Declaration>
+      <Get Name="Get" Id="{get-uuid}">
+        <Declaration><![CDATA[VAR
+END_VAR
+]]></Declaration>
+        <Implementation>
+          <ST><![CDATA[ReadOnly := nInternal;]]></ST>
+        </Implementation>
+      </Get>
+    </Property>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+
+        property_chunks = find_by_type(chunks, ChunkType.PROPERTY)
+        # 2 chunks: declaration + get (no set)
+        assert len(property_chunks) == 2
+        chunk_names = {c.name for c in property_chunks}
+        assert chunk_names == {"FB_Test.ReadOnly.declaration", "FB_Test.ReadOnly.get"}
+
+    def test_writeonly_property(self, twincat_parser):
+        """Test write-only PROPERTY (SET only, no GET)."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    nInternal : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+    <Property Name="WriteOnly" Id="{prop-uuid}">
+      <Declaration><![CDATA[PROPERTY WriteOnly : INT
+]]></Declaration>
+      <Set Name="Set" Id="{set-uuid}">
+        <Declaration><![CDATA[VAR
+END_VAR
+]]></Declaration>
+        <Implementation>
+          <ST><![CDATA[nInternal := WriteOnly;]]></ST>
+        </Implementation>
+      </Set>
+    </Property>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+
+        property_chunks = find_by_type(chunks, ChunkType.PROPERTY)
+        # 2 chunks: declaration + set (no get)
+        assert len(property_chunks) == 2
+        chunk_names = {c.name for c in property_chunks}
+        assert chunk_names == {"FB_Test.WriteOnly.declaration", "FB_Test.WriteOnly.set"}
+
+
+# =============================================================================
+# TestChunkNameInSourceCode
+# =============================================================================
+
+
+class TestChunkNameInSourceCode:
+    """Test that chunk names appear in their source code at start_line."""
+
+    def test_comprehensive_chunk_names_in_start_line(
+        self, twincat_parser, comprehensive_fixture
+    ):
+        """Verify each chunk's name component appears in code at its start_line.
+
+        For every chunk, extract the meaningful segment of the symbol,
+        and verify it exists in the line of code at start_line.
+
+        Excludes:
+        - BLOCK chunks: have synthetic names (if_block_XXX, for_loop_XXX)
+        - POU chunks: start_line points to CDATA section start
+        - Chunks with section suffixes (declaration, implementation, get, set)
+        """
+        # Parse the comprehensive fixture
+        chunks = extract_chunks_from_file(twincat_parser, comprehensive_fixture)
+        assert_no_parse_errors(twincat_parser)
+
+        # Read the source file to get individual lines
+        content = comprehensive_fixture.read_text()
+        lines = content.splitlines()
+
+        # Chunk kinds to skip (synthetic names or special line handling)
+        # Using metadata["kind"] for UniversalChunk
+        skip_kinds = {
+            # BLOCK chunks have synthetic names like if_block_295, for_loop_XYZ
+            "if_block",
+            "case_block",
+            "for_loop",
+            "while_loop",
+            "repeat_loop",
+            # COMMENT chunks have synthetic names like comment_line_4
+            "comment",
+            # POU chunks: start_line = CDATA start, not declaration line
+            "function_block",
+            "program",
+            "function",
+        }
+        # Section suffixes that won't appear in source
+        section_suffixes = {"declaration", "implementation", "get", "set"}
+
+        for chunk in chunks:
+            # Skip chunks with synthetic names or special line handling
+            kind = chunk.metadata.get("kind", "")
+            if kind in skip_kinds:
+                continue
+            # Also skip BLOCK concept entirely (covers control flow blocks)
+            if chunk.concept == UniversalConcept.BLOCK:
+                continue
+            # Also skip COMMENT concept
+            if chunk.concept == UniversalConcept.COMMENT:
+                continue
+            # Also skip IMPORT concept (FQN format is POUName:import_type:reference)
+            if chunk.concept == UniversalConcept.IMPORT:
+                continue
+
+            # Extract the name (last segment after the final '.')
+            name = chunk.name.rpartition(".")[2]
+            # Skip if name is a section suffix (won't appear in source)
+            if name in section_suffixes:
+                continue
+
+            # Get lines at start_line and start_line+1 (1-based indexing)
+            line_index = chunk.start_line - 1
+            assert 0 <= line_index < len(lines), (
+                f"Chunk {chunk.name} has start_line {chunk.start_line} "
+                f"which is out of range (file has {len(lines)} lines)"
+            )
+
+            line1 = lines[line_index]
+            line2 = lines[line_index + 1] if line_index + 1 < len(lines) else ""
+
+            # For variables (kind='field'), check first two lines to cover pragma attributes
+            if kind == "field":
+                assert name in line1 or name in line2, (
+                    f"Variable name '{name}' (from name '{chunk.name}') "
+                    f"not found in lines {chunk.start_line}-{chunk.start_line + 1}:\n"
+                    f"  Line {chunk.start_line}: '{line1}'\n"
+                    f"  Line {chunk.start_line + 1}: '{line2}'"
+                )
+            else:
+                # For non-variable chunks, keep single-line check
+                assert name in line1, (
+                    f"Chunk name '{name}' (from name '{chunk.name}') "
+                    f"not found in line {chunk.start_line}: '{line1}'"
+                )
+
+
+# =============================================================================
+# TestCommentExtraction
+# =============================================================================
+
+
+class TestCommentExtraction:
+    """Test comment chunk extraction from Structured Text code."""
+
+    @pytest.fixture
+    def comment_fixture(self):
+        """Load the comment test fixture."""
+        fixture_path = (
+            Path(__file__).parent
+            / "fixtures"
+            / "twincat"
+            / "example_with_comments.TcPOU"
+        )
+        if not fixture_path.exists():
+            pytest.skip("Comment fixture not found")
+        return fixture_path
+
+    def test_comment_chunks_extracted(self, twincat_parser, comment_fixture):
+        """Test that comment chunks are extracted from the fixture."""
+        chunks = extract_chunks_from_file(twincat_parser, comment_fixture)
+        assert_no_parse_errors(twincat_parser)
+        comment_chunks = find_by_type(chunks, ChunkType.COMMENT)
+        assert len(comment_chunks) > 0, "Expected at least one comment chunk"
+
+    def test_block_comment_type(self, twincat_parser, comment_fixture):
+        """Test that block comments have comment_type='block' in metadata."""
+        chunks = extract_chunks_from_file(twincat_parser, comment_fixture)
+        assert_no_parse_errors(twincat_parser)
+        block_comments = find_by_metadata(chunks, "comment_type", "block")
+        assert len(block_comments) > 0, "Expected at least one block comment"
+        for chunk in block_comments:
+            assert "(*" in chunk.content and "*)" in chunk.content
+
+    def test_line_comment_type(self, twincat_parser, comment_fixture):
+        """Test that line comments have comment_type='line' in metadata."""
+        chunks = extract_chunks_from_file(twincat_parser, comment_fixture)
+        assert_no_parse_errors(twincat_parser)
+        line_comments = find_by_metadata(chunks, "comment_type", "line")
+        assert len(line_comments) > 0, "Expected at least one line comment"
+        for chunk in line_comments:
+            assert chunk.content.startswith("//")
+
+    def test_comment_fqn_format(self, twincat_parser, comment_fixture):
+        """Test that comment FQNs follow pattern: POUName.comment_line_N."""
+        chunks = extract_chunks_from_file(twincat_parser, comment_fixture)
+        assert_no_parse_errors(twincat_parser)
+        comment_chunks = find_by_type(chunks, ChunkType.COMMENT)
+        for chunk in comment_chunks:
+            assert ".comment_line_" in chunk.name
+            assert chunk.name.startswith("FB_CommentExample.")
+
+    def test_comment_has_cleaned_text(self, twincat_parser, comment_fixture):
+        """Test that comment metadata includes cleaned_text without markers."""
+        chunks = extract_chunks_from_file(twincat_parser, comment_fixture)
+        assert_no_parse_errors(twincat_parser)
+        comment_chunks = find_by_type(chunks, ChunkType.COMMENT)
+        for chunk in comment_chunks:
+            assert "cleaned_text" in chunk.metadata
+            cleaned = chunk.metadata["cleaned_text"]
+            # Cleaned text should not have markers
+            assert not cleaned.startswith("(*")
+            assert not cleaned.startswith("//")
+
+    def test_comment_metadata_fields(self, twincat_parser, comment_fixture):
+        """Test that comment chunks have required metadata fields."""
+        chunks = extract_chunks_from_file(twincat_parser, comment_fixture)
+        assert_no_parse_errors(twincat_parser)
+        comment_chunks = find_by_type(chunks, ChunkType.COMMENT)
+        for chunk in comment_chunks:
+            assert chunk.metadata.get("kind") == "comment"
+            assert "comment_type" in chunk.metadata
+            assert "pou_name" in chunk.metadata
+            assert "pou_type" in chunk.metadata
+            assert "cleaned_text" in chunk.metadata
+
+    def test_multiline_block_comment(self, twincat_parser, comment_fixture):
+        """Test that multi-line block comments have correct end_line."""
+        chunks = extract_chunks_from_file(twincat_parser, comment_fixture)
+        assert_no_parse_errors(twincat_parser)
+        block_comments = find_by_metadata(chunks, "comment_type", "block")
+        # At least one multiline block comment should exist
+        multiline = [c for c in block_comments if c.end_line > c.start_line]
+        assert len(multiline) > 0, "Expected at least one multi-line block comment"
+
+    def test_comment_language_node_type(self, twincat_parser, comment_fixture):
+        """Test that all comment chunks have language_node_type indicating Lark origin."""
+        chunks = extract_chunks_from_file(twincat_parser, comment_fixture)
+        assert_no_parse_errors(twincat_parser)
+        comment_chunks = find_by_type(chunks, ChunkType.COMMENT)
+        for chunk in comment_chunks:
+            # UniversalChunk is language-agnostic but tracks origin
+            assert chunk.language_node_type == "lark_comment"
+
+    def test_comprehensive_fixture_has_comments(
+        self, twincat_parser, comprehensive_fixture
+    ):
+        """Test that the comprehensive fixture also extracts comments."""
+        chunks = extract_chunks_from_file(twincat_parser, comprehensive_fixture)
+        assert_no_parse_errors(twincat_parser)
+        comment_chunks = find_by_type(chunks, ChunkType.COMMENT)
+        # Comprehensive fixture has comments
+        assert len(comment_chunks) > 0, "Expected comments in comprehensive fixture"
+
+
+# =============================================================================
+# TestImportExtraction
+# =============================================================================
+
+
+def find_imports_by_type(
+    chunks: list[UniversalChunk], import_type: str
+) -> list[UniversalChunk]:
+    """Filter chunks by concept=IMPORT and import_type metadata."""
+    return [
+        c
+        for c in chunks
+        if c.concept == UniversalConcept.IMPORT
+        and c.metadata.get("import_type") == import_type
+    ]
+
+
+class TestImportExtraction:
+    """Test IMPORT concept extraction (VAR_EXTERNAL, EXTENDS, IMPLEMENTS, type references)."""
+
+    # --- VAR_EXTERNAL Tests ---
+
+    def test_var_external_creates_import_chunk(self, twincat_parser):
+        """Test VAR_EXTERNAL creates IMPORT chunk with import_type='var_external'."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR_EXTERNAL
+    nGlobalCounter : DINT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        import_chunks = find_imports_by_type(chunks, "var_external")
+        assert len(import_chunks) == 1
+        assert import_chunks[0].concept == UniversalConcept.IMPORT
+        assert import_chunks[0].metadata["var_name"] == "nGlobalCounter"
+        assert import_chunks[0].metadata["data_type"] == "DINT"
+
+    def test_var_external_import_metadata(self, twincat_parser):
+        """Test VAR_EXTERNAL import has all required metadata fields."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR_EXTERNAL
+    extValue : REAL;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        import_chunks = find_imports_by_type(chunks, "var_external")
+        assert len(import_chunks) == 1
+        metadata = import_chunks[0].metadata
+        assert metadata["kind"] == "import"
+        assert metadata["import_type"] == "var_external"
+        assert metadata["var_class"] == "external"
+        assert metadata["pou_name"] == "FB_Test"
+        assert metadata["pou_type"] == "FUNCTION_BLOCK"
+
+    def test_multiple_var_external(self, twincat_parser):
+        """Test multiple VAR_EXTERNAL declarations create multiple import chunks."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR_EXTERNAL
+    nCounter : DINT;
+    fTemperature : REAL;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        import_chunks = find_imports_by_type(chunks, "var_external")
+        assert len(import_chunks) == 2
+        names = {c.metadata["var_name"] for c in import_chunks}
+        assert names == {"nCounter", "fTemperature"}
+
+    # --- EXTENDS Tests ---
+
+    def test_extends_creates_import_chunk(self, twincat_parser):
+        """Test EXTENDS clause creates IMPORT chunk with import_type='extends'."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Child" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Child EXTENDS FB_Parent
+VAR
+    nValue : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        import_chunks = find_imports_by_type(chunks, "extends")
+        assert len(import_chunks) == 1
+        assert import_chunks[0].concept == UniversalConcept.IMPORT
+        assert import_chunks[0].metadata["base_type"] == "FB_Parent"
+        assert import_chunks[0].metadata["target_type"] == "FB_Child"
+
+    def test_extends_import_fqn(self, twincat_parser):
+        """Test EXTENDS import FQN follows pattern: POUName:extends:BaseType."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Motor" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Motor EXTENDS FB_Device
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        import_chunks = find_imports_by_type(chunks, "extends")
+        assert len(import_chunks) == 1
+        assert import_chunks[0].name == "FB_Motor:extends:FB_Device"
+
+    # --- IMPLEMENTS Tests ---
+
+    def test_implements_creates_import_chunk(self, twincat_parser):
+        """Test IMPLEMENTS clause creates IMPORT chunk with import_type='implements'."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Motor" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Motor IMPLEMENTS I_Motor
+VAR
+    nValue : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        import_chunks = find_imports_by_type(chunks, "implements")
+        assert len(import_chunks) == 1
+        assert import_chunks[0].concept == UniversalConcept.IMPORT
+        assert import_chunks[0].metadata["interface_name"] == "I_Motor"
+        assert import_chunks[0].metadata["implementing_type"] == "FB_Motor"
+
+    def test_multiple_implements(self, twincat_parser):
+        """Test multiple IMPLEMENTS interfaces create multiple import chunks."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Motor" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Motor IMPLEMENTS I_Motor, I_Device, I_Runnable
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        import_chunks = find_imports_by_type(chunks, "implements")
+        assert len(import_chunks) == 3
+        interface_names = {c.metadata["interface_name"] for c in import_chunks}
+        assert interface_names == {"I_Motor", "I_Device", "I_Runnable"}
+
+    def test_extends_and_implements_together(self, twincat_parser):
+        """Test EXTENDS and IMPLEMENTS can be used together."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Child" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Child EXTENDS FB_Parent IMPLEMENTS I_Child, I_Other
+VAR
+    n : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+
+        extends_chunks = find_imports_by_type(chunks, "extends")
+        assert len(extends_chunks) == 1
+        assert extends_chunks[0].metadata["base_type"] == "FB_Parent"
+
+        implements_chunks = find_imports_by_type(chunks, "implements")
+        assert len(implements_chunks) == 2
+        interface_names = {c.metadata["interface_name"] for c in implements_chunks}
+        assert interface_names == {"I_Child", "I_Other"}
+
+    # --- Type Reference Tests ---
+
+    def test_user_type_reference_creates_import(self, twincat_parser):
+        """Test user-defined type reference creates IMPORT chunk."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    fbMotor : FB_Motor;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        import_chunks = find_imports_by_type(chunks, "type_reference")
+        assert len(import_chunks) == 1
+        assert import_chunks[0].metadata["referenced_type"] == "FB_Motor"
+        assert import_chunks[0].metadata["var_name"] == "fbMotor"
+
+    def test_primitive_types_not_imported(self, twincat_parser):
+        """Test primitive types (BOOL, INT, REAL, etc.) don't create type_reference imports."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    bFlag : BOOL;
+    nCount : INT;
+    fValue : REAL;
+    tDelay : TIME;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        import_chunks = find_imports_by_type(chunks, "type_reference")
+        # No imports for primitive types
+        assert len(import_chunks) == 0
+
+    def test_array_of_user_type_creates_import(self, twincat_parser):
+        """Test ARRAY OF user-defined type creates type_reference import."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    aMotors : ARRAY[0..9] OF FB_Motor;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        import_chunks = find_imports_by_type(chunks, "type_reference")
+        assert len(import_chunks) == 1
+        assert import_chunks[0].metadata["referenced_type"] == "FB_Motor"
+
+    def test_pointer_to_user_type_creates_import(self, twincat_parser):
+        """Test POINTER TO user-defined type creates type_reference import."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    pMotor : POINTER TO FB_Motor;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        import_chunks = find_imports_by_type(chunks, "type_reference")
+        assert len(import_chunks) == 1
+        assert import_chunks[0].metadata["referenced_type"] == "FB_Motor"
+
+    def test_reference_to_user_type_creates_import(self, twincat_parser):
+        """Test REFERENCE TO user-defined type creates type_reference import."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    refMotor : REFERENCE TO FB_Motor;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        import_chunks = find_imports_by_type(chunks, "type_reference")
+        assert len(import_chunks) == 1
+        assert import_chunks[0].metadata["referenced_type"] == "FB_Motor"
+
+    def test_type_reference_deduplication(self, twincat_parser):
+        """Test same user type referenced multiple times creates only one import."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    fbMotor1 : FB_Motor;
+    fbMotor2 : FB_Motor;
+    fbMotor3 : FB_Motor;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        import_chunks = find_imports_by_type(chunks, "type_reference")
+        # Only one import despite three usages
+        assert len(import_chunks) == 1
+        assert import_chunks[0].metadata["referenced_type"] == "FB_Motor"
+
+    def test_type_reference_fqn_format(self, twincat_parser):
+        """Test type_reference import FQN follows pattern: POUName:type_ref:TypeName."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR
+    fbDevice : FB_Device;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+        import_chunks = find_imports_by_type(chunks, "type_reference")
+        assert len(import_chunks) == 1
+        assert import_chunks[0].name == "FB_Test:type_ref:FB_Device"
+
+    # --- Combined Import Tests ---
+
+    def test_all_import_types_together(self, twincat_parser):
+        """Test extraction of all import types in a single POU."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Child" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Child EXTENDS FB_Parent IMPLEMENTS I_Motor
+VAR_EXTERNAL
+    nGlobalCounter : DINT;
+END_VAR
+VAR
+    fbDriver : FB_MotorDriver;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+
+        # Check all import types present
+        var_external = find_imports_by_type(chunks, "var_external")
+        extends = find_imports_by_type(chunks, "extends")
+        implements = find_imports_by_type(chunks, "implements")
+        type_refs = find_imports_by_type(chunks, "type_reference")
+
+        assert len(var_external) == 1
+        assert var_external[0].metadata["var_name"] == "nGlobalCounter"
+
+        assert len(extends) == 1
+        assert extends[0].metadata["base_type"] == "FB_Parent"
+
+        assert len(implements) == 1
+        assert implements[0].metadata["interface_name"] == "I_Motor"
+
+        assert len(type_refs) == 1
+        assert type_refs[0].metadata["referenced_type"] == "FB_MotorDriver"
+
+    def test_import_chunks_have_language_node_type(self, twincat_parser):
+        """Test all import chunks have appropriate language_node_type."""
+        xml = """<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Child" Id="{1234}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Child EXTENDS FB_Parent IMPLEMENTS I_Motor
+VAR_EXTERNAL
+    nCounter : DINT;
+END_VAR
+VAR
+    fbMotor : FB_Motor;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>"""
+        chunks = twincat_parser.extract_universal_chunks(xml)
+        assert_no_parse_errors(twincat_parser)
+
+        import_chunks = [c for c in chunks if c.concept == UniversalConcept.IMPORT]
+        assert len(import_chunks) == 4  # var_external, extends, implements, type_ref
+
+        node_types = {c.language_node_type for c in import_chunks}
+        assert "lark_var_external" in node_types
+        assert "lark_extends" in node_types
+        assert "lark_implements" in node_types
+        assert "lark_type_reference" in node_types
+
+
+# =============================================================================
+# Import Resolution Tests
+# =============================================================================
+
+
+class TestTwinCATImportResolution:
+    """Test TwinCAT import path resolution."""
+
+    @pytest.fixture
+    def mapping(self):
+        from chunkhound.parsers.twincat.twincat_mapping import TwinCATMapping
+
+        return TwinCATMapping()
+
+    def test_resolve_direct_symbol(self, tmp_path, mapping):
+        """Test resolving a direct symbol name to .TcPOU file."""
+        motor_file = tmp_path / "FB_Motor.TcPOU"
+        motor_file.write_text("<xml/>")
+
+        resolved = mapping.resolve_import_paths(
+            "FB_Motor", tmp_path, tmp_path / "Main.TcPOU"
+        )
+        assert resolved == [motor_file]
+
+    def test_resolve_var_declaration(self, tmp_path, mapping):
+        """Test resolving type from variable declaration."""
+        motor_file = tmp_path / "FB_Motor.TcPOU"
+        motor_file.write_text("<xml/>")
+
+        resolved = mapping.resolve_import_paths(
+            "motor : FB_Motor;", tmp_path, tmp_path / "Main.TcPOU"
+        )
+        assert resolved == [motor_file]
+
+    def test_resolve_extends_keyword(self, tmp_path, mapping):
+        """Test resolving type from EXTENDS clause."""
+        base_file = tmp_path / "FB_Base.TcPOU"
+        base_file.write_text("<xml/>")
+
+        resolved = mapping.resolve_import_paths(
+            "EXTENDS FB_Base", tmp_path, tmp_path / "FB_Child.TcPOU"
+        )
+        assert resolved == [base_file]
+
+    def test_resolve_implements_keyword(self, tmp_path, mapping):
+        """Test resolving type from IMPLEMENTS clause."""
+        interface_file = tmp_path / "I_Runnable.TcPOU"
+        interface_file.write_text("<xml/>")
+
+        resolved = mapping.resolve_import_paths(
+            "IMPLEMENTS I_Runnable", tmp_path, tmp_path / "FB_Motor.TcPOU"
+        )
+        assert resolved == [interface_file]
+
+    def test_resolve_pointer_to_type(self, tmp_path, mapping):
+        """Test resolving type from POINTER TO declaration."""
+        motor_file = tmp_path / "FB_Motor.TcPOU"
+        motor_file.write_text("<xml/>")
+
+        resolved = mapping.resolve_import_paths(
+            "pMotor : POINTER TO FB_Motor;", tmp_path, tmp_path / "Main.TcPOU"
+        )
+        assert resolved == [motor_file]
+
+    def test_resolve_reference_to_type(self, tmp_path, mapping):
+        """Test resolving type from REFERENCE TO declaration."""
+        motor_file = tmp_path / "FB_Motor.TcPOU"
+        motor_file.write_text("<xml/>")
+
+        resolved = mapping.resolve_import_paths(
+            "refMotor : REFERENCE TO FB_Motor;", tmp_path, tmp_path / "Main.TcPOU"
+        )
+        assert resolved == [motor_file]
+
+    def test_resolve_array_of_type(self, tmp_path, mapping):
+        """Test resolving type from ARRAY OF declaration."""
+        motor_file = tmp_path / "FB_Motor.TcPOU"
+        motor_file.write_text("<xml/>")
+
+        resolved = mapping.resolve_import_paths(
+            "motors : ARRAY[0..9] OF FB_Motor;", tmp_path, tmp_path / "Main.TcPOU"
+        )
+        assert resolved == [motor_file]
+
+    def test_resolve_nested_pointer_array(self, tmp_path, mapping):
+        """Test resolving type from nested POINTER TO ARRAY OF declaration."""
+        motor_file = tmp_path / "FB_Motor.TcPOU"
+        motor_file.write_text("<xml/>")
+
+        resolved = mapping.resolve_import_paths(
+            "pMotors : POINTER TO ARRAY[0..9] OF FB_Motor;",
+            tmp_path,
+            tmp_path / "Main.TcPOU",
+        )
+        assert resolved == [motor_file]
+
+    def test_case_insensitive_matching(self, tmp_path, mapping):
+        """Test case-insensitive file matching."""
+        # Create file with different case than symbol
+        motor_file = tmp_path / "fb_motor.TcPOU"
+        motor_file.write_text("<xml/>")
+
+        resolved = mapping.resolve_import_paths(
+            "FB_MOTOR", tmp_path, tmp_path / "Main.TcPOU"
+        )
+        assert resolved == [motor_file]
+
+    def test_primitive_type_returns_empty_list(self, tmp_path, mapping):
+        """Test that IEC 61131-3 primitive types return empty list."""
+        resolved = mapping.resolve_import_paths(
+            "value : DINT;", tmp_path, tmp_path / "Main.TcPOU"
+        )
+        assert resolved == []
+
+    def test_stdlib_type_returns_empty_list(self, tmp_path, mapping):
+        """Test that standard library types (TON, etc.) return empty list."""
+        resolved = mapping.resolve_import_paths(
+            "timer : TON;", tmp_path, tmp_path / "Main.TcPOU"
+        )
+        assert resolved == []
+
+    def test_not_found_returns_empty_list(self, tmp_path, mapping):
+        """Test that non-existent symbols return empty list."""
+        resolved = mapping.resolve_import_paths(
+            "FB_NonExistent", tmp_path, tmp_path / "Main.TcPOU"
+        )
+        assert resolved == []
+
+    def test_searches_subdirectories(self, tmp_path, mapping):
+        """Test that file search includes subdirectories."""
+        lib_dir = tmp_path / "lib" / "motors"
+        lib_dir.mkdir(parents=True)
+        motor_file = lib_dir / "FB_Motor.TcPOU"
+        motor_file.write_text("<xml/>")
+
+        resolved = mapping.resolve_import_paths(
+            "FB_Motor", tmp_path, tmp_path / "Main.TcPOU"
+        )
+        assert resolved == [motor_file]

--- a/tests/unit/research/shared/test_import_context_twincat.py
+++ b/tests/unit/research/shared/test_import_context_twincat.py
@@ -1,0 +1,420 @@
+"""Tests for ImportContextService with TwinCAT parser integration.
+
+These tests verify that ImportContextService correctly detects and extracts
+imports from TwinCAT (Lark-based) parsers, ensuring deep research synthesis
+works correctly with Structured Text files.
+
+Test Categories:
+1. Parser detection - Verify Lark-based parser is correctly identified
+2. Import extraction - Test extraction of various TwinCAT import types
+3. Caching behavior - Verify imports are cached correctly
+4. Edge cases - Empty files, parse errors, etc.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from chunkhound.parsers.parser_factory import ParserFactory
+from chunkhound.services.research.shared.import_context import ImportContextService
+
+
+# TcPOU XML fixtures
+VAR_EXTERNAL_FIXTURE = """<?xml version="1.0"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Test" Id="{12345678-1234-1234-1234-123456789abc}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Test
+VAR_EXTERNAL
+    nGlobal : DINT;
+    sMessage : STRING;
+END_VAR
+VAR
+    nLocal : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>
+"""
+
+EXTENDS_FIXTURE = """<?xml version="1.0"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Child" Id="{12345678-1234-1234-1234-123456789abc}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Child EXTENDS FB_Base
+VAR
+    nValue : INT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>
+"""
+
+IMPLEMENTS_FIXTURE = """<?xml version="1.0"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Motor" Id="{12345678-1234-1234-1234-123456789abc}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Motor IMPLEMENTS I_Motor
+VAR
+    bRunning : BOOL;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>
+"""
+
+MULTIPLE_IMPLEMENTS_FIXTURE = """<?xml version="1.0"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Device" Id="{12345678-1234-1234-1234-123456789abc}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Device IMPLEMENTS I_Device, I_Controllable
+VAR
+    bEnabled : BOOL;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>
+"""
+
+TYPE_REFERENCE_FIXTURE = """<?xml version="1.0"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Controller" Id="{12345678-1234-1234-1234-123456789abc}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Controller
+VAR
+    fbDevice : FB_Device;
+    stData : ST_ProcessData;
+    eState : E_MachineState;
+    nCounter : DINT;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>
+"""
+
+COMBINED_FIXTURE = """<?xml version="1.0"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Combined" Id="{12345678-1234-1234-1234-123456789abc}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Combined EXTENDS FB_Base IMPLEMENTS I_Motor, I_Device
+VAR_EXTERNAL
+    nGlobal : DINT;
+END_VAR
+VAR
+    fbSensor : FB_Sensor;
+    stConfig : ST_Config;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>
+"""
+
+EMPTY_DECLARATION_FIXTURE = """<?xml version="1.0"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Empty" Id="{12345678-1234-1234-1234-123456789abc}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Empty
+END_FUNCTION_BLOCK
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>
+"""
+
+PRIMITIVES_ONLY_FIXTURE = """<?xml version="1.0"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Primitives" Id="{12345678-1234-1234-1234-123456789abc}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Primitives
+VAR
+    bFlag : BOOL;
+    nCount : DINT;
+    fValue : REAL;
+    sName : STRING;
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>
+"""
+
+
+@pytest.fixture
+def parser_factory():
+    """Create a ParserFactory for testing."""
+    return ParserFactory()
+
+
+@pytest.fixture
+def import_context_service(parser_factory):
+    """Create an ImportContextService for testing."""
+    return ImportContextService(parser_factory)
+
+
+class TestLarkParserDetection:
+    """Tests for detecting TwinCAT as a Lark-based parser."""
+
+    def test_detects_lark_based_parser(self, parser_factory):
+        """Parser for TwinCAT should have base_mapping.extract_imports."""
+        parser = parser_factory.create_parser_for_file(Path("test.TcPOU"))
+
+        # TwinCAT parser has engine=None (no tree-sitter)
+        assert parser.engine is None
+
+        # Should have base_mapping with extract_imports method
+        assert hasattr(parser, "base_mapping")
+        assert hasattr(parser.base_mapping, "extract_imports")
+
+    def test_tcpou_file_extension_recognized(self, parser_factory):
+        """Should recognize .TcPOU extension for TwinCAT files."""
+        # Test various case variations
+        for ext in [".TcPOU", ".tcpou", ".TCPOU"]:
+            parser = parser_factory.create_parser_for_file(Path(f"test{ext}"))
+            assert hasattr(parser, "base_mapping")
+
+
+class TestVarExternalExtraction:
+    """Tests for VAR_EXTERNAL import extraction."""
+
+    def test_extracts_var_external_imports(self, import_context_service):
+        """Should extract VAR_EXTERNAL declarations as imports."""
+        imports = import_context_service.get_file_imports(
+            "test.TcPOU", VAR_EXTERNAL_FIXTURE
+        )
+
+        # Should find both VAR_EXTERNAL variables
+        assert len(imports) >= 2
+        import_text = "\n".join(imports)
+        assert "nGlobal" in import_text
+        assert "sMessage" in import_text
+
+    def test_var_external_not_mixed_with_local_vars(self, import_context_service):
+        """Should not include regular VAR declarations as imports."""
+        imports = import_context_service.get_file_imports(
+            "test.TcPOU", VAR_EXTERNAL_FIXTURE
+        )
+
+        import_text = "\n".join(imports)
+        # nLocal is in VAR block, not VAR_EXTERNAL
+        assert "nLocal" not in import_text
+
+
+class TestExtendsExtraction:
+    """Tests for EXTENDS clause import extraction."""
+
+    def test_extracts_extends_import(self, import_context_service):
+        """Should extract EXTENDS clause as import."""
+        imports = import_context_service.get_file_imports(
+            "test.TcPOU", EXTENDS_FIXTURE
+        )
+
+        import_text = "\n".join(imports)
+        assert "FB_Base" in import_text
+
+    def test_extends_marked_as_inheritance_type(self, import_context_service):
+        """EXTENDS import should be identifiable in output."""
+        imports = import_context_service.get_file_imports(
+            "test.TcPOU", EXTENDS_FIXTURE
+        )
+
+        # Should have at least one import containing FB_Base
+        assert any("FB_Base" in imp for imp in imports)
+
+
+class TestImplementsExtraction:
+    """Tests for IMPLEMENTS clause import extraction."""
+
+    def test_extracts_single_implements(self, import_context_service):
+        """Should extract single IMPLEMENTS clause as import."""
+        imports = import_context_service.get_file_imports(
+            "test.TcPOU", IMPLEMENTS_FIXTURE
+        )
+
+        import_text = "\n".join(imports)
+        assert "I_Motor" in import_text
+
+    def test_extracts_multiple_implements(self, import_context_service):
+        """Should extract multiple IMPLEMENTS interfaces."""
+        imports = import_context_service.get_file_imports(
+            "test.TcPOU", MULTIPLE_IMPLEMENTS_FIXTURE
+        )
+
+        import_text = "\n".join(imports)
+        assert "I_Device" in import_text
+        assert "I_Controllable" in import_text
+
+
+class TestTypeReferenceExtraction:
+    """Tests for user-defined type reference extraction."""
+
+    def test_extracts_function_block_type_references(self, import_context_service):
+        """Should extract FB_ type references as imports."""
+        imports = import_context_service.get_file_imports(
+            "test.TcPOU", TYPE_REFERENCE_FIXTURE
+        )
+
+        import_text = "\n".join(imports)
+        assert "FB_Device" in import_text
+
+    def test_extracts_struct_type_references(self, import_context_service):
+        """Should extract ST_ struct type references as imports."""
+        imports = import_context_service.get_file_imports(
+            "test.TcPOU", TYPE_REFERENCE_FIXTURE
+        )
+
+        import_text = "\n".join(imports)
+        assert "ST_ProcessData" in import_text
+
+    def test_extracts_enum_type_references(self, import_context_service):
+        """Should extract E_ enum type references as imports."""
+        imports = import_context_service.get_file_imports(
+            "test.TcPOU", TYPE_REFERENCE_FIXTURE
+        )
+
+        import_text = "\n".join(imports)
+        assert "E_MachineState" in import_text
+
+    def test_excludes_primitive_types(self, import_context_service):
+        """Should not extract primitive types (DINT, BOOL, etc.) as imports."""
+        imports = import_context_service.get_file_imports(
+            "test.TcPOU", PRIMITIVES_ONLY_FIXTURE
+        )
+
+        # No imports should be extracted for primitives only
+        import_text = "\n".join(imports)
+        # Primitive types should not appear as standalone imports
+        assert "BOOL" not in import_text.split()[0] if imports else True
+
+
+class TestCombinedExtraction:
+    """Tests for combined import extraction scenarios."""
+
+    def test_extracts_all_import_types(self, import_context_service):
+        """Should extract EXTENDS, IMPLEMENTS, VAR_EXTERNAL, and type refs."""
+        imports = import_context_service.get_file_imports(
+            "test.TcPOU", COMBINED_FIXTURE
+        )
+
+        import_text = "\n".join(imports)
+
+        # EXTENDS
+        assert "FB_Base" in import_text
+        # IMPLEMENTS (both)
+        assert "I_Motor" in import_text
+        assert "I_Device" in import_text
+        # VAR_EXTERNAL
+        assert "nGlobal" in import_text
+        # Type references
+        assert "FB_Sensor" in import_text
+        assert "ST_Config" in import_text
+
+
+class TestCaching:
+    """Tests for import caching behavior."""
+
+    def test_caches_imports(self, import_context_service):
+        """Should cache imports and return cached value on second call."""
+        file_path = "cached_test.TcPOU"
+
+        # First call
+        imports1 = import_context_service.get_file_imports(
+            file_path, VAR_EXTERNAL_FIXTURE
+        )
+
+        # Second call with same path (content ignored, uses cache)
+        imports2 = import_context_service.get_file_imports(
+            file_path, "invalid content"
+        )
+
+        # Should return same cached result
+        assert imports1 == imports2
+
+    def test_clear_cache_removes_entries(self, import_context_service):
+        """Should remove cached entries when clear_cache is called."""
+        file_path = "cache_clear_test.TcPOU"
+
+        # Populate cache
+        imports1 = import_context_service.get_file_imports(
+            file_path, VAR_EXTERNAL_FIXTURE
+        )
+        assert len(imports1) > 0
+
+        # Clear cache
+        import_context_service.clear_cache()
+
+        # With empty declaration, should get no imports (not cached result)
+        imports2 = import_context_service.get_file_imports(
+            file_path, EMPTY_DECLARATION_FIXTURE
+        )
+
+        # Should not be the same (cache was cleared, parsed new content)
+        assert imports1 != imports2
+
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_returns_empty_for_no_imports(self, import_context_service):
+        """Should return empty list when no imports present."""
+        imports = import_context_service.get_file_imports(
+            "test.TcPOU", PRIMITIVES_ONLY_FIXTURE
+        )
+
+        # May be empty or contain only type refs depending on implementation
+        # At minimum, should not raise an error
+        assert isinstance(imports, list)
+
+    def test_returns_empty_for_empty_declaration(self, import_context_service):
+        """Should return empty list for empty declaration block."""
+        imports = import_context_service.get_file_imports(
+            "test.TcPOU", EMPTY_DECLARATION_FIXTURE
+        )
+
+        assert imports == []
+
+    def test_handles_invalid_xml_gracefully(self, import_context_service):
+        """Should handle invalid XML without raising exception."""
+        invalid_xml = "not valid xml content"
+
+        # Should not raise
+        imports = import_context_service.get_file_imports(
+            "test.TcPOU", invalid_xml
+        )
+
+        assert imports == []
+
+    def test_handles_malformed_declaration_gracefully(self, import_context_service):
+        """Should handle malformed Structured Text gracefully."""
+        malformed_tcpou = """<?xml version="1.0"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_Malformed" Id="{12345678-1234-1234-1234-123456789abc}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_Malformed
+VAR
+    this is not valid structured text syntax
+END_VAR
+]]></Declaration>
+    <Implementation><ST><![CDATA[]]></ST></Implementation>
+  </POU>
+</TcPlcObject>
+"""
+        # Should not raise
+        imports = import_context_service.get_file_imports(
+            "test.TcPOU", malformed_tcpou
+        )
+
+        # Should return empty list on parse error
+        assert isinstance(imports, list)
+
+    def test_different_file_paths_use_separate_cache_entries(
+        self, import_context_service
+    ):
+        """Different file paths should have independent cache entries."""
+        content = VAR_EXTERNAL_FIXTURE
+
+        imports1 = import_context_service.get_file_imports("file1.TcPOU", content)
+        imports2 = import_context_service.get_file_imports("file2.TcPOU", content)
+
+        # Both should have the same imports
+        assert imports1 == imports2
+
+        # But clearing should not affect other entries until cleared
+        # (This tests that paths are cached independently)
+        assert len(import_context_service._import_cache) == 2

--- a/tests/unit/research/shared/test_import_context_twincat.py
+++ b/tests/unit/research/shared/test_import_context_twincat.py
@@ -277,11 +277,7 @@ class TestTypeReferenceExtraction:
         imports = import_context_service.get_file_imports(
             "test.TcPOU", PRIMITIVES_ONLY_FIXTURE
         )
-
-        # No imports should be extracted for primitives only
-        import_text = "\n".join(imports)
-        # Primitive types should not appear as standalone imports
-        assert "BOOL" not in import_text.split()[0] if imports else True
+        assert imports == [], f"Expected no imports for primitives-only fixture, got: {imports}"
 
 
 class TestCombinedExtraction:

--- a/tests/unit/research/test_chunk_range.py
+++ b/tests/unit/research/test_chunk_range.py
@@ -1,16 +1,13 @@
 """Tests for smart boundary expansion edge cases."""
 
-from chunkhound.services.deep_research_service import DeepResearchService
-
-
-def _service() -> DeepResearchService:
-    return DeepResearchService.__new__(DeepResearchService)
+from chunkhound.services.research.shared.chunk_range import (
+    expand_to_natural_boundaries,
+)
 
 
 def test_boundary_expansion_skips_invalid_start() -> None:
-    service = _service()
     lines = ["line"] * 5
-    start, end = service._expand_to_natural_boundaries(
+    start, end = expand_to_natural_boundaries(
         lines=lines,
         start_line=10,
         end_line=12,
@@ -21,9 +18,8 @@ def test_boundary_expansion_skips_invalid_start() -> None:
 
 
 def test_boundary_expansion_skips_invalid_end() -> None:
-    service = _service()
     lines = ["line"] * 5
-    start, end = service._expand_to_natural_boundaries(
+    start, end = expand_to_natural_boundaries(
         lines=lines,
         start_line=1,
         end_line=0,
@@ -34,9 +30,8 @@ def test_boundary_expansion_skips_invalid_end() -> None:
 
 
 def test_boundary_expansion_skips_reversed_range() -> None:
-    service = _service()
     lines = ["line"] * 5
-    start, end = service._expand_to_natural_boundaries(
+    start, end = expand_to_natural_boundaries(
         lines=lines,
         start_line=4,
         end_line=2,

--- a/uv.lock
+++ b/uv.lock
@@ -380,6 +380,7 @@ dependencies = [
     { name = "google-genai" },
     { name = "httpx" },
     { name = "lancedb" },
+    { name = "lark" },
     { name = "loguru" },
     { name = "mcp" },
     { name = "msgpack" },
@@ -474,6 +475,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.51.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "lancedb", specifier = ">=0.25.3" },
+    { name = "lark", specifier = ">=1.1.0" },
     { name = "loguru", specifier = ">=0.6.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "msgpack", specifier = ">=1.0" },
@@ -1110,6 +1112,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/1e/c5b808f96340753f4b7c6b889e3c845cfe6fb6994720614fce8ed3329a92/langsmith-0.4.32.tar.gz", hash = "sha256:a90bb8297fe0d3c63d9868ea58fe46c52d7e2d1f06b614e43c6a78c948275f24", size = 963489, upload-time = "2025-10-03T03:07:25.711Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/72/80/ff33907e4d7b7dc56f8a592e404488baec9e79a1e5517dd19673a93597b7/langsmith-0.4.32-py3-none-any.whl", hash = "sha256:5c4dcaa5049360bd126fec2fd59af703294e08c75c8d5363261f71a941fa2963", size = 386360, upload-time = "2025-10-03T03:07:20.973Z" },
+]
+
+[[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Note**: This PR was generated by an AI agent. If you'd like to talk with other humans, drop by our [Discord](https://discord.gg/BAepHEXXnX)!

---

## TwinCAT / IEC 61131-3 Structured Text Parser

Adds first-class support for TwinCAT PLC files (`.TcPOU`) — the XML-wrapped Structured Text format used by Beckhoff TwinCAT 3. Since tree-sitter has no ST grammar, this uses a custom Lark LALR grammar split across three files (`common.lark`, `declarations.lark`, `implementation.lark`). An XML extractor layer first peels CDATA sections from the TcPOU envelope, tracks their byte offsets, and feeds the raw ST code into the Lark parsers with line numbers adjusted back to the XML file coordinates.

The parser maps the full IEC 61131-3 POU hierarchy — FUNCTION_BLOCK, PROGRAM, FUNCTION, METHOD, ACTION, PROPERTY, and variable blocks (VAR_INPUT/OUTPUT/IN_OUT/etc.) — to ChunkHound's existing `ChunkType` taxonomy. Integration with the `UniversalParser` pipeline is via a `TwinCATMapping` that implements `extract_universal_chunks()` (the same escape hatch used by the Svelte/Vue parsers), so TwinCAT files benefit from the cAST deduplication, comment merging, and greedy merge passes without special-casing. Import context resolution was also extended to extract FB instance dependencies for the research graph.

No breaking changes. `lark>=1.1.0` is a new project dependency. The parser degrades gracefully — Lark import failures disable TwinCAT without affecting anything else.

#AGENT_REVIEW.md contents:

# TwinCAT TcPOU Parser — Agent Review

## What changed

Two commits on `twincat_lang` branch (on top of `main`):
- `5ab1506` — Full TwinCAT parser implementation
- `44c82c4` — Refactor: consolidate `PRIMITIVE_TYPES` to single source in `TwinCATParser`

## New files

```
chunkhound/parsers/twincat/
  __init__.py              # Conditional export guarded by ImportError
  common.lark              # Shared terminals: primitives, literals, HW addresses
  declarations.lark        # VAR blocks, struct/union/enum/alias/type declarations
  implementation.lark      # ST statements: IF/WHILE/FOR/CASE/function calls
  exceptions.py            # STParserError / XMLExtractionError / DeclarationParseError / ImplementationParseError
  twincat_parser.py        # 1720 lines — TwinCATParser class
  twincat_mapping.py       # TwinCATMapping(BaseMapping) — UniversalParser integration
  xml_extractor.py         # 570 lines — XML/CDATA extraction with SourceLocation offsets

tests/fixtures/twincat/    # 9 fixture .TcPOU files (comprehensive, function, FB+methods, loops, etc.)
tests/test_twincat_parser.py  # 4571 lines of parser tests
tests/unit/research/shared/test_import_context_twincat.py  # 420 lines
```

## Architecture

### Parsing pipeline

```
.TcPOU file (XML)
  → TcPOUExtractor.extract_string()      # xml_extractor.py
      → parse XML tree (stdlib ET)
      → extract CDATA sections from Declaration/Implementation/Method/Action/Property elements
      → compute SourceLocation (line, col, pos) for each CDATA block
  → TwinCATParser.extract_universal_chunks()
      → parse declaration CDATA with declarations.lark (LALR)
      → parse implementation CDATA with implementation.lark (LALR)
      → emit UniversalChunk objects with line numbers adjusted to XML coordinates
  → TwinCATMapping.extract_universal_chunks()  (adapter into BaseMapping interface)
      → delegates to cached TwinCATParser singleton
  → UniversalParser (existing cAST pipeline: dedup, comment merge, greedy merge)
```

### Key design decisions

1. **Lark over tree-sitter** — no tree-sitter ST grammar exists; Lark LALR chosen for its CDATA-friendly API and propagate_positions support.

2. **Split grammars** — `declarations.lark` and `implementation.lark` import `common.lark` but define their own `IDENTIFIER` terminal with different keyword exclusion sets to avoid LALR conflicts.

3. **engine=None escape hatch** — `TwinCATMapping` implements `extract_universal_chunks()` instead of providing a tree-sitter query, which is the same pattern used by Svelte/Vue parsers. `UniversalParser` detects `engine=None` and calls this method directly.

4. **Line number adjustment** — `xml_extractor.py` tracks the character offset of each CDATA block's start in the XML file. The parser adds `source_location.line - 1` to every Lark `meta.line` value so all chunks reference the XML file's line numbers, not CDATA-relative lines.

## ChunkType mapping

| IEC 61131-3 construct | ChunkType |
|---|---|
| FUNCTION_BLOCK | FUNCTION_BLOCK |
| PROGRAM | PROGRAM |
| FUNCTION | FUNCTION |
| METHOD | METHOD |
| ACTION | ACTION |
| PROPERTY (get/set) | PROPERTY |
| VAR_INPUT/OUTPUT/etc. variables | VARIABLE |
| Struct fields | FIELD |
| IF/FOR/WHILE/CASE blocks | BLOCK |

## Registration

- `Language.TWINCAT = "twincat"` added to `chunkhound/core/types/common.py`
- `.TcPOU` extension mapped to `Language.TWINCAT` in `parser_factory.py`
- `TwinCATMapping` instantiated and returned from `parser_factory.py:get_mapping(".TcPOU")`
- Language detector extended to map `.tcpou` (case-insensitive) → `Language.TWINCAT`

## Import context / research graph

`chunkhound/services/research/shared/import_context.py` extended to handle `engine=None` parsers. For TwinCAT, `_extract_imports_from_lark_parser()` collects user-defined FB instance variables (filters out `PRIMITIVE_TYPES` and `_STDLIB_TYPES`) as import dependencies for the research graph.

## Dependency

`lark>=1.1.0` — a new dependency in `pyproject.toml`.

## Test coverage

- `tests/test_twincat_parser.py` — 4571 lines; covers XML extraction, declaration parsing, implementation parsing, method/action/property chunks, line number correctness, PRIMITIVE_TYPES classification, error handling
- `tests/unit/research/shared/test_import_context_twincat.py` — import resolution for FB dependencies
- 9 fixture files covering programs, functions, FBs with methods/properties/actions, loops, comments

## Breaking changes

None. TwinCAT support is purely additive. Lark failures are caught at import time in `__init__.py` — a missing or incompatible lark install disables TwinCAT silently without affecting any other language.

