### PR TITLE
fix: harden realtime indexing and provider-scoped cleanup

### DIFF
--- a/chunkhound/core/utils/path_utils.py
+++ b/chunkhound/core/utils/path_utils.py
@@ -110,3 +110,20 @@ def normalize_path_for_lookup(
             f"Path {input_path} is not under base directory {base_dir}. "
             f"This indicates a configuration or indexing issue."
         )
+
+
+def directory_prefix_for_relative_path(relative_path: str | Path) -> str:
+    """Return a normalized subtree prefix for stored relative file paths."""
+    normalized = Path(relative_path).as_posix()
+    if normalized in {"", "."}:
+        return ""
+    return normalized.rstrip("/") + "/"
+
+
+def path_is_within_relative_directory(path: str, directory: str | Path) -> bool:
+    """Check whether a stored relative path is inside the given relative directory."""
+    normalized_path = Path(path).as_posix()
+    prefix = directory_prefix_for_relative_path(directory)
+    if not prefix:
+        return True
+    return normalized_path.startswith(prefix)

--- a/chunkhound/core/utils/path_utils.py
+++ b/chunkhound/core/utils/path_utils.py
@@ -3,6 +3,27 @@
 from pathlib import Path
 
 
+def canonicalize_base_directory(base_dir: Path) -> Path:
+    """Return a stable project base directory for path storage and lookup.
+
+    When callers index a subdirectory inside the same repository from different
+    working directories, storing file paths relative to the raw input directory
+    produces duplicate logical file entries. This helper walks upward from the
+    requested base and prefers a project marker directory when one exists.
+    """
+    resolved_base = base_dir.resolve()
+
+    for candidate in (resolved_base, *resolved_base.parents):
+        if (candidate / ".chunkhound.json").exists():
+            return candidate
+        if (candidate / ".chunkhound" / "db").exists():
+            return candidate
+        if (candidate / ".git").exists():
+            return candidate
+
+    return resolved_base
+
+
 def resolve_path_for_relative(path: Path, base_dir: Path) -> tuple[Path, Path]:
     """Resolve path and base_dir for relative_to() computation.
 
@@ -16,7 +37,7 @@ def resolve_path_for_relative(path: Path, base_dir: Path) -> tuple[Path, Path]:
     Returns:
         Tuple of (path_to_use, resolved_base_dir) ready for relative_to()
     """
-    resolved_base = base_dir.resolve()
+    resolved_base = canonicalize_base_directory(base_dir)
     if path.is_symlink():
         return path, resolved_base
     return path.resolve(), resolved_base
@@ -43,7 +64,7 @@ def get_relative_path_safe(path: Path, base_dir: Path) -> Path:
         return path_to_use.relative_to(resolved_base)
     except ValueError:
         # Fallback for edge cases (e.g., symlink with different base resolution)
-        return path.relative_to(base_dir)
+        return path.relative_to(canonicalize_base_directory(base_dir))
 
 
 def normalize_path_for_lookup(

--- a/chunkhound/providers/database/duckdb/connection_manager.py
+++ b/chunkhound/providers/database/duckdb/connection_manager.py
@@ -178,8 +178,13 @@ class DuckDBConnectionManager:
             test_conn.execute("SELECT 1").fetchone()
             logger.debug("WAL file validation passed")
         except Exception as e:
-            logger.warning(f"WAL validation failed ({e}), cleaning up WAL file")
-            self._handle_wal_corruption()
+            if "Could not set lock" in str(e):
+                logger.warning(
+                    f"WAL validation hit lock contention ({e}), leaving WAL intact"
+                )
+            else:
+                logger.warning(f"WAL validation failed ({e}), cleaning up WAL file")
+                self._handle_wal_corruption()
         finally:
             # Ensure temporary validation connection is always closed
             if test_conn is not None:

--- a/chunkhound/providers/database/duckdb_provider.py
+++ b/chunkhound/providers/database/duckdb_provider.py
@@ -317,6 +317,7 @@ class DuckDBProvider(SerialDatabaseProvider):
         table_name = f"embeddings_{dims}"
 
         if self._executor_table_exists(conn, state, table_name):
+            self._executor_ensure_embedding_uniqueness(conn, state, table_name)
             return table_name
 
         logger.info(f"Creating embedding table for {dims} dimensions: {table_name}")
@@ -331,7 +332,8 @@ class DuckDBProvider(SerialDatabaseProvider):
                     model TEXT NOT NULL,
                     embedding FLOAT[{dims}],
                     dims INTEGER NOT NULL DEFAULT {dims},
-                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE (chunk_id, provider, model)
                 )
             """)
 
@@ -357,11 +359,37 @@ class DuckDBProvider(SerialDatabaseProvider):
                 f"Created {table_name} with HNSW index {hnsw_index_name} "
                 "and regular indexes"
             )
+            self._executor_ensure_embedding_uniqueness(conn, state, table_name)
             return table_name
 
         except Exception as e:
             logger.error(f"Failed to create embedding table for {dims} dimensions: {e}")
             raise
+
+    def _executor_ensure_embedding_uniqueness(
+        self, conn: Any, state: dict[str, Any], table_name: str
+    ) -> None:
+        """Deduplicate and enforce a unique embedding key for existing tables."""
+        conn.execute(f"""
+            DELETE FROM {table_name}
+            WHERE id IN (
+                SELECT id
+                FROM (
+                    SELECT
+                        id,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY chunk_id, provider, model
+                            ORDER BY id
+                        ) AS row_num
+                    FROM {table_name}
+                ) ranked
+                WHERE row_num > 1
+            )
+        """)
+        conn.execute(
+            f"CREATE UNIQUE INDEX IF NOT EXISTS idx_{table_name}_chunk_provider_model "
+            f"ON {table_name}(chunk_id, provider, model)"
+        )
 
     def _maybe_checkpoint(self, force: bool = False) -> None:
         """Perform checkpoint if needed - delegate to connection manager."""
@@ -483,7 +511,8 @@ class DuckDBProvider(SerialDatabaseProvider):
                     model TEXT NOT NULL,
                     embedding FLOAT[1536],
                     dims INTEGER NOT NULL DEFAULT 1536,
-                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE (chunk_id, provider, model)
                 )
             """)
 
@@ -509,6 +538,9 @@ class DuckDBProvider(SerialDatabaseProvider):
 
             # Handle schema migrations for existing databases
             self._executor_migrate_schema(conn, state)
+            self._executor_ensure_embedding_uniqueness(
+                conn, state, "embeddings_1536"
+            )
 
             # Track schema version
             current_version = self._get_schema_version(conn)
@@ -613,6 +645,9 @@ class DuckDBProvider(SerialDatabaseProvider):
 
             # Add metadata column if it doesn't exist (for databases without size/signature migration)
             conn.execute("ALTER TABLE chunks ADD COLUMN IF NOT EXISTS metadata TEXT")
+
+            for table_name in self._executor_get_all_embedding_tables(conn, state):
+                self._executor_ensure_embedding_uniqueness(conn, state, table_name)
 
         except Exception as e:
             logger.error(f"Failed to migrate schema: {e}")
@@ -1722,7 +1757,7 @@ class DuckDBProvider(SerialDatabaseProvider):
                     batch = batch_data[i : i + batch_size]
                     conn.executemany(
                         f"""
-                        INSERT INTO {table_name} (chunk_id, provider, model, embedding, dims)
+                        INSERT OR IGNORE INTO {table_name} (chunk_id, provider, model, embedding, dims)
                         VALUES (?, ?, ?, ?, ?)
                     """,
                         batch,
@@ -1732,7 +1767,7 @@ class DuckDBProvider(SerialDatabaseProvider):
                 # Insert all at once
                 conn.executemany(
                     f"""
-                    INSERT INTO {table_name} (chunk_id, provider, model, embedding, dims)
+                    INSERT OR IGNORE INTO {table_name} (chunk_id, provider, model, embedding, dims)
                     VALUES (?, ?, ?, ?, ?)
                 """,
                     batch_data,

--- a/chunkhound/providers/database/serial_database_provider.py
+++ b/chunkhound/providers/database/serial_database_provider.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from chunkhound.core.models import Chunk, File
+from chunkhound.core.utils.path_utils import canonicalize_base_directory
 from chunkhound.embeddings import EmbeddingManager
 from chunkhound.file_discovery_cache import FileDiscoveryCache
 from chunkhound.providers.database.serial_executor import SerialDatabaseExecutor
@@ -64,7 +65,7 @@ class SerialDatabaseProvider(ABC):
         self._file_discovery_cache = FileDiscoveryCache()
 
         # Base directory for path normalization (immutable after initialization)
-        self._base_directory: Path = base_directory
+        self._base_directory: Path = canonicalize_base_directory(base_directory)
 
     @abstractmethod
     def _create_connection(self) -> Any:

--- a/chunkhound/services/embedding_service.py
+++ b/chunkhound/services/embedding_service.py
@@ -113,8 +113,9 @@ class EmbeddingService(BaseService):
             progress.advance(embed_task, batch_size)
             # Calculate and display speed
             task_obj = progress.tasks[embed_task]
-            if task_obj.elapsed and task_obj.elapsed > 0:
-                speed = processed_count / task_obj.elapsed
+            elapsed = getattr(task_obj, "elapsed", None)
+            if elapsed and elapsed > 0:
+                speed = processed_count / elapsed
                 progress.update(embed_task, speed=f"{speed:.1f} chunks/s")
         except (AttributeError, IndexError, TypeError, KeyError) as e:
             # Progress display is non-critical, but log for debugging

--- a/chunkhound/services/indexing_coordinator.py
+++ b/chunkhound/services/indexing_coordinator.py
@@ -34,11 +34,12 @@ from chunkhound.core.types.common import FilePath, Language
 from chunkhound.core.utils import estimate_tokens_chunking
 from chunkhound.core.utils.path_utils import (
     canonicalize_base_directory,
+    directory_prefix_for_relative_path,
     get_relative_path_safe,
+    path_is_within_relative_directory,
 )
 from chunkhound.interfaces.database_provider import DatabaseProvider
 from chunkhound.interfaces.embedding_provider import EmbeddingProvider
-from chunkhound.providers.database.like_utils import escape_like_pattern
 from chunkhound.parsers.chunk_splitter import (
     CASTConfig,
     ChunkMetrics,
@@ -2887,19 +2888,15 @@ class IndexingCoordinator(BaseService):
             }
 
             directory_prefix_path = self._get_relative_path(directory)
-            directory_prefix = (
-                ""
-                if str(directory_prefix_path) in {"", "."}
-                else directory_prefix_path.as_posix().rstrip("/") + "/"
-            )
-
-            escaped_prefix = escape_like_pattern(directory_prefix)
-            query = """
-                SELECT id, path
-                FROM files
-                WHERE path LIKE ? ESCAPE '\\'
-            """
-            db_files = self._db.execute_query(query, [f"{escaped_prefix}%"])
+            directory_prefix = directory_prefix_for_relative_path(directory_prefix_path)
+            db_files = self._db.execute_query("SELECT path FROM files")
+            scoped_db_files = [
+                db_file
+                for db_file in db_files
+                if path_is_within_relative_directory(
+                    str(db_file.get("path", "")), directory_prefix
+                )
+            ]
 
             # Find orphaned files (in DB but not on disk or excluded by patterns)
             orphaned_files = []
@@ -2922,7 +2919,7 @@ class IndexingCoordinator(BaseService):
             else:
                 patterns_to_check = exclude_patterns
 
-            for db_file in db_files:
+            for db_file in scoped_db_files:
                 file_path = db_file["path"]
 
                 # Check if file should be excluded based on current patterns

--- a/chunkhound/services/indexing_coordinator.py
+++ b/chunkhound/services/indexing_coordinator.py
@@ -17,6 +17,7 @@ import asyncio
 import math
 import multiprocessing
 import os
+from collections import OrderedDict
 from concurrent.futures import ProcessPoolExecutor
 from fnmatch import fnmatch
 from pathlib import Path
@@ -31,9 +32,13 @@ from chunkhound.core.exceptions import DiskUsageLimitExceededError
 from chunkhound.core.models import Chunk, File
 from chunkhound.core.types.common import FilePath, Language
 from chunkhound.core.utils import estimate_tokens_chunking
-from chunkhound.core.utils.path_utils import get_relative_path_safe
+from chunkhound.core.utils.path_utils import (
+    canonicalize_base_directory,
+    get_relative_path_safe,
+)
 from chunkhound.interfaces.database_provider import DatabaseProvider
 from chunkhound.interfaces.embedding_provider import EmbeddingProvider
+from chunkhound.providers.database.like_utils import escape_like_pattern
 from chunkhound.parsers.chunk_splitter import (
     CASTConfig,
     ChunkMetrics,
@@ -213,12 +218,12 @@ class IndexingCoordinator(BaseService):
         # CRITICAL: Prevents race conditions during concurrent file processing
         # PATTERN: Lazy lock creation within event loop context
         # WHY: asyncio.Lock() must be created inside the event loop
-        self._file_locks: dict[str, asyncio.Lock] = {}
+        self._file_locks: OrderedDict[str, asyncio.Lock] = OrderedDict()
+        self._file_lock_cache_size = 2048
         self._locks_lock = None  # Will be initialized when first needed
 
         # Base directory for path normalization (immutable after initialization)
-        # Store raw path - will resolve at usage time for consistent symlink handling
-        self._base_directory: Path = base_directory
+        self._base_directory: Path = canonicalize_base_directory(base_directory)
 
     def _get_relative_path(self, file_path: Path) -> Path:
         """Get relative path, preserving symlink logical paths.
@@ -419,6 +424,28 @@ class IndexingCoordinator(BaseService):
         est = max(1000, min(int(est), 20000))
         return est
 
+    def _prune_file_locks(self) -> None:
+        """Bound the per-file lock cache to recently used, currently active entries."""
+        while len(self._file_locks) > self._file_lock_cache_size:
+            unlocked_pruned = False
+
+            for _ in range(len(self._file_locks)):
+                oldest_key = next(iter(self._file_locks), None)
+                if oldest_key is None:
+                    return
+
+                oldest_lock = self._file_locks[oldest_key]
+                if oldest_lock.locked():
+                    self._file_locks.move_to_end(oldest_key)
+                    continue
+
+                self._file_locks.popitem(last=False)
+                unlocked_pruned = True
+                break
+
+            if not unlocked_pruned:
+                return
+
     async def _get_file_lock(self, file_path: Path) -> asyncio.Lock:
         """Get or create a lock for the given file path.
 
@@ -441,10 +468,15 @@ class IndexingCoordinator(BaseService):
 
         # Use the locks lock to ensure thread-safe access to the locks dictionary
         async with self._locks_lock:
-            if file_key not in self._file_locks:
-                # Create the lock within the event loop context
-                self._file_locks[file_key] = asyncio.Lock()
-            return self._file_locks[file_key]
+            lock = self._file_locks.get(file_key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._file_locks[file_key] = lock
+            else:
+                self._file_locks.move_to_end(file_key)
+
+            self._prune_file_locks()
+            return lock
 
     def _cleanup_file_lock(self, file_path: Path) -> None:
         """Remove lock for a file that no longer exists.
@@ -457,6 +489,8 @@ class IndexingCoordinator(BaseService):
         if file_key in self._file_locks:
             del self._file_locks[file_key]
             logger.debug(f"Cleaned up lock for deleted file: {file_key}")
+        else:
+            self._prune_file_locks()
 
     async def process_file(
         self, file_path: Path, skip_embeddings: bool = False
@@ -2847,18 +2881,25 @@ class IndexingCoordinator(BaseService):
         """
         try:
             # Create set of relative paths for fast lookup
-            base_dir = self._base_directory
             current_file_paths = {
-                file_path.relative_to(base_dir).as_posix()
+                self._get_relative_path(file_path).as_posix()
                 for file_path in current_files
             }
 
-            # Get all files in database (stored as relative paths)
+            directory_prefix_path = self._get_relative_path(directory)
+            directory_prefix = (
+                ""
+                if str(directory_prefix_path) in {"", "."}
+                else directory_prefix_path.as_posix().rstrip("/") + "/"
+            )
+
+            escaped_prefix = escape_like_pattern(directory_prefix)
             query = """
                 SELECT id, path
                 FROM files
+                WHERE path LIKE ? ESCAPE '\\'
             """
-            db_files = self._db.execute_query(query, [])
+            db_files = self._db.execute_query(query, [f"{escaped_prefix}%"])
 
             # Find orphaned files (in DB but not on disk or excluded by patterns)
             orphaned_files = []

--- a/chunkhound/services/realtime_indexing_service.py
+++ b/chunkhound/services/realtime_indexing_service.py
@@ -415,6 +415,7 @@ class RealtimeIndexingService:
                 logger.debug("Watchdog setup aborted during shutdown/timeout")
                 return
             logger.warning(f"Watchdog setup failed: {e} - falling back to polling")
+            await self._stop_watchdog_observer()
             await self._start_polling_fallback(watch_path)
             self._debug("watchdog failed; switched to polling")
 

--- a/chunkhound/services/realtime_indexing_service.py
+++ b/chunkhound/services/realtime_indexing_service.py
@@ -13,6 +13,7 @@ Architecture:
 
 import asyncio
 import gc
+import threading
 import time
 from collections.abc import Callable, Iterator
 from pathlib import Path
@@ -23,7 +24,9 @@ from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 from chunkhound.core.config.config import Config
+from chunkhound.core.utils.path_utils import normalize_path_for_lookup
 from chunkhound.database_factory import DatabaseServices
+from chunkhound.providers.database.like_utils import escape_like_pattern
 from chunkhound.utils.windows_constants import IS_WINDOWS
 
 
@@ -264,6 +267,9 @@ class RealtimeIndexingService:
         self.process_task: asyncio.Task | None = None
         self.event_consumer_task: asyncio.Task | None = None
         self._polling_task: asyncio.Task | None = None
+        self._watchdog_setup_task: asyncio.Task | None = None
+        self._watchdog_stop_event = threading.Event()
+        self._using_polling = False
 
         # Directory watch management for progressive monitoring
         self.watched_directories: set[str] = set()  # Track watched dirs
@@ -308,6 +314,10 @@ class RealtimeIndexingService:
 
         # Store the watch path
         self.watch_path = watch_path
+        self.monitoring_ready.clear()
+        self._monitoring_ready_time = None
+        self._using_polling = False
+        self._watchdog_stop_event.clear()
 
         loop = asyncio.get_running_loop()
 
@@ -325,28 +335,21 @@ class RealtimeIndexingService:
         if monitoring_ok:
             self._debug("monitoring ready")
         else:
-            self._debug("monitoring timeout; continuing")
+            logger.warning(
+                "Watchdog setup timed out before readiness; stopping watchdog startup"
+                " and switching to polling"
+            )
+            self._debug("monitoring timeout; switching to polling")
+            await self._stop_watchdog_observer()
+            await self._start_polling_fallback(watch_path)
 
     async def stop(self) -> None:
         """Stop the service gracefully."""
         logger.debug("Stopping real-time indexing service")
         self._debug("stopping service")
 
-        # Cancel watchdog setup if still running
-        if hasattr(self, "_watchdog_setup_task") and self._watchdog_setup_task:
-            self._watchdog_setup_task.cancel()
-            try:
-                await self._watchdog_setup_task
-            except asyncio.CancelledError:
-                pass
-
-        # Stop filesystem observer
-        if self.observer:
-            self.observer.stop()
-            loop = asyncio.get_running_loop()
-            await loop.run_in_executor(None, self.observer.join, 1.0)
-            if self.observer.is_alive():
-                logger.warning("Observer thread did not exit within timeout")
+        self._watchdog_stop_event.set()
+        await self._stop_watchdog_observer()
 
         # Cancel event consumer task
         if self.event_consumer_task:
@@ -392,11 +395,7 @@ class RealtimeIndexingService:
         # Skip watchdog entirely if force_polling is enabled (e.g., Windows CI)
         if self._force_polling:
             logger.info(f"Polling mode forced for {watch_path}")
-            self._using_polling = True
-            self._polling_task = asyncio.create_task(self._polling_monitor(watch_path))
-            await asyncio.sleep(0.5)
-            self._monitoring_ready_time = time.time()
-            self.monitoring_ready.set()
+            await self._start_polling_fallback(watch_path)
             self._debug("force_polling enabled; using polling mode")
             return
 
@@ -404,18 +403,61 @@ class RealtimeIndexingService:
             # No asyncio-level timeout: _start_fs_monitor has its own deadline,
             # and asyncio.wait_for cannot interrupt running executor threads.
             await loop.run_in_executor(None, self._start_fs_monitor, watch_path, loop)
+            if self._watchdog_stop_event.is_set():
+                logger.debug("Watchdog startup aborted before readiness")
+                return
             logger.debug("Watchdog setup completed successfully (recursive mode)")
             self._debug("watchdog setup complete (recursive)")
             self._monitoring_ready_time = time.time()
             self.monitoring_ready.set()
         except Exception as e:
+            if self._watchdog_stop_event.is_set():
+                logger.debug("Watchdog setup aborted during shutdown/timeout")
+                return
             logger.warning(f"Watchdog setup failed: {e} - falling back to polling")
-            self._using_polling = True
-            self._polling_task = asyncio.create_task(self._polling_monitor(watch_path))
-            await asyncio.sleep(0.5)
-            self._monitoring_ready_time = time.time()
-            self.monitoring_ready.set()
+            await self._start_polling_fallback(watch_path)
             self._debug("watchdog failed; switched to polling")
+
+    async def _start_polling_fallback(self, watch_path: Path) -> None:
+        """Start polling mode once, after watchdog has been ruled out."""
+        if self._polling_task is not None and not self._polling_task.done():
+            self._using_polling = True
+            if not self.monitoring_ready.is_set():
+                self._monitoring_ready_time = time.time()
+                self.monitoring_ready.set()
+            return
+
+        self._using_polling = True
+        self._polling_task = asyncio.create_task(self._polling_monitor(watch_path))
+        await asyncio.sleep(0.5)
+        self._monitoring_ready_time = time.time()
+        self.monitoring_ready.set()
+
+    async def _stop_watchdog_observer(self) -> None:
+        """Stop watchdog setup/observer before switching modes or shutting down."""
+        self._watchdog_stop_event.set()
+
+        watchdog_task = self._watchdog_setup_task
+        if watchdog_task is not None:
+            try:
+                await asyncio.wait_for(asyncio.shield(watchdog_task), timeout=2.0)
+            except asyncio.TimeoutError:
+                logger.warning("Watchdog setup task did not exit within timeout")
+            except Exception:
+                pass
+
+        observer = self.observer
+        self.observer = None
+        self.event_handler = None
+
+        if observer is None:
+            return
+
+        observer.stop()
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, observer.join, 1.0)
+        if observer.is_alive():
+            logger.warning("Observer thread did not exit within timeout")
 
     def _start_fs_monitor(
         self, watch_path: Path, loop: asyncio.AbstractEventLoop
@@ -424,6 +466,9 @@ class RealtimeIndexingService:
         # Deadline covers the entire setup (schedule + start + thread alive check).
         # On Windows, observer thread startup can be noticeably slower.
         deadline = time.time() + (5.0 if IS_WINDOWS else 1.0)
+
+        if self._watchdog_stop_event.is_set():
+            return
 
         self.event_handler = SimpleEventHandler(
             self.event_queue, self.config, loop, root_path=watch_path
@@ -438,10 +483,23 @@ class RealtimeIndexingService:
             recursive=True,  # Use recursive for complete event coverage
         )
         self.watched_directories.add(str(watch_path))
+
+        if self._watchdog_stop_event.is_set():
+            return
+
         self.observer.start()
 
-        while not self.observer.is_alive() and time.time() < deadline:
+        while (
+            not self.observer.is_alive()
+            and time.time() < deadline
+            and not self._watchdog_stop_event.is_set()
+        ):
             time.sleep(0.01)
+
+        if self._watchdog_stop_event.is_set():
+            self.observer.stop()
+            self.observer.join(timeout=1.0)
+            return
 
         if self.observer.is_alive():
             logger.debug(f"Started recursive filesystem monitoring for {watch_path}")
@@ -492,12 +550,6 @@ class RealtimeIndexingService:
                                     )
                                 if files_checked % 100 == 0:
                                     await asyncio.sleep(0)
-                                    if files_checked > 5000:
-                                        logger.warning(
-                                            f"Polling checked {files_checked} files,"
-                                            " skipping rest",
-                                        )
-                                        break
                             except (OSError, PermissionError):
                                 continue
                     finally:
@@ -715,16 +767,22 @@ class RealtimeIndexingService:
     async def _cleanup_deleted_directory(self, dir_path: str) -> None:
         """Clean up database entries for files in a deleted directory."""
         try:
-            # Get all files that were in this directory from database
-            # Use the provider's search capability to find files with this path prefix
-            search_results, _ = await self.services.provider.search_regex_async(
-                pattern=f"^{dir_path}/.*",
-                page_size=1000,  # Large page to get all matches
+            base_dir = self.watch_path or self.config.target_dir
+            relative_dir = normalize_path_for_lookup(dir_path, base_dir)
+            directory_prefix = (
+                ""
+                if relative_dir in {"", "."}
+                else relative_dir.rstrip("/") + "/"
+            )
+            escaped_prefix = escape_like_pattern(directory_prefix)
+            search_results = self.services.provider.execute_query(
+                "SELECT path FROM files WHERE path LIKE ? ESCAPE '\\'",
+                [f"{escaped_prefix}%"],
             )
 
             # Delete each file found in the directory
             for result in search_results:
-                file_path = result.get("file_path", result.get("path", ""))
+                file_path = result.get("path", "")
                 if file_path:
                     logger.debug(f"Cleaning up deleted file: {file_path}")
                     await self.services.provider.delete_file_completely_async(file_path)
@@ -853,7 +911,7 @@ class RealtimeIndexingService:
         monitoring_active = False
         if self.observer and self.observer.is_alive():
             monitoring_active = True
-        elif hasattr(self, "_using_polling"):
+        elif self._using_polling:
             # If we're using polling mode, consider it "alive"
             monitoring_active = True
 

--- a/chunkhound/services/realtime_indexing_service.py
+++ b/chunkhound/services/realtime_indexing_service.py
@@ -24,9 +24,12 @@ from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 from chunkhound.core.config.config import Config
-from chunkhound.core.utils.path_utils import normalize_path_for_lookup
+from chunkhound.core.utils.path_utils import (
+    directory_prefix_for_relative_path,
+    normalize_path_for_lookup,
+    path_is_within_relative_directory,
+)
 from chunkhound.database_factory import DatabaseServices
-from chunkhound.providers.database.like_utils import escape_like_pattern
 from chunkhound.utils.windows_constants import IS_WINDOWS
 
 
@@ -439,7 +442,8 @@ class RealtimeIndexingService:
         self._watchdog_stop_event.set()
 
         watchdog_task = self._watchdog_setup_task
-        if watchdog_task is not None:
+        current_task = asyncio.current_task()
+        if watchdog_task is not None and watchdog_task is not current_task:
             try:
                 await asyncio.wait_for(asyncio.shield(watchdog_task), timeout=2.0)
             except asyncio.TimeoutError:
@@ -770,26 +774,25 @@ class RealtimeIndexingService:
         try:
             base_dir = self.watch_path or self.config.target_dir
             relative_dir = normalize_path_for_lookup(dir_path, base_dir)
-            directory_prefix = (
-                ""
-                if relative_dir in {"", "."}
-                else relative_dir.rstrip("/") + "/"
-            )
-            escaped_prefix = escape_like_pattern(directory_prefix)
-            search_results = self.services.provider.execute_query(
-                "SELECT path FROM files WHERE path LIKE ? ESCAPE '\\'",
-                [f"{escaped_prefix}%"],
-            )
+            directory_prefix = directory_prefix_for_relative_path(relative_dir)
+            search_results = self.services.provider.execute_query("SELECT path FROM files")
+            scoped_results = [
+                result
+                for result in search_results
+                if path_is_within_relative_directory(
+                    str(result.get("path", "")), directory_prefix
+                )
+            ]
 
             # Delete each file found in the directory
-            for result in search_results:
+            for result in scoped_results:
                 file_path = result.get("path", "")
                 if file_path:
                     logger.debug(f"Cleaning up deleted file: {file_path}")
                     await self.services.provider.delete_file_completely_async(file_path)
 
             logger.info(
-                f"Cleaned up {len(search_results)} files from deleted directory: {dir_path}"
+                f"Cleaned up {len(scoped_results)} files from deleted directory: {dir_path}"
             )
 
         except Exception as e:

--- a/tests/integration/test_lancedb_scoped_cleanup.py
+++ b/tests/integration/test_lancedb_scoped_cleanup.py
@@ -1,0 +1,57 @@
+"""Regression tests for provider-portable scoped cleanup behavior."""
+
+from pathlib import Path
+
+from chunkhound.core.models import File
+from chunkhound.core.types.common import Language
+from chunkhound.services.indexing_coordinator import IndexingCoordinator
+
+
+def test_lancedb_scoped_orphan_cleanup_preserves_files_outside_directory(
+    lancedb_provider, tmp_path: Path
+) -> None:
+    """Scoped cleanup should only remove stale files from the selected subtree."""
+    src_dir = tmp_path / "src"
+    other_dir = tmp_path / "other"
+    src_dir.mkdir()
+    other_dir.mkdir()
+
+    current_file = src_dir / "keep.py"
+    current_file.write_text("def keep():\n    return 1\n")
+
+    lancedb_provider.insert_file(
+        File(
+            path="src/keep.py",
+            mtime=1.0,
+            language=Language.PYTHON,
+            size_bytes=10,
+        )
+    )
+    lancedb_provider.insert_file(
+        File(
+            path="src/stale.py",
+            mtime=1.0,
+            language=Language.PYTHON,
+            size_bytes=10,
+        )
+    )
+    lancedb_provider.insert_file(
+        File(
+            path="other/keep.py",
+            mtime=1.0,
+            language=Language.PYTHON,
+            size_bytes=10,
+        )
+    )
+
+    coordinator = IndexingCoordinator(
+        database_provider=lancedb_provider,
+        base_directory=tmp_path,
+    )
+
+    orphaned_count = coordinator._cleanup_orphaned_files(src_dir, [current_file], [])
+
+    assert orphaned_count == 1
+    assert lancedb_provider.get_file_by_path("src/keep.py") is not None
+    assert lancedb_provider.get_file_by_path("src/stale.py") is None
+    assert lancedb_provider.get_file_by_path("other/keep.py") is not None

--- a/tests/services/test_clustering_service.py
+++ b/tests/services/test_clustering_service.py
@@ -162,7 +162,7 @@ class TestKMeansClustering:
         self, clustering_service: ClusteringService
     ) -> None:
         """Test that token counts in metadata are accurate."""
-        files = {f"file{i}.py": "test content" * 10 for i in range(5)}
+        files = {f"file{i}.py": f"test content {i} " * 10 for i in range(5)}
 
         clusters, metadata = await clustering_service.cluster_files(files, n_clusters=2)
 
@@ -705,8 +705,10 @@ class TestClusterFilesHDBSCANBounded:
     ) -> None:
         """Test that final cluster IDs are renumbered sequentially from 0."""
         # Create scenario that produces multiple clusters
-        medium_content = self._make_content_with_tokens(25_000)
-        files = {f"file{i}.py": medium_content for i in range(4)}
+        files = {
+            f"file{i}.py": self._make_unique_content_with_tokens(25_000, seed=f"medium{i}")
+            for i in range(4)
+        }
 
         clusters, _ = await clustering_service.cluster_files_hdbscan_bounded(
             files,

--- a/tests/test_realtime_failures.py
+++ b/tests/test_realtime_failures.py
@@ -12,6 +12,7 @@ import pytest
 
 from chunkhound.core.config.config import Config
 from chunkhound.database_factory import create_services
+from chunkhound.services import realtime_indexing_service as realtime_module
 from chunkhound.services.realtime_indexing_service import RealtimeIndexingService
 from tests.utils.windows_compat import (
     get_fs_event_timeout,
@@ -246,3 +247,33 @@ class TestRealtimeFailures:
         # Verify cleanup completed - task should be done or None
         assert service._polling_task is None or service._polling_task.done(), \
             "Polling task should be cleaned up after stop()"
+
+    @pytest.mark.asyncio
+    async def test_watchdog_failure_switches_to_polling_without_self_wait_warning(
+        self, realtime_setup, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Watchdog startup failure should fall back without timing out on itself."""
+        service, watch_dir, _, _ = realtime_setup
+
+        def fail_start_fs_monitor(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        warning_messages: list[str] = []
+
+        monkeypatch.setattr(service, "_start_fs_monitor", fail_start_fs_monitor)
+        monkeypatch.setattr(
+            realtime_module.logger,
+            "warning",
+            lambda message: warning_messages.append(str(message)),
+        )
+
+        await service.start(watch_dir)
+
+        assert service._using_polling is True
+        assert service.monitoring_ready.is_set()
+        assert not any(
+            "Watchdog setup task did not exit within timeout" in message
+            for message in warning_messages
+        )
+
+        await service.stop()


### PR DESCRIPTION
## Summary
This branch fixes a set of correctness and stability issues in realtime indexing, scoped cleanup, and embedding persistence.

## What changed
### Realtime indexing
- fix watchdog startup fallback so a failed watchdog setup switches to polling cleanly instead of waiting on the setup task itself
- improve watchdog shutdown behavior during timeout and service stop paths
- keep monitoring readiness and polling fallback behavior consistent after startup failures
- remove the hard polling file-count cap that could skip valid files in large trees

### Scoped cleanup and path handling
- make directory-scoped cleanup provider-portable by filtering stored relative paths in Python instead of relying on SQL `LIKE` support
- prevent LanceDB cleanup paths from deleting files outside the active subtree
- canonicalize base directories for path storage and lookup so the same repo is not indexed under multiple logical path roots
- keep orphan cleanup bounded to the scanned directory while preserving unrelated files elsewhere in the database

### DuckDB embedding and WAL robustness
- avoid deleting the WAL on lock-contention-only validation failures
- enforce embedding uniqueness on `(chunk_id, provider, model)` for DuckDB embedding tables
- deduplicate existing embedding rows during schema setup/migration and ignore duplicate inserts during batch writes

### Smaller fixes and tests
- guard progress-speed reporting against `_Task.elapsed` access issues
- make clustering tests use unique content so they do not rely on duplicate embeddings collapsing by accident
- add regression coverage for LanceDB scoped cleanup and watchdog fallback behavior

## Verification
- `uv run pytest tests/integration/test_lancedb_scoped_cleanup.py -v`
- `uv run pytest tests/test_realtime_failures.py -k "watchdog_failure_switches_to_polling_without_self_wait_warning or polling_monitor_cleanup_on_cancellation" -v`
- `uv run pytest tests/ -v`
  - result: `2221 passed, 45 skipped`
