### PR TITLE
fix: Respect gitignore when scanning repo roots

### DIFF
--- a/chunkhound/services/directory_indexing_service.py
+++ b/chunkhound/services/directory_indexing_service.py
@@ -84,7 +84,7 @@ class DirectoryIndexingService:
             include_patterns, exclude_patterns = self._resolve_file_patterns()
 
             # Directory processing (extracted from run.py:80-82, 253-284)
-            self.progress_callback("Starting file processing...")
+            self.progress_callback("Discovering files...")
             process_result = await self._process_directory_files(
                 target_path, include_patterns, exclude_patterns
             )
@@ -108,7 +108,8 @@ class DirectoryIndexingService:
 
     def _resolve_file_patterns(self) -> tuple[list[str], list[str]]:
         """Extracted from run.py:152-175 - file pattern resolution logic."""
-        # Use patterns from config (CLI overrides already applied during config creation)
+        # Use patterns from config. CLI overrides are already applied during
+        # config creation.
         include_patterns = list(self.config.indexing.include)
         exclude_patterns = list(self.config.indexing.exclude)
 

--- a/chunkhound/services/indexing_coordinator.py
+++ b/chunkhound/services/indexing_coordinator.py
@@ -2299,7 +2299,17 @@ class IndexingCoordinator(BaseService):
                     if indexing_config is not None
                     else []
                 )
-                repo_roots = self._get_or_detect_repo_roots(directory, eff)
+                if indexing_config is not None and callable(
+                    getattr(indexing_config, "resolve_ignore_sources", None)
+                ):
+                    sources = indexing_config.resolve_ignore_sources()
+                else:
+                    sources = ["gitignore"]
+                repo_roots = self._get_or_detect_repo_roots(
+                    directory,
+                    eff,
+                    prune_ignored_gitfile_roots=("gitignore" in (sources or [])),
+                )
             except Exception:
                 repo_roots = []
             if not repo_roots:

--- a/chunkhound/services/indexing_coordinator.py
+++ b/chunkhound/services/indexing_coordinator.py
@@ -1974,15 +1974,19 @@ class IndexingCoordinator(BaseService):
             detect_repo_roots = None  # type: ignore[assignment]
 
         if detect_repo_roots is not None:
+            idx = getattr(getattr(self, "config", None), "indexing", None)
             prune_gitfile_roots = (
-                self.config is not None
-                and "gitignore" in self.config.indexing.resolve_ignore_sources()
+                idx is not None and "gitignore" in idx.resolve_ignore_sources()
+            )
+            workspace_root_only_gitignore = bool(
+                getattr(idx, "workspace_gitignore_nonrepo", False)
             )
             try:
                 precomputed_roots = detect_repo_roots(
                     directory,
                     effective_excludes,
                     prune_ignored_gitfile_roots=prune_gitfile_roots,
+                    workspace_root_only_gitignore=workspace_root_only_gitignore,
                 )
             except Exception as e:
                 logger.debug(
@@ -2248,6 +2252,9 @@ class IndexingCoordinator(BaseService):
                 if _idx is not None
                 else False,
             }
+            workspace_root_only_gitignore = bool(
+                getattr(_idx, "workspace_gitignore_nonrepo", False)
+            ) if _idx is not None else False
             # Provide precomputed repo roots to parallel workers so they can
             # avoid re-detecting per process
             try:
@@ -2255,6 +2262,7 @@ class IndexingCoordinator(BaseService):
                     directory.resolve(),
                     list(cfg_excludes),
                     prune_ignored_gitfile_roots=("gitignore" in (sources or [])),
+                    workspace_root_only_gitignore=workspace_root_only_gitignore,
                 )
                 if roots:
                     engine_args["roots"] = roots
@@ -2305,10 +2313,14 @@ class IndexingCoordinator(BaseService):
                     sources = indexing_config.resolve_ignore_sources()
                 else:
                     sources = ["gitignore"]
+                workspace_root_only_gitignore = bool(
+                    getattr(indexing_config, "workspace_gitignore_nonrepo", False)
+                ) if indexing_config is not None else False
                 repo_roots = self._get_or_detect_repo_roots(
                     directory,
                     eff,
                     prune_ignored_gitfile_roots=("gitignore" in (sources or [])),
+                    workspace_root_only_gitignore=workspace_root_only_gitignore,
                 )
             except Exception:
                 repo_roots = []
@@ -2550,8 +2562,12 @@ class IndexingCoordinator(BaseService):
             idx = getattr(getattr(self, "config", None), "indexing", None)
             sources = idx.resolve_ignore_sources() if idx is not None else []
             prune_gitfile_roots = "gitignore" in (sources or [])
+            workspace_root_only_gitignore = bool(
+                getattr(idx, "workspace_gitignore_nonrepo", False)
+            )
         except Exception:
             prune_gitfile_roots = False
+            workspace_root_only_gitignore = False
 
         # Detect repo roots under directory (pruned by effective_excludes) with cache reuse
         try:
@@ -2559,6 +2575,7 @@ class IndexingCoordinator(BaseService):
                 directory,
                 effective_excludes,
                 prune_ignored_gitfile_roots=prune_gitfile_roots,
+                workspace_root_only_gitignore=workspace_root_only_gitignore,
             )
         except Exception as e:
             logger.debug(f"Repo root detection failed in git discovery: {e}")
@@ -2773,7 +2790,8 @@ class IndexingCoordinator(BaseService):
         cfg_excludes: list[str] | tuple[str, ...],
         *,
         prune_ignored_gitfile_roots: bool = False,
-    ) -> tuple[str, tuple[str, ...], int]:
+        workspace_root_only_gitignore: bool = False,
+    ) -> tuple[str, tuple[str, ...], int, int]:
         try:
             base = str(root.resolve())
         except Exception:
@@ -2782,7 +2800,12 @@ class IndexingCoordinator(BaseService):
             items = tuple(sorted([str(x) for x in list(cfg_excludes)]))
         except Exception:
             items = tuple()
-        return (base, items, 1 if prune_ignored_gitfile_roots else 0)
+        return (
+            base,
+            items,
+            1 if prune_ignored_gitfile_roots else 0,
+            1 if workspace_root_only_gitignore else 0,
+        )
 
     def _get_or_detect_repo_roots(
         self,
@@ -2790,11 +2813,13 @@ class IndexingCoordinator(BaseService):
         cfg_excludes: list[str] | tuple[str, ...],
         *,
         prune_ignored_gitfile_roots: bool = False,
+        workspace_root_only_gitignore: bool = False,
     ) -> list[Path]:
         key = self._repo_roots_cache_key(
             root,
             cfg_excludes,
             prune_ignored_gitfile_roots=prune_ignored_gitfile_roots,
+            workspace_root_only_gitignore=workspace_root_only_gitignore,
         )
         cached = self._repo_roots_cache.get(key)
         if cached is not None:
@@ -2806,6 +2831,7 @@ class IndexingCoordinator(BaseService):
                 root,
                 cfg_excludes,  # type: ignore[arg-type]
                 prune_ignored_gitfile_roots=prune_ignored_gitfile_roots,
+                workspace_root_only_gitignore=workspace_root_only_gitignore,
             )
         except Exception:
             roots = []

--- a/chunkhound/utils/ignore_engine.py
+++ b/chunkhound/utils/ignore_engine.py
@@ -31,6 +31,10 @@ class _GitignorePruneState:
     spec: PathSpec | None
 
 
+def _empty_gitignore_prune_state() -> _GitignorePruneState:
+    return _GitignorePruneState(patterns=(), spec=None)
+
+
 class IgnoreEngine:
     def __init__(self, root: Path, compiled_specs: list[tuple[Path, PathSpec]]):
         self.root = root.resolve()
@@ -177,7 +181,10 @@ def _read_transformed_gitignore_patterns(root: Path, dir_path: Path) -> list[str
     except Exception:
         return []
 
-    rel_from_root = dir_path.relative_to(root)
+    try:
+        rel_from_root = dir_path.relative_to(root)
+    except ValueError:
+        return []
     dir_rel = "." if str(rel_from_root) == "." else rel_from_root.as_posix()
 
     out: list[str] = []
@@ -195,11 +202,12 @@ def _extend_gitignore_prune_state(
     parent_state: _GitignorePruneState | None,
 ) -> _GitignorePruneState | None:
     """Build prune state for a directory from inherited + local .gitignore rules."""
-    inherited = () if parent_state is None else parent_state.patterns
+    base_state = parent_state or _empty_gitignore_prune_state()
+    inherited = base_state.patterns
 
     local_patterns = _read_transformed_gitignore_patterns(root, dir_path)
     if not local_patterns:
-        return parent_state
+        return base_state
 
     combined = inherited + tuple(local_patterns)
     return _GitignorePruneState(
@@ -213,12 +221,14 @@ def _detect_repo_roots(
     pre_exclude_spec: PathSpec | None = None,
     *,
     prune_ignored_gitfile_roots: bool = False,
+    workspace_root_only_gitignore: bool = False,
 ) -> list[Path]:
     """Detect Git repository roots under root by looking for .git dir or file.
 
     Prunes excluded subtrees using pre_exclude_spec (e.g., node_modules) and,
     when enabled, prunes directories ignored by the active repo's .gitignore
-    rules while preserving direct child repo boundaries.
+    rules or the workspace-root non-repo overlay while preserving direct child
+    repo boundaries.
     """
     roots: list[Path] = []
     root = root.resolve()
@@ -249,7 +259,11 @@ def _detect_repo_roots(
                     "Worktree ignore pruning: failed to import git_check_ignored: {}",
                     e,
                 )
-        if (root / ".git").is_dir() or (root / ".git").is_file():
+        if (
+            (root / ".git").is_dir()
+            or (root / ".git").is_file()
+            or workspace_root_only_gitignore
+        ):
             gitignore_state_by_dir[root] = _extend_gitignore_prune_state(
                 root,
                 root,
@@ -305,20 +319,27 @@ def _detect_repo_roots(
         # own .gitignore lineage so parent rules do not leak into nested repos.
         if prune_ignored_gitfile_roots:
             for dn in dirnames:
-                child_path = (dpath / dn).resolve()
-                child_is_repo = (child_path / ".git").is_dir() or (
-                    child_path / ".git"
+                child_logical_path = dpath / dn
+                if child_logical_path.is_symlink():
+                    continue
+                child_resolved = child_logical_path.resolve()
+                child_is_repo = (child_resolved / ".git").is_dir() or (
+                    child_resolved / ".git"
                 ).is_file()
                 if child_is_repo:
-                    gitignore_state_by_dir[child_path] = _extend_gitignore_prune_state(
+                    gitignore_state_by_dir[
+                        child_resolved
+                    ] = _extend_gitignore_prune_state(
                         root,
-                        child_path,
+                        child_logical_path,
                         None,
                     )
                 elif current_gitignore_state is not None:
-                    gitignore_state_by_dir[child_path] = _extend_gitignore_prune_state(
+                    gitignore_state_by_dir[
+                        child_resolved
+                    ] = _extend_gitignore_prune_state(
                         root,
-                        child_path,
+                        child_logical_path,
                         current_gitignore_state,
                     )
 
@@ -493,10 +514,22 @@ def build_repo_aware_ignore_engine(
     workspace_root_only_gitignore: bool | None = None,
 ) -> RepoAwareIgnoreEvaluator:
     pre_spec = _compile_gitwildmatch(config_exclude or []) if (config_exclude) else None
+
+    if workspace_root_only_gitignore is not None:
+        prune_workspace_root_only = bool(workspace_root_only_gitignore)
+    else:
+        try:
+            prune_workspace_root_only = os.environ.get(
+                "CHUNKHOUND_INDEXING__WORKSPACE_GITIGNORE_NONREPO", ""
+            ).strip() not in ("", "0", "false", "no")
+        except Exception:
+            prune_workspace_root_only = False
+
     repo_roots = _detect_repo_roots(
         root,
         pre_spec,
         prune_ignored_gitfile_roots=("gitignore" in (sources or [])),
+        workspace_root_only_gitignore=prune_workspace_root_only,
     )
     if backend == "libgit2":
         eng = _try_build_libgit2_repo_aware(
@@ -511,17 +544,12 @@ def build_repo_aware_ignore_engine(
     #    default to True to honor a root .gitignore for non‑repo trees
     # 3) Legacy ENV override (kept for backward compatibility)
     if workspace_root_only_gitignore is not None:
-        wr_only = bool(workspace_root_only_gitignore)
+        wr_only = prune_workspace_root_only
     else:
         if ("gitignore" in (sources or [])) and (not repo_roots):
             wr_only = True
         else:
-            try:
-                wr_only = os.environ.get(
-                    "CHUNKHOUND_INDEXING__WORKSPACE_GITIGNORE_NONREPO", ""
-                ).strip() not in ("", "0", "false", "no")
-            except Exception:
-                wr_only = False
+            wr_only = prune_workspace_root_only
     return RepoAwareIgnoreEvaluator(
         root,
         repo_roots,
@@ -601,19 +629,22 @@ def detect_repo_roots(
     config_exclude: Iterable[str] | None = None,
     *,
     prune_ignored_gitfile_roots: bool = False,
+    workspace_root_only_gitignore: bool = False,
 ) -> list[Path]:
     """Public helper to detect repo roots under a workspace root.
 
     Applies pruning using config_exclude (gitwildmatch semantics) to avoid
     descending into heavy trees (e.g., node_modules) while scanning. When
     ``prune_ignored_gitfile_roots`` is enabled, directories ignored by the
-    active repo's .gitignore rules are also pruned during the scan.
+    active repo's .gitignore rules or the workspace-root non-repo overlay are
+    also pruned during the scan.
     """
     pre_spec = _compile_gitwildmatch(config_exclude or []) if config_exclude else None
     return _detect_repo_roots(
         root,
         pre_spec,
         prune_ignored_gitfile_roots=prune_ignored_gitfile_roots,
+        workspace_root_only_gitignore=workspace_root_only_gitignore,
     )
 
 

--- a/chunkhound/utils/ignore_engine.py
+++ b/chunkhound/utils/ignore_engine.py
@@ -1,10 +1,4 @@
-"""IgnoreEngine: central exclusion logic with gitwildmatch semantics.
-
-Initial implementation supports root-level .gitignore files
-via the `pathspec` library using gitwildmatch patterns. This is sufficient to
-make the initial tests pass; we will extend it to per-directory inheritance
-and richer rule origins in follow-up steps.
-"""
+"""Ignore handling and repo-root detection with gitwildmatch semantics."""
 
 from __future__ import annotations
 
@@ -29,6 +23,12 @@ class MatchInfo:
     matched: bool
     source: Path | None = None
     pattern: str | None = None
+
+
+@dataclass(frozen=True)
+class _GitignorePruneState:
+    patterns: tuple[str, ...]
+    spec: PathSpec | None
 
 
 class IgnoreEngine:
@@ -104,7 +104,7 @@ def build_ignore_engine(
     """Build an IgnoreEngine for the given root and sources.
 
     Currently supports:
-    - gitignore: uses only the root-level .gitignore file
+    - gitignore: collects transformed .gitignore rules across the tree
     - config: uses provided glob-like patterns (gitwildmatch semantics)
 
     Note: Global gitignore (core.excludesFile) is NOT loaded here because the
@@ -120,7 +120,8 @@ def build_ignore_engine(
 
     for src in sources:
         if src == "gitignore":
-            # Collect and transform .gitignore rules across the tree to root-relative patterns
+            # Collect and transform .gitignore rules across the tree to
+            # root-relative patterns.
             pre_spec = None
             if config_exclude:
                 pre_spec = _compile_gitwildmatch(config_exclude)
@@ -161,21 +162,50 @@ def _collect_gitignore_patterns(
                     to_remove.append(dn)
             for dn in to_remove:
                 dirnames.remove(dn)
-        gi = dpath / ".gitignore"
-        if not gi.exists():
-            continue
-        try:
-            lines = gi.read_text(encoding="utf-8", errors="ignore").splitlines()
-        except Exception:
-            continue
-        rel_from_root = dpath.relative_to(root)
-        dir_rel = "." if str(rel_from_root) == "." else rel_from_root.as_posix()
-        for raw in lines:
-            line = raw.strip()
-            if not line or line.startswith("#"):
-                continue
-            out.extend(_transform_gitignore_line(dir_rel, line))
+        out.extend(_read_transformed_gitignore_patterns(root, dpath))
     return out
+
+
+def _read_transformed_gitignore_patterns(root: Path, dir_path: Path) -> list[str]:
+    """Load a directory's .gitignore and transform it to root-relative patterns."""
+    gi = dir_path / ".gitignore"
+    if not gi.exists():
+        return []
+
+    try:
+        lines = gi.read_text(encoding="utf-8", errors="ignore").splitlines()
+    except Exception:
+        return []
+
+    rel_from_root = dir_path.relative_to(root)
+    dir_rel = "." if str(rel_from_root) == "." else rel_from_root.as_posix()
+
+    out: list[str] = []
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.extend(_transform_gitignore_line(dir_rel, line))
+    return out
+
+
+def _extend_gitignore_prune_state(
+    root: Path,
+    dir_path: Path,
+    parent_state: _GitignorePruneState | None,
+) -> _GitignorePruneState | None:
+    """Build prune state for a directory from inherited + local .gitignore rules."""
+    inherited = () if parent_state is None else parent_state.patterns
+
+    local_patterns = _read_transformed_gitignore_patterns(root, dir_path)
+    if not local_patterns:
+        return parent_state
+
+    combined = inherited + tuple(local_patterns)
+    return _GitignorePruneState(
+        patterns=combined,
+        spec=_compile_gitwildmatch(combined),
+    )
 
 
 def _detect_repo_roots(
@@ -186,12 +216,14 @@ def _detect_repo_roots(
 ) -> list[Path]:
     """Detect Git repository roots under root by looking for .git dir or file.
 
-    Prunes excluded subtrees using pre_exclude_spec (e.g., node_modules) to
-    avoid unnecessary traversal.
+    Prunes excluded subtrees using pre_exclude_spec (e.g., node_modules) and,
+    when enabled, prunes directories ignored by the active repo's .gitignore
+    rules while preserving direct child repo boundaries.
     """
     roots: list[Path] = []
     root = root.resolve()
     ignored_cache: dict[tuple[str, str], bool] = {}
+    gitignore_state_by_dir: dict[Path, _GitignorePruneState | None] = {}
 
     git_available = False
     git_check_ignored_fn = None
@@ -217,8 +249,16 @@ def _detect_repo_roots(
                     "Worktree ignore pruning: failed to import git_check_ignored: {}",
                     e,
                 )
+        if (root / ".git").is_dir() or (root / ".git").is_file():
+            gitignore_state_by_dir[root] = _extend_gitignore_prune_state(
+                root,
+                root,
+                None,
+            )
     for dirpath, dirnames, filenames in os.walk(root, topdown=True):
         dpath = Path(dirpath)
+        dpath_resolved = dpath.resolve()
+        current_gitignore_state = gitignore_state_by_dir.get(dpath_resolved)
 
         # Prune excluded dirs
         if pre_exclude_spec is not None:
@@ -232,6 +272,55 @@ def _detect_repo_roots(
                     to_remove.append(dn)
             for dn in to_remove:
                 dirnames.remove(dn)
+
+        # When gitignore is an active ignore source, avoid descending into
+        # gitignored directories during repo-root detection. This closes the
+        # gap where backend selection scans large ignored trees before actual
+        # file discovery starts.
+        if (
+            current_gitignore_state is not None
+            and current_gitignore_state.spec is not None
+        ):
+            rel_base = "." if dpath == root else dpath.relative_to(root).as_posix()
+            to_remove = []
+            for dn in dirnames:
+                child_path = dpath / dn
+                child_resolved = child_path.resolve()
+                # Preserve direct child repo / worktree boundaries even when
+                # the parent repo ignores the directory name.
+                if (child_resolved / ".git").is_dir() or (
+                    child_resolved / ".git"
+                ).is_file():
+                    continue
+                child = dn if rel_base == "." else f"{rel_base}/{dn}"
+                if current_gitignore_state.spec.match_file(
+                    child
+                ) or current_gitignore_state.spec.match_file(child + "/"):
+                    to_remove.append(dn)
+            for dn in to_remove:
+                dirnames.remove(dn)
+
+        # Propagate gitignore prune state to directories that remain after
+        # pruning. Repo boundaries start a fresh state from that repository's
+        # own .gitignore lineage so parent rules do not leak into nested repos.
+        if prune_ignored_gitfile_roots:
+            for dn in dirnames:
+                child_path = (dpath / dn).resolve()
+                child_is_repo = (child_path / ".git").is_dir() or (
+                    child_path / ".git"
+                ).is_file()
+                if child_is_repo:
+                    gitignore_state_by_dir[child_path] = _extend_gitignore_prune_state(
+                        root,
+                        child_path,
+                        None,
+                    )
+                elif current_gitignore_state is not None:
+                    gitignore_state_by_dir[child_path] = _extend_gitignore_prune_state(
+                        root,
+                        child_path,
+                        current_gitignore_state,
+                    )
 
         # Repo root if .git dir exists or .git file exists (worktree/submodule)
         git_dir = (dpath / ".git").is_dir()
@@ -286,7 +375,8 @@ def _detect_repo_roots(
                                 on_error=lambda e,
                                 _dpath=dpath,
                                 _parent=parent: logger.debug(
-                                    "Worktree ignore pruning: git check failed for {} (parent={}): {}",
+                                    "Worktree ignore pruning: git check failed "
+                                    "for {} (parent={}): {}",
                                     _dpath,
                                     _parent,
                                     e,
@@ -299,7 +389,8 @@ def _detect_repo_roots(
                             continue
                 except Exception as e:
                     logger.debug(
-                        "Worktree ignore pruning: unexpected failure for {} (parent={}): {}",
+                        "Worktree ignore pruning: unexpected failure for {} "
+                        "(parent={}): {}",
                         dpath,
                         parent,
                         e,
@@ -470,8 +561,10 @@ def _transform_gitignore_line(dir_rel: str, line: str) -> list[str]:
     # Resolve directory prefix with Git semantics
     # Rules (simplified from gitignore docs):
     # - Leading '/' anchors to the directory containing the .gitignore.
-    # - A pattern that contains a '/' (after trimming trailing '/') is anchored to that directory.
-    # - A pattern without any '/' matches in any directory under the .gitignore directory.
+    # - A pattern that contains a '/' (after trimming trailing '/') is
+    #   anchored to that directory.
+    # - A pattern without any '/' matches in any directory under the
+    #   .gitignore directory.
     core = line
     has_slash = "/" in core
 
@@ -512,7 +605,9 @@ def detect_repo_roots(
     """Public helper to detect repo roots under a workspace root.
 
     Applies pruning using config_exclude (gitwildmatch semantics) to avoid
-    descending into heavy trees (e.g., node_modules) while scanning.
+    descending into heavy trees (e.g., node_modules) while scanning. When
+    ``prune_ignored_gitfile_roots`` is enabled, directories ignored by the
+    active repo's .gitignore rules are also pruned during the scan.
     """
     pre_spec = _compile_gitwildmatch(config_exclude or []) if config_exclude else None
     return _detect_repo_roots(
@@ -683,7 +778,8 @@ def _try_build_libgit2_repo_aware(
     except Exception:
         if not _LIBGIT2_WARNED and not os.environ.get("CHUNKHOUND_MCP_MODE"):
             logger.warning(
-                "gitignore_backend=libgit2 requested but pygit2 is not available; falling back to python backend"
+                "gitignore_backend=libgit2 requested but pygit2 is not "
+                "available; falling back to python backend"
             )
             _LIBGIT2_WARNED = True  # type: ignore[assignment]
         return None
@@ -694,7 +790,8 @@ def _try_build_libgit2_repo_aware(
     except Exception:
         if not _LIBGIT2_WARNED and not os.environ.get("CHUNKHOUND_MCP_MODE"):
             logger.warning(
-                "gitignore_backend=libgit2 requested but initialization failed; falling back to python backend"
+                "gitignore_backend=libgit2 requested but initialization "
+                "failed; falling back to python backend"
             )
             _LIBGIT2_WARNED = True  # type: ignore[assignment]
         return None

--- a/tests/ignore/test_detect_repo_roots_gitignore_prune.py
+++ b/tests/ignore/test_detect_repo_roots_gitignore_prune.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None,
+    reason="git required for repo-root detection tests",
+)
+
+
+def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        text=True,
+        capture_output=True,
+    )
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    assert _git(["init"], repo).returncode == 0
+    assert _git(["config", "user.email", "test@example.com"], repo).returncode == 0
+    assert _git(["config", "user.name", "Test User"], repo).returncode == 0
+
+
+def test_detect_repo_roots_prunes_root_gitignored_dirs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    (repo / ".gitignore").write_text("ignored/\n", encoding="utf-8")
+    (repo / "main.py").write_text("print('ok')\n", encoding="utf-8")
+    (repo / "ignored" / "deep" / "deeper").mkdir(parents=True, exist_ok=True)
+    (repo / "ignored" / "deep" / "deeper" / "payload.txt").write_text(
+        "x\n",
+        encoding="utf-8",
+    )
+
+    assert _git(["add", ".gitignore", "main.py"], repo).returncode == 0
+    assert _git(["commit", "-m", "init"], repo).returncode == 0
+
+    from chunkhound.utils import ignore_engine as ignore_engine_module
+
+    real_walk = os.walk
+    visited: list[Path] = []
+
+    def _recording_walk(top: str | os.PathLike[str], topdown: bool = True):
+        for dirpath, dirnames, filenames in real_walk(top, topdown=topdown):
+            visited.append(Path(dirpath).resolve())
+            yield dirpath, dirnames, filenames
+
+    monkeypatch.setattr(ignore_engine_module.os, "walk", _recording_walk)
+
+    roots = ignore_engine_module.detect_repo_roots(
+        repo,
+        prune_ignored_gitfile_roots=True,
+    )
+
+    assert roots == [repo.resolve()]
+
+    ignored_root = (repo / "ignored").resolve()
+    assert ignored_root not in visited
+    assert not any(str(path).startswith(str(ignored_root) + os.sep) for path in visited)

--- a/tests/ignore/test_detect_repo_roots_gitignore_prune.py
+++ b/tests/ignore/test_detect_repo_roots_gitignore_prune.py
@@ -29,6 +29,32 @@ def _init_repo(repo: Path) -> None:
     assert _git(["config", "user.name", "Test User"], repo).returncode == 0
 
 
+def _detect_with_recorded_walk(
+    root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    prune_ignored_gitfile_roots: bool = False,
+    workspace_root_only_gitignore: bool = False,
+) -> tuple[list[Path], list[Path]]:
+    from chunkhound.utils import ignore_engine as ignore_engine_module
+
+    real_walk = os.walk
+    visited: list[Path] = []
+
+    def _recording_walk(top: str | os.PathLike[str], topdown: bool = True):
+        for dirpath, dirnames, filenames in real_walk(top, topdown=topdown):
+            visited.append(Path(dirpath).resolve())
+            yield dirpath, dirnames, filenames
+
+    monkeypatch.setattr(ignore_engine_module.os, "walk", _recording_walk)
+    roots = ignore_engine_module.detect_repo_roots(
+        root,
+        prune_ignored_gitfile_roots=prune_ignored_gitfile_roots,
+        workspace_root_only_gitignore=workspace_root_only_gitignore,
+    )
+    return roots, visited
+
+
 def test_detect_repo_roots_prunes_root_gitignored_dirs(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -47,20 +73,9 @@ def test_detect_repo_roots_prunes_root_gitignored_dirs(
     assert _git(["add", ".gitignore", "main.py"], repo).returncode == 0
     assert _git(["commit", "-m", "init"], repo).returncode == 0
 
-    from chunkhound.utils import ignore_engine as ignore_engine_module
-
-    real_walk = os.walk
-    visited: list[Path] = []
-
-    def _recording_walk(top: str | os.PathLike[str], topdown: bool = True):
-        for dirpath, dirnames, filenames in real_walk(top, topdown=topdown):
-            visited.append(Path(dirpath).resolve())
-            yield dirpath, dirnames, filenames
-
-    monkeypatch.setattr(ignore_engine_module.os, "walk", _recording_walk)
-
-    roots = ignore_engine_module.detect_repo_roots(
+    roots, visited = _detect_with_recorded_walk(
         repo,
+        monkeypatch,
         prune_ignored_gitfile_roots=True,
     )
 
@@ -69,3 +84,92 @@ def test_detect_repo_roots_prunes_root_gitignored_dirs(
     ignored_root = (repo / "ignored").resolve()
     assert ignored_root not in visited
     assert not any(str(path).startswith(str(ignored_root) + os.sep) for path in visited)
+
+
+def test_detect_repo_roots_prunes_nested_gitignore_scopes_without_root_patterns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    (repo / "data" / ".gitignore").parent.mkdir(parents=True, exist_ok=True)
+    (repo / "data" / ".gitignore").write_text("binaries/\n", encoding="utf-8")
+    (repo / "data" / "keep.txt").write_text("keep\n", encoding="utf-8")
+    (repo / "data" / "binaries" / "deep" / "payload.bin").parent.mkdir(
+        parents=True, exist_ok=True
+    )
+    (repo / "data" / "binaries" / "deep" / "payload.bin").write_text(
+        "x\n",
+        encoding="utf-8",
+    )
+
+    roots, visited = _detect_with_recorded_walk(
+        repo,
+        monkeypatch,
+        prune_ignored_gitfile_roots=True,
+    )
+
+    assert roots == [repo.resolve()]
+
+    ignored_root = (repo / "data" / "binaries").resolve()
+    assert ignored_root not in visited
+    assert not any(str(path).startswith(str(ignored_root) + os.sep) for path in visited)
+
+
+def test_detect_repo_roots_prunes_nonrepo_workspace_gitignore_overlay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / ".gitignore").write_text("datasets/\n", encoding="utf-8")
+    (workspace / "datasets" / "raw" / "payload.json").parent.mkdir(
+        parents=True, exist_ok=True
+    )
+    (workspace / "datasets" / "raw" / "payload.json").write_text(
+        "{}\n",
+        encoding="utf-8",
+    )
+
+    repo = workspace / "repo"
+    _init_repo(repo)
+
+    roots, visited = _detect_with_recorded_walk(
+        workspace,
+        monkeypatch,
+        prune_ignored_gitfile_roots=True,
+        workspace_root_only_gitignore=True,
+    )
+
+    assert roots == [repo.resolve()]
+
+    ignored_root = (workspace / "datasets").resolve()
+    assert ignored_root not in visited
+    assert not any(str(path).startswith(str(ignored_root) + os.sep) for path in visited)
+
+
+def test_detect_repo_roots_ignores_external_symlink_dirs_during_state_propagation(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / ".gitignore").write_text("ignored/\n", encoding="utf-8")
+
+    external_repo = tmp_path / "external-repo"
+    _init_repo(external_repo)
+
+    symlink_path = repo / "linked-external"
+    try:
+        symlink_path.symlink_to(external_repo, target_is_directory=True)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlink creation required for test: {exc}")
+
+    from chunkhound.utils import ignore_engine as ignore_engine_module
+
+    roots = ignore_engine_module.detect_repo_roots(
+        repo,
+        prune_ignored_gitfile_roots=True,
+    )
+
+    assert roots == [repo.resolve()]

--- a/tests/unit/test_directory_service_pattern_normalization.py
+++ b/tests/unit/test_directory_service_pattern_normalization.py
@@ -6,8 +6,9 @@ the service leaves patterns starting with "**/" unchanged when delegating to
 the coordinator.
 """
 
-import pytest
 from pathlib import Path
+
+import pytest
 
 from chunkhound.core.config.indexing_config import IndexingConfig
 from chunkhound.services.directory_indexing_service import DirectoryIndexingService
@@ -54,3 +55,17 @@ async def test_patterns_not_double_prefixed(tmp_path: Path):
     # And a sanity check: python pattern should remain exactly "**/*.py"
     assert "**/*.py" in patts, "Expected default python pattern '**/*.py'"
 
+
+@pytest.mark.asyncio
+async def test_process_directory_reports_discovery_phase_first(tmp_path: Path) -> None:
+    coord = _CaptureCoordinator()
+    messages: list[str] = []
+    svc = DirectoryIndexingService(
+        indexing_coordinator=coord,
+        config=_DummyConfig(),
+        progress_callback=messages.append,
+    )
+
+    await svc.process_directory(tmp_path, no_embeddings=True)
+
+    assert messages[0] == "Discovering files..."

--- a/tests/unit/test_discovery_backend_gitignore_prune.py
+++ b/tests/unit/test_discovery_backend_gitignore_prune.py
@@ -13,9 +13,14 @@ class _FakeDb:
 
 
 class _IndexingConfig:
-    def __init__(self, sources: list[str]) -> None:
+    def __init__(
+        self,
+        sources: list[str],
+        workspace_gitignore_nonrepo: bool = False,
+    ) -> None:
         self.discovery_backend = "auto"
         self._sources = sources
+        self.workspace_gitignore_nonrepo = workspace_gitignore_nonrepo
 
     def resolve_ignore_sources(self) -> list[str]:
         return list(self._sources)
@@ -37,15 +42,21 @@ async def test_auto_backend_prunes_gitignored_repo_roots_when_gitignore_active(
         base_directory=tmp_path,
     )
 
-    calls: list[bool] = []
+    calls: list[tuple[bool, bool]] = []
 
     def _fake_repo_roots(
         directory: Path,
         config_exclude: list[str],
         prune_ignored_gitfile_roots: bool = False,
+        workspace_root_only_gitignore: bool = False,
     ) -> list[Path]:
         del config_exclude
-        calls.append(prune_ignored_gitfile_roots)
+        calls.append(
+            (
+                prune_ignored_gitfile_roots,
+                workspace_root_only_gitignore,
+            )
+        )
         return [Path(directory).resolve()]
 
     monkeypatch.setattr(coordinator, "_get_or_detect_repo_roots", _fake_repo_roots)
@@ -63,7 +74,8 @@ async def test_auto_backend_prunes_gitignored_repo_roots_when_gitignore_active(
     )
 
     assert files == [file_path]
-    assert calls == [True]
+    assert calls
+    assert all(call == (True, False) for call in calls)
     assert getattr(coordinator, "_resolved_discovery_backend", None) == "git_only"
 
 
@@ -81,15 +93,21 @@ async def test_auto_backend_skips_gitignore_prune_without_gitignore_source(
         config=SimpleNamespace(indexing=_IndexingConfig(["config"])),
     )
 
-    calls: list[bool] = []
+    calls: list[tuple[bool, bool]] = []
 
     def _fake_repo_roots(
         directory: Path,
         config_exclude: list[str],
         prune_ignored_gitfile_roots: bool = False,
+        workspace_root_only_gitignore: bool = False,
     ) -> list[Path]:
         del config_exclude
-        calls.append(prune_ignored_gitfile_roots)
+        calls.append(
+            (
+                prune_ignored_gitfile_roots,
+                workspace_root_only_gitignore,
+            )
+        )
         return [Path(directory).resolve()]
 
     monkeypatch.setattr(coordinator, "_get_or_detect_repo_roots", _fake_repo_roots)
@@ -107,5 +125,108 @@ async def test_auto_backend_skips_gitignore_prune_without_gitignore_source(
     )
 
     assert files == [file_path]
-    assert calls == [False, False]
+    assert calls
+    assert all(call == (False, False) for call in calls)
     assert getattr(coordinator, "_resolved_discovery_backend", None) == "git_only"
+
+
+@pytest.mark.asyncio
+async def test_auto_backend_passes_workspace_nonrepo_overlay_to_repo_root_detection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    file_path = tmp_path / "main.py"
+    file_path.write_text("print('ok')\n", encoding="utf-8")
+
+    coordinator = IndexingCoordinator(
+        database_provider=_FakeDb(),
+        base_directory=tmp_path,
+        config=SimpleNamespace(
+            indexing=_IndexingConfig(
+                ["gitignore"],
+                workspace_gitignore_nonrepo=True,
+            )
+        ),
+    )
+
+    calls: list[tuple[bool, bool]] = []
+
+    def _fake_repo_roots(
+        directory: Path,
+        config_exclude: list[str],
+        prune_ignored_gitfile_roots: bool = False,
+        workspace_root_only_gitignore: bool = False,
+    ) -> list[Path]:
+        del config_exclude
+        calls.append(
+            (
+                prune_ignored_gitfile_roots,
+                workspace_root_only_gitignore,
+            )
+        )
+        return [Path(directory).resolve()]
+
+    monkeypatch.setattr(coordinator, "_get_or_detect_repo_roots", _fake_repo_roots)
+    monkeypatch.setattr(
+        coordinator,
+        "_discover_files_via_git",
+        lambda directory, patterns, exclude_patterns, fallback_to_python: [file_path],
+    )
+
+    files = await coordinator._discover_files(
+        tmp_path,
+        patterns=["**/*.py"],
+        exclude_patterns=[],
+        parallel_discovery=False,
+    )
+
+    assert files == [file_path]
+    assert calls
+    assert all(call == (True, True) for call in calls)
+    assert getattr(coordinator, "_resolved_discovery_backend", None) == "git_only"
+
+
+def test_repo_root_cache_distinguishes_workspace_nonrepo_overlay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator = IndexingCoordinator(
+        database_provider=_FakeDb(),
+        base_directory=tmp_path,
+    )
+
+    calls: list[bool] = []
+
+    from chunkhound.utils import ignore_engine as ignore_engine_module
+
+    def _fake_detect(
+        root: Path,
+        config_exclude: list[str],
+        *,
+        prune_ignored_gitfile_roots: bool = False,
+        workspace_root_only_gitignore: bool = False,
+    ) -> list[Path]:
+        del config_exclude, prune_ignored_gitfile_roots
+        calls.append(workspace_root_only_gitignore)
+        if workspace_root_only_gitignore:
+            return [root / "overlay"]
+        return [root / "default"]
+
+    monkeypatch.setattr(ignore_engine_module, "detect_repo_roots", _fake_detect)
+
+    without_overlay = coordinator._get_or_detect_repo_roots(
+        tmp_path,
+        [],
+        prune_ignored_gitfile_roots=True,
+        workspace_root_only_gitignore=False,
+    )
+    with_overlay = coordinator._get_or_detect_repo_roots(
+        tmp_path,
+        [],
+        prune_ignored_gitfile_roots=True,
+        workspace_root_only_gitignore=True,
+    )
+
+    assert calls == [False, True]
+    assert without_overlay == [tmp_path / "default"]
+    assert with_overlay == [tmp_path / "overlay"]

--- a/tests/unit/test_discovery_backend_gitignore_prune.py
+++ b/tests/unit/test_discovery_backend_gitignore_prune.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from chunkhound.services.indexing_coordinator import IndexingCoordinator
+
+
+class _FakeDb:
+    db_path = None
+
+
+class _IndexingConfig:
+    def __init__(self, sources: list[str]) -> None:
+        self.discovery_backend = "auto"
+        self._sources = sources
+
+    def resolve_ignore_sources(self) -> list[str]:
+        return list(self._sources)
+
+    def get_effective_config_excludes(self) -> list[str]:
+        return []
+
+
+@pytest.mark.asyncio
+async def test_auto_backend_prunes_gitignored_repo_roots_when_gitignore_active(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    file_path = tmp_path / "main.py"
+    file_path.write_text("print('ok')\n", encoding="utf-8")
+
+    coordinator = IndexingCoordinator(
+        database_provider=_FakeDb(),
+        base_directory=tmp_path,
+    )
+
+    calls: list[bool] = []
+
+    def _fake_repo_roots(
+        directory: Path,
+        config_exclude: list[str],
+        prune_ignored_gitfile_roots: bool = False,
+    ) -> list[Path]:
+        del config_exclude
+        calls.append(prune_ignored_gitfile_roots)
+        return [Path(directory).resolve()]
+
+    monkeypatch.setattr(coordinator, "_get_or_detect_repo_roots", _fake_repo_roots)
+    monkeypatch.setattr(
+        coordinator,
+        "_discover_files_via_git",
+        lambda directory, patterns, exclude_patterns, fallback_to_python: [file_path],
+    )
+
+    files = await coordinator._discover_files(
+        tmp_path,
+        patterns=["**/*.py"],
+        exclude_patterns=[],
+        parallel_discovery=False,
+    )
+
+    assert files == [file_path]
+    assert calls == [True]
+    assert getattr(coordinator, "_resolved_discovery_backend", None) == "git_only"
+
+
+@pytest.mark.asyncio
+async def test_auto_backend_skips_gitignore_prune_without_gitignore_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    file_path = tmp_path / "main.py"
+    file_path.write_text("print('ok')\n", encoding="utf-8")
+
+    coordinator = IndexingCoordinator(
+        database_provider=_FakeDb(),
+        base_directory=tmp_path,
+        config=SimpleNamespace(indexing=_IndexingConfig(["config"])),
+    )
+
+    calls: list[bool] = []
+
+    def _fake_repo_roots(
+        directory: Path,
+        config_exclude: list[str],
+        prune_ignored_gitfile_roots: bool = False,
+    ) -> list[Path]:
+        del config_exclude
+        calls.append(prune_ignored_gitfile_roots)
+        return [Path(directory).resolve()]
+
+    monkeypatch.setattr(coordinator, "_get_or_detect_repo_roots", _fake_repo_roots)
+    monkeypatch.setattr(
+        coordinator,
+        "_discover_files_via_git",
+        lambda directory, patterns, exclude_patterns, fallback_to_python: [file_path],
+    )
+
+    files = await coordinator._discover_files(
+        tmp_path,
+        patterns=["**/*.py"],
+        exclude_patterns=[],
+        parallel_discovery=False,
+    )
+
+    assert files == [file_path]
+    assert calls == [False, False]
+    assert getattr(coordinator, "_resolved_discovery_backend", None) == "git_only"


### PR DESCRIPTION
Note: This is an AI Generated change + PR. I am new to the codebase and have a few days to turnaround some required functionality, so I may be moving fast and (hopefully not) breaking things.

I'm on Discord (Crowe), please feel free to reach out directly if you have questions / concerns

---

## Summary

ChunkHound could appear to hang during `chunkhound index` in repositories with very large gitignored trees (700gb of binaries in my case). The stall happened before parsing started, while repo-root detection was still walking ignored directories during backend selection. Using the command line specified ignore flags would prevent this stall.

## Bug / impact

- Repo-root detection pruned `config_exclude` patterns but not `.gitignore` rules.
- `git_only` still hit the slow path because repo-root detection ran before `git ls-files`.
- Large ignored top-level trees could be traversed even though Git would exclude them from indexing.
- The last visible progress message, `Starting file processing...`, was misleading because discovery had not completed yet.

## Fix approach

- Thread the resolved ignore sources into auto backend repo-root detection.
- Enable gitignore-based pruning during repo-root detection when `gitignore` is active.
- Maintain incremental `.gitignore` prune state while walking so ignored subtrees are skipped early.
- Preserve direct child repo / worktree boundaries so nested repositories are still detected.
- Update the progress text to `Discovering files...` so the visible phase matches the actual work being done.

## Tests added

- Added repo-root detection coverage to verify root-level gitignored directories are not descended into.
- Added auto backend coverage for both `gitignore`-active and non-`gitignore` cases.
- Added progress-message coverage for the discovery phase.
- Kept existing nested repo / ignored worktree coverage green.

## Validation

- `uv run pytest tests/unit/test_directory_service_pattern_normalization.py tests/unit/test_discovery_backend_gitignore_prune.py tests/ignore/test_detect_repo_roots_gitignore_prune.py -v`
- `uv run pytest tests/cli/test_index_simulate_prune_ignored_worktree.py -v`
- `uv run pytest tests/integration/test_discovery_layouts.py -k "layout_D or auto_selects_python_git_gitonly" -v`