### PR TITLE
fix(ci): publish pre-releases to PyPI not TestPyPI

### DIFF
--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -84,7 +84,7 @@ jobs:
   publish-rc:
     needs: [build-sdist, build-runtime-wheels]
     runs-on: ubuntu-latest
-    environment: testpypi
+    environment: pypi
     timeout-minutes: 15
 
     steps:
@@ -99,5 +99,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
-          repository-url: https://test.pypi.org/legacy/
-          # No token needed — OIDC Trusted Publishing configured on TestPyPI project
+          # No token needed — OIDC Trusted Publishing configured on PyPI project


### PR DESCRIPTION
## Summary

- `publish-rc` job was using `environment: testpypi` and `repository-url: https://test.pypi.org/legacy/`, causing OIDC Trusted Publishing failure
- The configured trusted publisher on PyPI uses `environment: pypi` — the token claim `sub: repo:chunkhound/chunkhound:environment:testpypi` didn't match
- Fixed by aligning `publish-rc` with the `validate-tag` job (which already correctly used `environment: pypi`) and removing the TestPyPI URL override

## Root cause

`invalid-publisher` error from PyPI:
```
sub: repo:chunkhound/chunkhound:environment:testpypi
```
No trusted publisher was configured for the `testpypi` environment — AGENTS.md specifies pre-releases go to PyPI (not TestPyPI) using `environment: pypi`.

## Test plan

- [ ] Merge this fix to main
- [ ] Delete and re-push tag `v5.0.0a1` to re-trigger `release-rc.yml`
- [ ] Confirm `publish-rc` job passes and `5.0.0a1` appears on PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)