### PR TITLE
fix(deps): pin duckdb below dev builds to prevent vss extension 404

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
 ]
 dependencies = [
-    "duckdb>=1.4.0",
+    "duckdb>=1.4.0,<1.5.3.dev0",
     "openai>=1.0.0",
     "packaging>=21.0",
     "aiohttp>=3.12.15",

--- a/uv.lock
+++ b/uv.lock
@@ -474,7 +474,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.15" },
     { name = "anthropic", specifier = ">=0.96.0,<1.0.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
-    { name = "duckdb", specifier = ">=1.4.0" },
+    { name = "duckdb", specifier = ">=1.4.0,<1.5.3.dev0" },
     { name = "google-genai", specifier = ">=1.51.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "lancedb", specifier = ">=0.25.3" },


### PR DESCRIPTION
When installing a pre-release ChunkHound with `--prerelease=allow`, uv propagates pre-release resolution to all dependencies, pulling in duckdb nightly builds (e.g. `1.6.0.dev12`, `1.5.3.dev13`). DuckDB only hosts extensions for official releases, so `INSTALL vss` fails with HTTP 404 on the dev build's hash-based URL.

Constraining to `<1.5.3.dev0` ensures stable `1.5.2` is resolved even when `--prerelease=allow` is active.

**Why now:** This fix is needed before cutting the `v5.0.0` stable release, as the alpha was published and users installing with `--prerelease=allow` hit this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)