### PR TITLE
fix(embedding): retry VoyageAI rate limit errors instead of failing permanently

### DIFF
--- a/chunkhound/providers/embeddings/voyageai_provider.py
+++ b/chunkhound/providers/embeddings/voyageai_provider.py
@@ -101,6 +101,64 @@ VOYAGE_MODEL_CONFIG = {
 }
 
 
+# Base backoff (seconds) for each retry category. Network errors fall through
+# to the per-provider ``self._retry_delay`` so the existing instance setting
+# still drives generic connection retries.
+_CATEGORY_BACKOFFS: dict[str, float] = {
+    # TPM / RPM windows on VoyageAI are 60s; 30s lets the window partially
+    # drain before the first retry.
+    "rate_limit": 30.0,
+    # Azure ML / proxy 408s mean the upstream endpoint is overloaded; give it
+    # room to recover before we hit it again.
+    "upstream_timeout": 10.0,
+}
+
+
+def _classify_voyageai_error(e: Exception) -> str | None:
+    """Classify a VoyageAI SDK exception for retry decisions.
+
+    Returns one of ``"rate_limit"``, ``"upstream_timeout"``, ``"network"``,
+    or ``None`` for a non-retryable error. Shared by the embedding and
+    reranking code paths so their retry behavior cannot silently drift
+    apart (a prior bug where the rerank path was missing ``str(e)`` went
+    unnoticed for exactly this reason).
+    """
+    error_type = type(e).__name__
+    error_str = str(e)
+    error_lower = error_str.lower()
+
+    # Rate limit / server errors from the VoyageAI SDK (HTTP 429, 5xx).
+    # The ``"rate limit"`` substring match is a fallback for custom
+    # endpoints (Azure ML, self-hosted proxies) that surface 429s as
+    # generic ``RuntimeError`` / ``Exception`` rather than a dedicated
+    # SDK exception class.
+    if (
+        "RateLimitError" in error_type
+        or "TryAgain" in error_type
+        or "ServerError" in error_type
+        or "ServiceUnavailableError" in error_type
+        or "rate limit" in error_lower
+    ):
+        return "rate_limit"
+
+    # HTTP 408 (upstream request timeout) from Azure ML / proxies: treat
+    # as transient and retry with a longer initial backoff.
+    if "408" in error_str or "upstream request timeout" in error_lower:
+        return "upstream_timeout"
+
+    # Network / transient connection errors.
+    if (
+        "APIConnectionError" in error_type
+        or "ConnectionError" in error_type
+        or "RemoteDisconnected" in error_type
+        or "Timeout" in error_type
+        or "TimeoutError" in error_type
+    ):
+        return "network"
+
+    return None
+
+
 class VoyageAIEmbeddingProvider:
     """VoyageAI embedding provider using voyage-3.5 by default."""
 
@@ -323,49 +381,12 @@ class VoyageAIEmbeddingProvider:
                 return [embedding for embedding in result.embeddings]
 
             except Exception as e:
-                # Classify error type for retry decision
                 error_type = type(e).__name__
                 error_module = type(e).__module__
-                error_str = str(e)
+                category = _classify_voyageai_error(e)
 
-                # Network / transient errors that should be retried
-                is_network_error = any(
-                    [
-                        "APIConnectionError" in error_type,
-                        "ConnectionError" in error_type,
-                        "RemoteDisconnected" in error_type,
-                        "Timeout" in error_type,
-                        "TimeoutError" in error_type,
-                    ]
-                )
-
-                # Rate limit / server errors from VoyageAI SDK (HTTP 429, 5xx)
-                is_rate_limit_error = any(
-                    [
-                        "RateLimitError" in error_type,
-                        "TryAgain" in error_type,
-                        "ServerError" in error_type,
-                        "ServiceUnavailableError" in error_type,
-                        "rate limit" in error_str.lower(),
-                    ]
-                )
-
-                # HTTP 408 (upstream request timeout) from Azure ML / proxies:
-                # treat as transient and retry with a longer initial backoff
-                is_upstream_timeout = "408" in error_str or (
-                    "upstream request timeout" in error_str.lower()
-                )
-
-                is_retryable = is_network_error or is_rate_limit_error or is_upstream_timeout
-
-                if is_retryable and attempt < self._retry_attempts - 1:
-                    # Rate limits need longer backoff (TPM window is 60s)
-                    if is_rate_limit_error:
-                        base_delay = 30.0
-                    elif is_upstream_timeout:
-                        base_delay = 10.0
-                    else:
-                        base_delay = self._retry_delay
+                if category is not None and attempt < self._retry_attempts - 1:
+                    base_delay = _CATEGORY_BACKOFFS.get(category, self._retry_delay)
                     delay = base_delay * (2**attempt)
                     logger.warning(
                         f"VoyageAI embedding failed with {error_module}.{error_type} "
@@ -375,8 +396,7 @@ class VoyageAIEmbeddingProvider:
                     await asyncio.sleep(delay)
                     continue
                 else:
-                    # Non-retryable error or last attempt
-                    if is_retryable:
+                    if category is not None:
                         logger.error(
                             f"VoyageAI embedding failed after {self._retry_attempts} attempts: {e}"
                         )
@@ -655,31 +675,10 @@ class VoyageAIEmbeddingProvider:
             except Exception as e:
                 error_type = type(e).__name__
                 error_module = type(e).__module__
-                error_str = str(e)
-                is_network_error = any(
-                    [
-                        "APIConnectionError" in error_type,
-                        "ConnectionError" in error_type,
-                        "RemoteDisconnected" in error_type,
-                        "Timeout" in error_type,
-                        "TimeoutError" in error_type,
-                    ]
-                )
-                is_rate_limit_error = any(
-                    [
-                        "RateLimitError" in error_type,
-                        "TryAgain" in error_type,
-                        "ServerError" in error_type,
-                        "ServiceUnavailableError" in error_type,
-                        "rate limit" in error_str.lower(),
-                    ]
-                )
-                is_retryable = is_network_error or is_rate_limit_error
-                if is_retryable and attempt < self._retry_attempts - 1:
-                    if is_rate_limit_error:
-                        base_delay = 30.0
-                    else:
-                        base_delay = self._retry_delay
+                category = _classify_voyageai_error(e)
+
+                if category is not None and attempt < self._retry_attempts - 1:
+                    base_delay = _CATEGORY_BACKOFFS.get(category, self._retry_delay)
                     delay = base_delay * (2**attempt)
                     logger.warning(
                         f"VoyageAI reranking failed with {error_module}.{error_type} "
@@ -689,7 +688,7 @@ class VoyageAIEmbeddingProvider:
                     await asyncio.sleep(delay)
                     continue
                 else:
-                    if is_retryable:
+                    if category is not None:
                         logger.error(
                             f"VoyageAI reranking failed after {self._retry_attempts} attempts: {e}"
                         )

--- a/chunkhound/providers/embeddings/voyageai_provider.py
+++ b/chunkhound/providers/embeddings/voyageai_provider.py
@@ -339,17 +339,33 @@ class VoyageAIEmbeddingProvider:
                     ]
                 )
 
+                # Rate limit / server errors from VoyageAI SDK (HTTP 429, 5xx)
+                is_rate_limit_error = any(
+                    [
+                        "RateLimitError" in error_type,
+                        "TryAgain" in error_type,
+                        "ServerError" in error_type,
+                        "ServiceUnavailableError" in error_type,
+                        "rate limit" in error_str.lower(),
+                    ]
+                )
+
                 # HTTP 408 (upstream request timeout) from Azure ML / proxies:
                 # treat as transient and retry with a longer initial backoff
                 is_upstream_timeout = "408" in error_str or (
                     "upstream request timeout" in error_str.lower()
                 )
 
-                if (
-                    is_network_error or is_upstream_timeout
-                ) and attempt < self._retry_attempts - 1:
-                    # Longer backoff for upstream timeouts — endpoint needs time to recover
-                    base_delay = 10.0 if is_upstream_timeout else self._retry_delay
+                is_retryable = is_network_error or is_rate_limit_error or is_upstream_timeout
+
+                if is_retryable and attempt < self._retry_attempts - 1:
+                    # Rate limits need longer backoff (TPM window is 60s)
+                    if is_rate_limit_error:
+                        base_delay = 30.0
+                    elif is_upstream_timeout:
+                        base_delay = 10.0
+                    else:
+                        base_delay = self._retry_delay
                     delay = base_delay * (2**attempt)
                     logger.warning(
                         f"VoyageAI embedding failed with {error_module}.{error_type} "
@@ -359,8 +375,8 @@ class VoyageAIEmbeddingProvider:
                     await asyncio.sleep(delay)
                     continue
                 else:
-                    # Non-retryable error or last attempt - log and raise
-                    if is_network_error or is_upstream_timeout:
+                    # Non-retryable error or last attempt
+                    if is_retryable:
                         logger.error(
                             f"VoyageAI embedding failed after {self._retry_attempts} attempts: {e}"
                         )
@@ -639,6 +655,7 @@ class VoyageAIEmbeddingProvider:
             except Exception as e:
                 error_type = type(e).__name__
                 error_module = type(e).__module__
+                error_str = str(e)
                 is_network_error = any(
                     [
                         "APIConnectionError" in error_type,
@@ -648,8 +665,22 @@ class VoyageAIEmbeddingProvider:
                         "TimeoutError" in error_type,
                     ]
                 )
-                if is_network_error and attempt < self._retry_attempts - 1:
-                    delay = self._retry_delay * (2**attempt)
+                is_rate_limit_error = any(
+                    [
+                        "RateLimitError" in error_type,
+                        "TryAgain" in error_type,
+                        "ServerError" in error_type,
+                        "ServiceUnavailableError" in error_type,
+                        "rate limit" in error_str.lower(),
+                    ]
+                )
+                is_retryable = is_network_error or is_rate_limit_error
+                if is_retryable and attempt < self._retry_attempts - 1:
+                    if is_rate_limit_error:
+                        base_delay = 30.0
+                    else:
+                        base_delay = self._retry_delay
+                    delay = base_delay * (2**attempt)
                     logger.warning(
                         f"VoyageAI reranking failed with {error_module}.{error_type} "
                         f"(attempt {attempt + 1}/{self._retry_attempts}): {e}. "
@@ -658,7 +689,7 @@ class VoyageAIEmbeddingProvider:
                     await asyncio.sleep(delay)
                     continue
                 else:
-                    if is_network_error:
+                    if is_retryable:
                         logger.error(
                             f"VoyageAI reranking failed after {self._retry_attempts} attempts: {e}"
                         )

--- a/tests/unit/test_voyageai_provider.py
+++ b/tests/unit/test_voyageai_provider.py
@@ -23,9 +23,10 @@ import voyageai
 from chunkhound.core.config.embedding_config import validate_rerank_configuration
 from chunkhound.core.config.embedding_factory import EmbeddingProviderFactory
 from chunkhound.providers.embeddings.voyageai_provider import (
+    _CATEGORY_BACKOFFS,
     VoyageAIEmbeddingProvider,
+    _classify_voyageai_error,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -693,6 +694,229 @@ class TestUpstreamTimeoutRetry:
         ):
             with pytest.raises(RuntimeError, match="Embedding generation failed"):
                 await p._embed_single_batch_locked(["text"])
+
+        assert call_count == 1
+
+
+# ===========================================================================
+# 10b. Error classifier (shared between embed and rerank retry loops)
+# ===========================================================================
+
+
+# Stand-ins for VoyageAI SDK exception classes. The classifier matches on
+# ``type(e).__name__`` so the names here are what's significant, not the
+# inheritance graph.
+class _FakeRateLimitError(Exception):
+    pass
+
+
+class _FakeTryAgainError(Exception):
+    pass
+
+
+class _FakeServerError(Exception):
+    pass
+
+
+class _FakeServiceUnavailableError(Exception):
+    pass
+
+
+class _FakeAPIConnectionError(Exception):
+    pass
+
+
+class _FakeRemoteDisconnectedError(Exception):
+    pass
+
+
+class _FakeTimeoutError(Exception):
+    pass
+
+
+class TestErrorClassifier:
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            _FakeRateLimitError("429"),
+            _FakeTryAgainError("retry me"),
+            _FakeServerError("500"),
+            _FakeServiceUnavailableError("503"),
+            RuntimeError("rate limit exceeded for tier 1"),
+            RuntimeError("Voyage rate limit hit"),
+        ],
+    )
+    def test_rate_limit_category(self, exc):
+        assert _classify_voyageai_error(exc) == "rate_limit"
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            RuntimeError("HTTP 408 upstream request timeout"),
+            RuntimeError("Upstream Request Timeout"),
+            RuntimeError("upstream request timeout from proxy"),
+            RuntimeError("status 408 returned"),
+        ],
+    )
+    def test_upstream_timeout_category(self, exc):
+        assert _classify_voyageai_error(exc) == "upstream_timeout"
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            _FakeAPIConnectionError("dns lookup failed"),
+            ConnectionError("refused"),
+            _FakeRemoteDisconnectedError("conn closed"),
+            _FakeTimeoutError("socket timeout"),
+        ],
+    )
+    def test_network_category(self, exc):
+        assert _classify_voyageai_error(exc) == "network"
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            ValueError("bad input"),
+            TypeError("wrong arg shape"),
+            KeyError("missing field"),
+            RuntimeError("authentication failed"),
+        ],
+    )
+    def test_non_retryable_returns_none(self, exc):
+        assert _classify_voyageai_error(exc) is None
+
+    def test_rate_limit_takes_precedence_over_network_keywords(self):
+        # A RateLimitError whose message also contains a connection-keyword
+        # must classify as rate_limit, not network — order matters because
+        # rate-limited requests should back off longer than connection drops.
+        exc = _FakeRateLimitError("rate limit; connection reset by peer")
+        assert _classify_voyageai_error(exc) == "rate_limit"
+
+    def test_rate_limit_message_takes_precedence_over_408(self):
+        # If a generic RuntimeError carries both 'rate limit' and '408',
+        # rate_limit wins (longer backoff is the safer choice).
+        exc = RuntimeError("HTTP 408 rate limit applied")
+        assert _classify_voyageai_error(exc) == "rate_limit"
+
+
+class TestCategoryBackoffs:
+    def test_rate_limit_backoff_is_30s(self):
+        assert _CATEGORY_BACKOFFS["rate_limit"] == pytest.approx(30.0)
+
+    def test_upstream_timeout_backoff_is_10s(self):
+        assert _CATEGORY_BACKOFFS["upstream_timeout"] == pytest.approx(10.0)
+
+    def test_network_has_no_entry_so_caller_uses_self_retry_delay(self):
+        # The retry loops use ``_CATEGORY_BACKOFFS.get(category, self._retry_delay)``
+        # so 'network' intentionally has no entry — the per-instance retry_delay
+        # drives generic connection retries.
+        assert "network" not in _CATEGORY_BACKOFFS
+
+
+# ===========================================================================
+# 10c. Rerank SDK path retry behavior (must match embed path)
+# ===========================================================================
+
+
+class TestRerankSdkRetry:
+    """Rerank path goes through the same shared classifier as embed —
+    these tests pin the rerank-specific retry behavior so future drift is
+    caught by a failing test, not a production stack trace."""
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_error_retried_with_30s_base_delay(self):
+        p = _make_provider(api_key="test-key", retry_attempts=2, retry_delay=0.0)
+        call_count = 0
+
+        def fake_to_thread(fn, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise _FakeRateLimitError("429 rate limit")
+
+        with patch(
+            "chunkhound.providers.embeddings.voyageai_provider.asyncio.to_thread",
+            side_effect=fake_to_thread,
+        ):
+            with patch(
+                "chunkhound.providers.embeddings.voyageai_provider.asyncio.sleep",
+                new_callable=AsyncMock,
+            ) as mock_sleep:
+                with pytest.raises(RuntimeError, match="Reranking failed"):
+                    await p._rerank_via_sdk("q", ["d1", "d2"], top_k=None)
+
+        assert call_count == 2
+        # Rate-limit base delay = 30.0, attempt=0 → 30.0 * 2^0 = 30.0
+        assert mock_sleep.call_args_list[0].args[0] == pytest.approx(30.0)
+
+    @pytest.mark.asyncio
+    async def test_408_upstream_timeout_retried_in_rerank_path(self):
+        # Regression guard: prior to PR #249 the rerank path did not retry
+        # 408s at all. The shared classifier brings it in line with embed.
+        p = _make_provider(api_key="test-key", retry_attempts=2, retry_delay=0.0)
+        call_count = 0
+
+        def fake_to_thread(fn, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("HTTP 408 upstream request timeout")
+
+        with patch(
+            "chunkhound.providers.embeddings.voyageai_provider.asyncio.to_thread",
+            side_effect=fake_to_thread,
+        ):
+            with patch(
+                "chunkhound.providers.embeddings.voyageai_provider.asyncio.sleep",
+                new_callable=AsyncMock,
+            ) as mock_sleep:
+                with pytest.raises(RuntimeError, match="Reranking failed"):
+                    await p._rerank_via_sdk("q", ["d1"], top_k=None)
+
+        assert call_count == 2
+        # Upstream-timeout base delay = 10.0
+        assert mock_sleep.call_args_list[0].args[0] == pytest.approx(10.0)
+
+    @pytest.mark.asyncio
+    async def test_network_error_retried_with_instance_retry_delay(self):
+        # Network errors fall through _CATEGORY_BACKOFFS.get() to self._retry_delay
+        p = _make_provider(api_key="test-key", retry_attempts=2, retry_delay=0.5)
+        call_count = 0
+
+        def fake_to_thread(fn, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise ConnectionError("connection reset")
+
+        with patch(
+            "chunkhound.providers.embeddings.voyageai_provider.asyncio.to_thread",
+            side_effect=fake_to_thread,
+        ):
+            with patch(
+                "chunkhound.providers.embeddings.voyageai_provider.asyncio.sleep",
+                new_callable=AsyncMock,
+            ) as mock_sleep:
+                with pytest.raises(RuntimeError, match="Reranking failed"):
+                    await p._rerank_via_sdk("q", ["d1"], top_k=None)
+
+        assert call_count == 2
+        # Network base delay = self._retry_delay (0.5), attempt=0 → 0.5 * 2^0 = 0.5
+        assert mock_sleep.call_args_list[0].args[0] == pytest.approx(0.5)
+
+    @pytest.mark.asyncio
+    async def test_non_retryable_error_fails_immediately(self):
+        p = _make_provider(api_key="test-key", retry_attempts=3, retry_delay=0.0)
+        call_count = 0
+
+        def fake_to_thread(fn, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("bad input")
+
+        with patch(
+            "chunkhound.providers.embeddings.voyageai_provider.asyncio.to_thread",
+            side_effect=fake_to_thread,
+        ):
+            with pytest.raises(RuntimeError, match="Reranking failed"):
+                await p._rerank_via_sdk("q", ["d1"], top_k=None)
 
         assert call_count == 1
 


### PR DESCRIPTION
## Summary

`RateLimitError` (HTTP 429), `TryAgain`, `ServerError`, and `ServiceUnavailableError` from the VoyageAI SDK were classified as non-retryable because the error allowlist in `_embed_single_batch_locked` and `_rerank_via_sdk` only matched connection and timeout errors.

With 40 concurrent batches at ~96K tokens each, a burst of ~3.84M tokens can be sent in seconds, which exceeds the 3M TPM limit for `voyage-code-3`. Every batch that hit a 429 died permanently instead of backing off.

## Changes

- Added `RateLimitError`, `TryAgain`, `ServerError`, `ServiceUnavailableError`, and a `"rate limit"` string fallback to the retryable error classification
- Rate limit errors use a 30s base delay (doubling per attempt) to let the TPM window reset
- Applied the same fix to both the embed and rerank code paths

## Workaround (no code change)

Users hitting this today can reduce concurrency via env var:

```bash
export CHUNKHOUND_EMBEDDING__MAX_CONCURRENT_BATCHES="5"
```

This keeps the token burst under the TPM limit but does not make 429s retryable.

## Test plan

- [x] `uv run pytest tests/test_smoke.py -v -n auto` (17 passed)
