### PR TITLE
fix(db): commit transaction before HNSW recreation to prevent CreateDeltaIndex crash (issue #280)

### DIFF
--- a/chunkhound/providers/database/duckdb_provider.py
+++ b/chunkhound/providers/database/duckdb_provider.py
@@ -614,18 +614,21 @@ class DuckDBProvider(SerialDatabaseProvider):
 
             result = mutation_func()
 
+            # Commit data changes before recreating HNSW indexes. DuckDB VSS HNSW indexes
+            # do not support CreateDeltaIndex, so committing a transaction that contains an
+            # HNSW CREATE triggers a BoundIndex::CreateDeltaIndex assertion failure.
+            if transactional:
+                self._executor_commit_transaction(conn, state, False)
+
             for index_info in existing_indexes:
                 self._executor_recreate_vector_index_from_info(
                     conn, state, index_info
                 )
 
-            if transactional:
-                self._executor_commit_transaction(conn, state, True)
-            else:
-                self._executor_maybe_checkpoint(conn, state, True)
+            self._executor_maybe_checkpoint(conn, state, True)
             return result
         except Exception as e:
-            if transactional:
+            if transactional and state.get("transaction_active", False):
                 try:
                     self._executor_rollback_transaction(conn, state)
                 except Exception as rollback_error:
@@ -1752,6 +1755,12 @@ class DuckDBProvider(SerialDatabaseProvider):
 
             result = mutation_func()
 
+            # Commit data changes before recreating HNSW indexes. DuckDB VSS HNSW indexes
+            # do not support CreateDeltaIndex, so committing a transaction that contains an
+            # HNSW CREATE triggers a BoundIndex::CreateDeltaIndex assertion failure.
+            if transactional:
+                self._executor_commit_transaction(conn, state, False)
+
             if existing_indexes:
                 logger.info(
                     f"Recreating {len(existing_indexes)} HNSW indexes after {mutation_label}"
@@ -1762,10 +1771,7 @@ class DuckDBProvider(SerialDatabaseProvider):
                     )
                 indexes_recreated = True
 
-            if transactional:
-                self._executor_commit_transaction(conn, state, True)
-            else:
-                self._executor_maybe_checkpoint(conn, state, True)
+            self._executor_maybe_checkpoint(conn, state, True)
             logger.info(f"{mutation_label} completed successfully with HNSW safety")
             return result
         except Exception as e:

--- a/tests/unit/test_duckdb_chunk_delete_hnsw.py
+++ b/tests/unit/test_duckdb_chunk_delete_hnsw.py
@@ -158,6 +158,76 @@ def test_process_file_avoids_in_transaction_hnsw_guard_for_modified_chunk_delete
         provider.disconnect(skip_checkpoint=True)
 
 
+def test_reindex_with_existing_hnsw_does_not_crash_connection(
+    tmp_path: Path,
+):
+    """Regression test for issue #280: HNSW recreation must happen after COMMIT.
+
+    Before the fix, _executor_run_hnsw_guarded_mutation would recreate the HNSW
+    index inside the open transaction, triggering:
+      BoundIndex::CreateDeltaIndex is not supported for this index type
+    which fatally invalidates the DuckDB connection.
+
+    This test exercises the full index → embed → re-index path without
+    monkeypatching so any regression in commit ordering causes a real crash.
+    """
+    pytest.importorskip("duckdb")
+
+    provider = DuckDBProvider(db_path=tmp_path / "db.duckdb", base_directory=tmp_path)
+    provider.connect()
+    try:
+        coordinator = IndexingCoordinator(provider, tmp_path)
+
+        test_file = tmp_path / "sample.py"
+        test_file.write_text(
+            "def alpha():\n"
+            "    return 1\n\n"
+            "def beta():\n"
+            "    return 2\n"
+        )
+
+        first_result = asyncio.run(
+            coordinator.process_file(test_file, skip_embeddings=True)
+        )
+        assert first_result["status"] == "success"
+
+        first_chunk_ids = [
+            int(c["id"])
+            for c in provider.get_chunks_by_file_id(
+                first_result["file_id"], as_model=False
+            )
+        ]
+        _seed_embeddings(provider, first_chunk_ids)
+
+        hnsw_indexes = _get_hnsw_index_names(provider)
+        if not hnsw_indexes:
+            pytest.skip("DuckDB HNSW indexes are unavailable in this environment")
+
+        # Modify the file so re-indexing deletes old chunks while HNSW indexes exist.
+        # Before the fix this triggered the CreateDeltaIndex assertion failure.
+        test_file.write_text(
+            "def alpha():\n"
+            "    return 1\n\n"
+            "def gamma():\n"
+            "    return 3\n"
+        )
+
+        second_result = asyncio.run(
+            coordinator.process_file(test_file, skip_embeddings=True)
+        )
+        assert second_result["status"] == "success"
+
+        # Connection must still be usable — it would be dead if CreateDeltaIndex fired.
+        live_count = provider.execute_query(
+            "SELECT COUNT(*) AS count FROM chunks", []
+        )
+        assert live_count[0]["count"] > 0
+
+        assert _get_hnsw_index_names(provider) == hnsw_indexes
+    finally:
+        provider.disconnect(skip_checkpoint=True)
+
+
 def test_delete_chunks_batch_still_uses_hnsw_guard_outside_transaction(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):


### PR DESCRIPTION


DuckDB VSS HNSW indexes do not support CreateDeltaIndex, so committing a transaction that contains an HNSW CREATE triggers a fatal assertion failure (BoundIndex::CreateDeltaIndex is not supported for this index type) that invalidates the entire connection.

Move HNSW index recreation to after COMMIT in both _executor_run_embedding_table_hnsw_guarded_mutation and _executor_run_hnsw_guarded_mutation so the transaction only contains data mutations. Also fix the exception handler to check transaction_active state rather than the transactional flag, so post-commit HNSW failures correctly fall through to best-effort restore instead of attempting a redundant rollback.