### PR TITLE
fix item #225

### DIFF
--- a/chunkhound/api/cli/main.py
+++ b/chunkhound/api/cli/main.py
@@ -206,6 +206,13 @@ async def async_main() -> None:
 
 def main() -> None:
     """Main entry point for the CLI."""
+    # On Windows, cp1252 terminals crash on CJK/non-Latin chars. Use backslashreplace so
+    # unencodable characters survive as \uXXXX escapes rather than being silently dropped.
+    if sys.platform == "win32":
+        if hasattr(sys.stdout, "reconfigure"):
+            sys.stdout.reconfigure(errors="backslashreplace")
+        if hasattr(sys.stderr, "reconfigure"):
+            sys.stderr.reconfigure(errors="backslashreplace")
     try:
         asyncio.run(async_main())
     except KeyboardInterrupt:

--- a/chunkhound/api/cli/main.py
+++ b/chunkhound/api/cli/main.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 from loguru import logger
 
+from chunkhound.utils.windows_constants import IS_WINDOWS
+
 from .utils.config_factory import create_validated_config
 
 # Required for PyInstaller multiprocessing support
@@ -206,9 +208,7 @@ async def async_main() -> None:
 
 def main() -> None:
     """Main entry point for the CLI."""
-    # On Windows, cp1252 terminals crash on CJK/non-Latin chars. Use backslashreplace so
-    # unencodable characters survive as \uXXXX escapes rather than being silently dropped.
-    if sys.platform == "win32":
+    if IS_WINDOWS:
         if hasattr(sys.stdout, "reconfigure"):
             sys.stdout.reconfigure(errors="backslashreplace")
         if hasattr(sys.stderr, "reconfigure"):

--- a/chunkhound/mcp_server/stdio.py
+++ b/chunkhound/mcp_server/stdio.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:  # type-checkers only; avoid runtime hard deps at import
     from mcp.server.models import InitializationOptions  # noqa: F401
 
 from chunkhound.core.config.config import Config  # noqa: E402
+from chunkhound.utils.windows_constants import IS_WINDOWS  # noqa: E402
 from chunkhound.version import __version__  # noqa: E402
 
 from .base import MCPServerBase  # noqa: E402
@@ -427,6 +428,11 @@ async def main(args: Any = None) -> None:
 
 def main_sync() -> None:
     """Synchronous wrapper for CLI entry point."""
+    if IS_WINDOWS:
+        if hasattr(sys.stdout, "reconfigure"):
+            sys.stdout.reconfigure(errors="backslashreplace")
+        if hasattr(sys.stderr, "reconfigure"):
+            sys.stderr.reconfigure(errors="backslashreplace")
     asyncio.run(main())
 
 

--- a/tests/unit/test_cli_unicode_output.py
+++ b/tests/unit/test_cli_unicode_output.py
@@ -1,130 +1,125 @@
-"""Tests for Unicode-safe stdout/stderr configuration in the CLI entry point."""
-import sys
+"""Tests for Unicode-safe stdout/stderr configuration in CLI entry points."""
+import asyncio
 import io
-import unittest.mock as mock
+import sys
 
 import pytest
 
 
-def _run_main_reconfigure(platform: str, monkeypatch: pytest.MonkeyPatch):
-    """Run the reconfigure block from main() under a simulated platform."""
-    monkeypatch.setattr(sys, "platform", platform)
+class TrackingWriter(io.StringIO):
+    """StringIO that records reconfigure() calls and starts with strict errors."""
 
-    # Simulate a narrow-encoding terminal (cp1252) via a StringIO with a custom encode method.
-    class NarrowWriter(io.StringIO):
-        errors = "strict"
-        encoding = "cp1252"
+    errors = "strict"
+    encoding = "cp1252"
 
-        def reconfigure(self, **kwargs):
-            for k, v in kwargs.items():
-                setattr(self, k, v)
+    def __init__(self):
+        super().__init__()
+        self.reconfigure_calls: list[dict] = []
 
-    stdout = NarrowWriter()
-    stderr = NarrowWriter()
-    monkeypatch.setattr(sys, "stdout", stdout)
-    monkeypatch.setattr(sys, "stderr", stderr)
-
-    # Import fresh so the module-level state doesn't interfere.
-    from chunkhound.api.cli import main as main_mod
-    import importlib
-    importlib.reload(main_mod)
-
-    # Execute only the reconfigure block, not asyncio.run.
-    if sys.platform == "win32":
-        if hasattr(sys.stdout, "reconfigure"):
-            sys.stdout.reconfigure(errors="backslashreplace")
-        if hasattr(sys.stderr, "reconfigure"):
-            sys.stderr.reconfigure(errors="backslashreplace")
-
-    return stdout, stderr
+    def reconfigure(self, **kwargs):
+        self.reconfigure_calls.append(kwargs)
+        for k, v in kwargs.items():
+            setattr(self, k, v)
 
 
-class TestCliUnicodeReconfigure:
-    def test_windows_sets_backslashreplace(self, monkeypatch: pytest.MonkeyPatch):
-        """On Windows, stdout/stderr errors mode must be 'backslashreplace'."""
-        stdout, stderr = _run_main_reconfigure("win32", monkeypatch)
-        assert stdout.errors == "backslashreplace"
-        assert stderr.errors == "backslashreplace"
-
-    def test_non_windows_unchanged(self, monkeypatch: pytest.MonkeyPatch):
-        """On Linux/macOS, stdout/stderr must not be reconfigured."""
-        stdout, stderr = _run_main_reconfigure("linux", monkeypatch)
-        assert stdout.errors == "strict"
-        assert stderr.errors == "strict"
-
-    def test_main_no_crash_on_missing_reconfigure(self, monkeypatch: pytest.MonkeyPatch):
-        """Streams without reconfigure() (e.g. raw BytesIO wrapper) must not raise."""
-        monkeypatch.setattr(sys, "platform", "win32")
-
-        class NoReconfigure(io.StringIO):
-            pass  # no reconfigure attribute
-
-        monkeypatch.setattr(sys, "stdout", NoReconfigure())
-        monkeypatch.setattr(sys, "stderr", NoReconfigure())
-
-        # Should not raise AttributeError
-        if sys.platform == "win32":
-            if hasattr(sys.stdout, "reconfigure"):
-                sys.stdout.reconfigure(errors="backslashreplace")
-            if hasattr(sys.stderr, "reconfigure"):
-                sys.stderr.reconfigure(errors="backslashreplace")
+class NoReconfigureWriter(io.StringIO):
+    """StringIO without a reconfigure() method."""
 
 
-def test_main_entrypoint_calls_reconfigure_on_windows(monkeypatch: pytest.MonkeyPatch):
-    """main() calls reconfigure(errors='backslashreplace') on Windows and not elsewhere."""
-    reconfigure_calls = []
-
-    class TrackingWriter(io.StringIO):
-        errors = "strict"
-        encoding = "cp1252"
-
-        def reconfigure(self, **kwargs):
-            reconfigure_calls.append(kwargs)
-
-    monkeypatch.setattr(sys, "stdout", TrackingWriter())
-    monkeypatch.setattr(sys, "stderr", TrackingWriter())
-    monkeypatch.setattr(sys, "platform", "win32")
-
-    # Stub asyncio.run so main() doesn't actually run the CLI.
-    import asyncio
-
-    def _raise_exit(coro):
-        coro.close()  # prevent unawaited-coroutine warning
-        raise SystemExit(0)
-
-    monkeypatch.setattr(asyncio, "run", _raise_exit)
-
-    from chunkhound.api.cli.main import main
-    with pytest.raises(SystemExit):
-        main()
-
-    assert any(c.get("errors") == "backslashreplace" for c in reconfigure_calls), (
-        "Expected backslashreplace reconfigure on Windows"
-    )
-
-
-def test_main_entrypoint_skips_reconfigure_on_linux(monkeypatch: pytest.MonkeyPatch):
-    """main() must NOT call reconfigure() on non-Windows platforms."""
-    reconfigure_calls = []
-
-    class TrackingWriter(io.StringIO):
-        def reconfigure(self, **kwargs):
-            reconfigure_calls.append(kwargs)
-
-    monkeypatch.setattr(sys, "stdout", TrackingWriter())
-    monkeypatch.setattr(sys, "stderr", TrackingWriter())
-    monkeypatch.setattr(sys, "platform", "linux")
-
-    import asyncio
-
+def _stub_asyncio_run(monkeypatch: pytest.MonkeyPatch) -> None:
     def _raise_exit(coro):
         coro.close()
         raise SystemExit(0)
 
     monkeypatch.setattr(asyncio, "run", _raise_exit)
 
+
+# ---------------------------------------------------------------------------
+# CLI main() entry point
+# ---------------------------------------------------------------------------
+
+
+def test_main_sets_backslashreplace_on_windows(monkeypatch: pytest.MonkeyPatch):
+    """main() reconfigures stdout/stderr with backslashreplace on Windows."""
+    stdout, stderr = TrackingWriter(), TrackingWriter()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    monkeypatch.setattr("chunkhound.api.cli.main.IS_WINDOWS", True)
+    _stub_asyncio_run(monkeypatch)
+
     from chunkhound.api.cli.main import main
+
     with pytest.raises(SystemExit):
         main()
 
-    assert reconfigure_calls == [], "reconfigure() must not be called on Linux"
+    assert stdout.errors == "backslashreplace"
+    assert stderr.errors == "backslashreplace"
+
+
+def test_main_skips_reconfigure_on_non_windows(monkeypatch: pytest.MonkeyPatch):
+    """main() must not reconfigure stdout/stderr on Linux/macOS."""
+    stdout, stderr = TrackingWriter(), TrackingWriter()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    monkeypatch.setattr("chunkhound.api.cli.main.IS_WINDOWS", False)
+    _stub_asyncio_run(monkeypatch)
+
+    from chunkhound.api.cli.main import main
+
+    with pytest.raises(SystemExit):
+        main()
+
+    assert stdout.reconfigure_calls == []
+    assert stderr.reconfigure_calls == []
+
+
+def test_main_no_crash_when_reconfigure_absent(monkeypatch: pytest.MonkeyPatch):
+    """main() must not raise when streams lack reconfigure()."""
+    monkeypatch.setattr(sys, "stdout", NoReconfigureWriter())
+    monkeypatch.setattr(sys, "stderr", NoReconfigureWriter())
+    monkeypatch.setattr("chunkhound.api.cli.main.IS_WINDOWS", True)
+    _stub_asyncio_run(monkeypatch)
+
+    from chunkhound.api.cli.main import main
+
+    with pytest.raises(SystemExit):
+        main()
+
+
+# ---------------------------------------------------------------------------
+# MCP main_sync() entry point
+# ---------------------------------------------------------------------------
+
+
+def test_main_sync_sets_backslashreplace_on_windows(monkeypatch: pytest.MonkeyPatch):
+    """main_sync() reconfigures stdout/stderr with backslashreplace on Windows."""
+    stdout, stderr = TrackingWriter(), TrackingWriter()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    monkeypatch.setattr("chunkhound.mcp_server.stdio.IS_WINDOWS", True)
+    _stub_asyncio_run(monkeypatch)
+
+    from chunkhound.mcp_server.stdio import main_sync
+
+    with pytest.raises(SystemExit):
+        main_sync()
+
+    assert stdout.errors == "backslashreplace"
+    assert stderr.errors == "backslashreplace"
+
+
+def test_main_sync_skips_reconfigure_on_non_windows(monkeypatch: pytest.MonkeyPatch):
+    """main_sync() must not reconfigure stdout/stderr on Linux/macOS."""
+    stdout, stderr = TrackingWriter(), TrackingWriter()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    monkeypatch.setattr("chunkhound.mcp_server.stdio.IS_WINDOWS", False)
+    _stub_asyncio_run(monkeypatch)
+
+    from chunkhound.mcp_server.stdio import main_sync
+
+    with pytest.raises(SystemExit):
+        main_sync()
+
+    assert stdout.reconfigure_calls == []
+    assert stderr.reconfigure_calls == []

--- a/tests/unit/test_cli_unicode_output.py
+++ b/tests/unit/test_cli_unicode_output.py
@@ -1,0 +1,130 @@
+"""Tests for Unicode-safe stdout/stderr configuration in the CLI entry point."""
+import sys
+import io
+import unittest.mock as mock
+
+import pytest
+
+
+def _run_main_reconfigure(platform: str, monkeypatch: pytest.MonkeyPatch):
+    """Run the reconfigure block from main() under a simulated platform."""
+    monkeypatch.setattr(sys, "platform", platform)
+
+    # Simulate a narrow-encoding terminal (cp1252) via a StringIO with a custom encode method.
+    class NarrowWriter(io.StringIO):
+        errors = "strict"
+        encoding = "cp1252"
+
+        def reconfigure(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    stdout = NarrowWriter()
+    stderr = NarrowWriter()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+
+    # Import fresh so the module-level state doesn't interfere.
+    from chunkhound.api.cli import main as main_mod
+    import importlib
+    importlib.reload(main_mod)
+
+    # Execute only the reconfigure block, not asyncio.run.
+    if sys.platform == "win32":
+        if hasattr(sys.stdout, "reconfigure"):
+            sys.stdout.reconfigure(errors="backslashreplace")
+        if hasattr(sys.stderr, "reconfigure"):
+            sys.stderr.reconfigure(errors="backslashreplace")
+
+    return stdout, stderr
+
+
+class TestCliUnicodeReconfigure:
+    def test_windows_sets_backslashreplace(self, monkeypatch: pytest.MonkeyPatch):
+        """On Windows, stdout/stderr errors mode must be 'backslashreplace'."""
+        stdout, stderr = _run_main_reconfigure("win32", monkeypatch)
+        assert stdout.errors == "backslashreplace"
+        assert stderr.errors == "backslashreplace"
+
+    def test_non_windows_unchanged(self, monkeypatch: pytest.MonkeyPatch):
+        """On Linux/macOS, stdout/stderr must not be reconfigured."""
+        stdout, stderr = _run_main_reconfigure("linux", monkeypatch)
+        assert stdout.errors == "strict"
+        assert stderr.errors == "strict"
+
+    def test_main_no_crash_on_missing_reconfigure(self, monkeypatch: pytest.MonkeyPatch):
+        """Streams without reconfigure() (e.g. raw BytesIO wrapper) must not raise."""
+        monkeypatch.setattr(sys, "platform", "win32")
+
+        class NoReconfigure(io.StringIO):
+            pass  # no reconfigure attribute
+
+        monkeypatch.setattr(sys, "stdout", NoReconfigure())
+        monkeypatch.setattr(sys, "stderr", NoReconfigure())
+
+        # Should not raise AttributeError
+        if sys.platform == "win32":
+            if hasattr(sys.stdout, "reconfigure"):
+                sys.stdout.reconfigure(errors="backslashreplace")
+            if hasattr(sys.stderr, "reconfigure"):
+                sys.stderr.reconfigure(errors="backslashreplace")
+
+
+def test_main_entrypoint_calls_reconfigure_on_windows(monkeypatch: pytest.MonkeyPatch):
+    """main() calls reconfigure(errors='backslashreplace') on Windows and not elsewhere."""
+    reconfigure_calls = []
+
+    class TrackingWriter(io.StringIO):
+        errors = "strict"
+        encoding = "cp1252"
+
+        def reconfigure(self, **kwargs):
+            reconfigure_calls.append(kwargs)
+
+    monkeypatch.setattr(sys, "stdout", TrackingWriter())
+    monkeypatch.setattr(sys, "stderr", TrackingWriter())
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    # Stub asyncio.run so main() doesn't actually run the CLI.
+    import asyncio
+
+    def _raise_exit(coro):
+        coro.close()  # prevent unawaited-coroutine warning
+        raise SystemExit(0)
+
+    monkeypatch.setattr(asyncio, "run", _raise_exit)
+
+    from chunkhound.api.cli.main import main
+    with pytest.raises(SystemExit):
+        main()
+
+    assert any(c.get("errors") == "backslashreplace" for c in reconfigure_calls), (
+        "Expected backslashreplace reconfigure on Windows"
+    )
+
+
+def test_main_entrypoint_skips_reconfigure_on_linux(monkeypatch: pytest.MonkeyPatch):
+    """main() must NOT call reconfigure() on non-Windows platforms."""
+    reconfigure_calls = []
+
+    class TrackingWriter(io.StringIO):
+        def reconfigure(self, **kwargs):
+            reconfigure_calls.append(kwargs)
+
+    monkeypatch.setattr(sys, "stdout", TrackingWriter())
+    monkeypatch.setattr(sys, "stderr", TrackingWriter())
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    import asyncio
+
+    def _raise_exit(coro):
+        coro.close()
+        raise SystemExit(0)
+
+    monkeypatch.setattr(asyncio, "run", _raise_exit)
+
+    from chunkhound.api.cli.main import main
+    with pytest.raises(SystemExit):
+        main()
+
+    assert reconfigure_calls == [], "reconfigure() must not be called on Linux"


### PR DESCRIPTION
This should fix https://github.com/chunkhound/chunkhound/issues/225


fix: Windows UnicodeEncodeError on CJK search results (#225)    
                                                                                                                                                                                                                                                                         
  Windows terminals default to cp1252, which can't encode CJK/non-Latin characters — causing chunkhound search to crash with UnicodeEncodeError when results contain translated content.                                                                                 
                                                                  
  What changed:                                                                                                                                                                                                                                                          
  - main() now reconfigures stdout/stderr with errors="backslashreplace" on Windows at startup, so unencodable characters render as \uXXXX escapes instead of crashing. Scoped to sys.platform == "win32" only — Linux/macOS are untouched.
  - Chose backslashreplace over replace (?) to avoid silent data loss when piping output to a file.                                                                                                                                                                      
  - 5 unit tests added covering: Windows sets correct error mode, Linux leaves streams unchanged, graceful handling of streams without reconfigure(), and end-to-end main() entry point behaviour on both platforms.
                                                                                                                                                                                                                                                                         
  No breaking changes. On non-Windows the behaviour is identical to before.