### PR TITLE
fix: fix to item #87 - can't reindex multiple repos in one workspace directory

### DIFF
--- a/chunkhound/services/indexing_coordinator.py
+++ b/chunkhound/services/indexing_coordinator.py
@@ -2853,12 +2853,29 @@ class IndexingCoordinator(BaseService):
                 for file_path in current_files
             }
 
-            # Get all files in database (stored as relative paths)
-            query = """
-                SELECT id, path
-                FROM files
-            """
-            db_files = self._db.execute_query(query, [])
+            # Compute the directory prefix relative to base_dir so the DB query
+            # is scoped to only files under the directory being indexed.
+            # This prevents re-indexing a sub-directory from deleting other
+            # repos' data stored under sibling prefixes.
+            try:
+                dir_prefix = directory.resolve().relative_to(base_dir.resolve()).as_posix()
+            except ValueError:
+                dir_prefix = ""
+
+            # Get only files under the directory being indexed (stored as relative paths)
+            if dir_prefix and dir_prefix != ".":
+                query = """
+                    SELECT id, path
+                    FROM files
+                    WHERE path = ? OR path LIKE ?
+                """
+                db_files = self._db.execute_query(query, [dir_prefix, dir_prefix + "/%"])
+            else:
+                query = """
+                    SELECT id, path
+                    FROM files
+                """
+                db_files = self._db.execute_query(query, [])
 
             # Find orphaned files (in DB but not on disk or excluded by patterns)
             orphaned_files = []

--- a/chunkhound/services/indexing_coordinator.py
+++ b/chunkhound/services/indexing_coordinator.py
@@ -42,6 +42,7 @@ from chunkhound.parsers.chunk_splitter import (
     universal_to_chunk,
 )
 from chunkhound.parsers.universal_parser import UniversalParser
+from chunkhound.providers.database.like_utils import escape_like_pattern
 
 # File pattern utilities for directory discovery
 from chunkhound.utils.file_patterns import (
@@ -2858,18 +2859,19 @@ class IndexingCoordinator(BaseService):
             # This prevents re-indexing a sub-directory from deleting other
             # repos' data stored under sibling prefixes.
             try:
-                dir_prefix = directory.resolve().relative_to(base_dir.resolve()).as_posix()
+                dir_prefix = get_relative_path_safe(directory, base_dir).as_posix()
             except ValueError:
                 dir_prefix = ""
 
             # Get only files under the directory being indexed (stored as relative paths)
             if dir_prefix and dir_prefix != ".":
+                escaped_prefix = escape_like_pattern(dir_prefix)
                 query = """
                     SELECT id, path
                     FROM files
-                    WHERE path = ? OR path LIKE ?
+                    WHERE path = ? OR path LIKE ? ESCAPE '\\'
                 """
-                db_files = self._db.execute_query(query, [dir_prefix, dir_prefix + "/%"])
+                db_files = self._db.execute_query(query, [dir_prefix, escaped_prefix + "/%"])
             else:
                 query = """
                     SELECT id, path

--- a/tests/integration/test_multi_repo_orphan_cleanup.py
+++ b/tests/integration/test_multi_repo_orphan_cleanup.py
@@ -1,0 +1,102 @@
+"""Regression test for ALGINF-5452 / GitHub #87.
+
+Bug: re-indexing a sub-directory of a multi-repo workspace deletes all other
+repos' data from the database because _cleanup_orphaned_files has no WHERE
+clause scoped to the directory being indexed.
+
+Scenario:
+  /workspace/
+    repo1/src/a.py
+    repo2/lib/b.py
+
+  1. Index /workspace  → both files in DB
+  2. Re-index /workspace/repo1 → repo2/lib/b.py must NOT be deleted
+"""
+
+import os
+import subprocess
+
+import pytest
+from pathlib import Path
+
+from chunkhound.core.config.indexing_config import IndexingConfig
+from chunkhound.core.types.common import Language
+from chunkhound.parsers.parser_factory import create_parser_for_language
+from chunkhound.providers.database.duckdb_provider import DuckDBProvider
+from chunkhound.services.directory_indexing_service import DirectoryIndexingService
+from chunkhound.services.indexing_coordinator import IndexingCoordinator
+
+
+class _DummyConfig:
+    def __init__(self) -> None:
+        self.indexing = IndexingConfig()
+
+
+def _make_coordinator(db: DuckDBProvider, base_dir: Path) -> IndexingCoordinator:
+    parser = create_parser_for_language(Language.PYTHON)
+    return IndexingCoordinator(
+        db,
+        base_dir,
+        None,
+        {Language.PYTHON: parser},
+        None,
+        None,
+    )
+
+
+def _db_paths(db: DuckDBProvider) -> set[str]:
+    rows = db.execute_query("SELECT path FROM files ORDER BY path", [])
+    return {r["path"] for r in rows}
+
+
+@pytest.mark.skipif(
+    os.environ.get("CHUNKHOUND_ALLOW_PROCESSPOOL", "0") != "1",
+    reason="Requires ProcessPool-friendly environment (SemLock).",
+)
+@pytest.mark.asyncio
+async def test_reindex_subrepo_preserves_other_repos(tmp_path: Path):
+    """Re-indexing repo1 must not delete repo2's data from the database."""
+    workspace = tmp_path / "workspace"
+
+    repo1 = workspace / "repo1"
+    repo2 = workspace / "repo2"
+    (repo1 / "src").mkdir(parents=True)
+    (repo2 / "lib").mkdir(parents=True)
+
+    file_a = repo1 / "src" / "a.py"
+    file_b = repo2 / "lib" / "b.py"
+    file_a.write_text("def foo(): pass\n")
+    file_b.write_text("def bar(): pass\n")
+
+    db = DuckDBProvider(":memory:", base_directory=workspace)
+    db.connect()
+
+    # --- Step 1: index the full workspace ---
+    coordinator = _make_coordinator(db, workspace)
+    service = DirectoryIndexingService(
+        indexing_coordinator=coordinator,
+        config=_DummyConfig(),
+    )
+    await service.process_directory(workspace, no_embeddings=True)
+
+    after_full = _db_paths(db)
+    assert "repo1/src/a.py" in after_full, "repo1 file missing after full index"
+    assert "repo2/lib/b.py" in after_full, "repo2 file missing after full index"
+
+    # --- Step 2: re-index only repo1 ---
+    coordinator2 = _make_coordinator(db, workspace)
+    service2 = DirectoryIndexingService(
+        indexing_coordinator=coordinator2,
+        config=_DummyConfig(),
+    )
+    await service2.process_directory(repo1, no_embeddings=True)
+
+    after_reindex = _db_paths(db)
+
+    # repo2 data must survive the repo1-only re-index
+    assert "repo2/lib/b.py" in after_reindex, (
+        "BUG: repo2/lib/b.py was deleted from DB after re-indexing only repo1. "
+        "The orphan cleanup is not scoped to the directory being indexed."
+    )
+    # repo1 data must still be present
+    assert "repo1/src/a.py" in after_reindex, "repo1 file missing after re-index"

--- a/tests/integration/test_multi_repo_orphan_cleanup.py
+++ b/tests/integration/test_multi_repo_orphan_cleanup.py
@@ -14,7 +14,6 @@ Scenario:
 """
 
 import os
-import subprocess
 
 import pytest
 from pathlib import Path


### PR DESCRIPTION
**Note**: This PR was generated by an AI agent. If you'd like to talk with other humans, drop by our [Discord](https://discord.gg/BAepHEXXnX)!

---

Fixes a silent data loss bug in multi-repo workspaces (closes #87). When ChunkHound re-indexed a sub-directory of a workspace that had previously been fully indexed, `_cleanup_orphaned_files` would query **all** files from the database with no scope, then delete anything not found in the current scan. Re-indexing `repo1` would therefore wipe `repo2`'s data completely — no warning, no error, just gone.

The fix is a targeted scope on the cleanup query: compute the directory's relative prefix against `_base_directory` and add `WHERE path = ? OR path LIKE ?||'/%'` when indexing a sub-directory. When the workspace root itself is indexed the query stays unscoped, so existing behaviour is unchanged. This covers the primary failure mode — the MCP daemon performing background re-scans of individual repos within a shared workspace DB.

A regression test (`test_reindex_subrepo_preserves_other_repos`) pins the fix: full workspace index → verify both repos in DB → re-index only `repo1` → assert `repo2` data survives.

---

# PR: fix multi-repo orphan cleanup scope (closes #87)

## Root Cause

`IndexingCoordinator._cleanup_orphaned_files` (`indexing_coordinator.py:2856`) ran:

```sql
SELECT id, path FROM files
```

No `WHERE` clause. It then compared every DB path against `current_file_paths` (files found in the current scan). Any DB path not in that set was deleted. When `process_directory(repo1)` is called with `_base_directory = /workspace`, `current_file_paths` contains only `repo1/**` paths — so all `repo2/**` paths are treated as orphans and permanently deleted via `delete_file_completely`.

## Changed File

### `chunkhound/services/indexing_coordinator.py`

**Location:** `_cleanup_orphaned_files` method (~line 2848)

**Before:**
```python
query = """
    SELECT id, path
    FROM files
"""
db_files = self._db.execute_query(query, [])
```

**After:**
```python
try:
    dir_prefix = directory.resolve().relative_to(base_dir.resolve()).as_posix()
except ValueError:
    dir_prefix = ""

if dir_prefix and dir_prefix != ".":
    query = """
        SELECT id, path FROM files
        WHERE path = ? OR path LIKE ?
    """
    db_files = self._db.execute_query(query, [dir_prefix, dir_prefix + "/%"])
else:
    query = """SELECT id, path FROM files"""
    db_files = self._db.execute_query(query, [])
```

**Logic:** `dir_prefix` is the relative path of `directory` from `_base_directory`. If it's a real sub-path (not `.` or empty), the SELECT is scoped to that subtree. When indexing the workspace root, `dir_prefix == "."` → falls through to the original unscoped query (no regression).

## Scope of Fix

Covers the case where `_base_directory` is the workspace root and `process_directory` is called with a sub-directory — the primary pattern used by the MCP daemon for background re-scans.

**Not covered:** CLI invocations of `chunkhound index /workspace/repo1 --db /workspace/.chunkhound` where `config.target_dir` (and therefore `_base_directory`) is set to the sub-repo. In that case `directory == base_dir`, so `dir_prefix == "."` and the query is unscoped. This is a path-space mismatch (DB paths were computed relative to the workspace, new paths relative to the sub-repo) — a separate issue outside this bug's scope.

## New Test

**`tests/integration/test_multi_repo_orphan_cleanup.py`**

- Uses in-memory DuckDB with `base_directory = workspace`
- Full index of `workspace/` → asserts `repo1/src/a.py` and `repo2/lib/b.py` both present
- Re-index of `workspace/repo1` via `process_directory(repo1)` with the **same coordinator base** → asserts `repo2/lib/b.py` still present
- Gated on `CHUNKHOUND_ALLOW_PROCESSPOOL=1` (consistent with existing integration tests)

## Breaking Changes

None. The unscoped path (`dir_prefix == "."`) retains identical SQL to the original.


Attached is an agent optimized description of the changes in this PR - 


Closes #87