### PR TITLE
feat: add --index-unknown-files flag (issue #277)

### DIFF
--- a/chunkhound/core/config/indexing_config.py
+++ b/chunkhound/core/config/indexing_config.py
@@ -62,6 +62,14 @@ class IndexingConfig(BaseModel):
         description="Detect and index SQL embedded in string literals",
     )
 
+    index_unknown_files: bool = Field(
+        default=False,
+        description=(
+            "Index files with unrecognized extensions as plain text. "
+            "Binary files (containing null bytes) are still skipped."
+        ),
+    )
+
     # File parsing safety
     per_file_timeout_seconds: float = Field(
         default=3.0,
@@ -378,6 +386,16 @@ class IndexingConfig(BaseModel):
             action="store_true",
             help="Disable detection of SQL code embedded in string literals",
         )
+        parser.add_argument(
+            "--index-unknown-files",
+            action="store_true",
+            default=False,
+            dest="index_unknown_files",
+            help=(
+                "Index files with unrecognized extensions as plain text "
+                "(binary files are still skipped)"
+            ),
+        )
 
     @classmethod
     def load_from_env(cls) -> dict[str, Any]:
@@ -466,6 +484,9 @@ class IndexingConfig(BaseModel):
         if sql_detect := os.getenv("CHUNKHOUND_INDEXING__DETECT_EMBEDDED_SQL"):
             config["detect_embedded_sql"] = sql_detect.lower() in ("true", "1", "yes")
 
+        if index_unknown := os.getenv("CHUNKHOUND_INDEXING__INDEX_UNKNOWN_FILES"):
+            config["index_unknown_files"] = index_unknown.lower() in ("true", "1", "yes")
+
         return config
 
     @model_validator(mode="before")
@@ -502,6 +523,17 @@ class IndexingConfig(BaseModel):
             # Be permissive; validation will catch true errors later
             pass
         return data
+
+    @model_validator(mode="after")
+    def _inject_wildcard_for_unknown_files(self) -> "IndexingConfig":
+        """Append **/* to include patterns when index_unknown_files is enabled.
+
+        This ensures files with unrecognised extensions are discovered during
+        the directory scan. Existing exclude patterns still apply.
+        """
+        if self.index_unknown_files and "**/*" not in self.include:
+            self.include = list(self.include) + ["**/*"]
+        return self
 
     # Convenience helper for callers to interpret ignore source selection
     def resolve_ignore_sources(self) -> list[str]:
@@ -613,6 +645,9 @@ class IndexingConfig(BaseModel):
 
         if hasattr(args, "no_detect_embedded_sql") and args.no_detect_embedded_sql:
             overrides["detect_embedded_sql"] = False
+
+        if hasattr(args, "index_unknown_files") and args.index_unknown_files:
+            overrides["index_unknown_files"] = True
 
         return overrides
 

--- a/chunkhound/services/batch_processor.py
+++ b/chunkhound/services/batch_processor.py
@@ -222,22 +222,59 @@ def process_file_batch(
             )
             t0 = perf_counter()
             if language == Language.UNKNOWN:
-                results.append(
-                    ParsedFileResult(
-                        file_path=file_path,
-                        chunks=[],
-                        language=language,
-                        file_size=file_stat.st_size,
-                        file_mtime=file_stat.st_mtime,
-                        status="skipped",
-                        error="Unknown file type",
+                if not config_dict.get("index_unknown_files"):
+                    results.append(
+                        ParsedFileResult(
+                            file_path=file_path,
+                            chunks=[],
+                            language=language,
+                            file_size=file_stat.st_size,
+                            file_mtime=file_stat.st_mtime,
+                            status="skipped",
+                            error="Unknown file type",
+                        )
                     )
-                )
-                _dbg_log(
-                    f"END   file={file_path} status=skipped reason=unknown_type dur_ms={(perf_counter() - t0) * 1000:.1f}"
-                )
-                logger.debug("Skipping file with unknown type: {}", file_path)
-                continue
+                    _dbg_log(
+                        f"END   file={file_path} status=skipped reason=unknown_type dur_ms={(perf_counter() - t0) * 1000:.1f}"
+                    )
+                    logger.debug("Skipping file with unknown type: {}", file_path)
+                    continue
+                # Binary guard: read first 8 KB and check for null bytes
+                try:
+                    with open(file_path, "rb") as _fh:
+                        _sample = _fh.read(8192)
+                    if b"\x00" in _sample:
+                        results.append(
+                            ParsedFileResult(
+                                file_path=file_path,
+                                chunks=[],
+                                language=language,
+                                file_size=file_stat.st_size,
+                                file_mtime=file_stat.st_mtime,
+                                status="skipped",
+                                error="binary_file",
+                            )
+                        )
+                        _dbg_log(
+                            f"END   file={file_path} status=skipped reason=binary_file dur_ms={(perf_counter() - t0) * 1000:.1f}"
+                        )
+                        logger.debug("Skipping binary file: {}", file_path)
+                        continue
+                except OSError as _e:
+                    results.append(
+                        ParsedFileResult(
+                            file_path=file_path,
+                            chunks=[],
+                            language=language,
+                            file_size=file_stat.st_size,
+                            file_mtime=file_stat.st_mtime,
+                            status="error",
+                            error=str(_e),
+                        )
+                    )
+                    continue
+                language = Language.TEXT
+                logger.debug("Indexing unknown file as text: {}", file_path)
 
             # Skip large config/data files (config files are typically < 20KB)
             if language.is_structured_config_language:

--- a/docs/superpowers/specs/2026-05-13-index-unknown-files-design.md
+++ b/docs/superpowers/specs/2026-05-13-index-unknown-files-design.md
@@ -1,0 +1,156 @@
+# Design: `index_unknown_files` Flag
+
+**Date:** 2026-05-13
+**Issue:** [#277 — Chunkhound no longer indexes unknown files in version 5](https://github.com/chunkhound/chunkhound/issues/277)
+**Branch:** `unknown_files`
+
+---
+
+## Problem
+
+In v5, files with unrecognized extensions (`Dockerfile`, `.proto`, `.feature`, etc.) are silently skipped at `batch_processor.py:224` when `language == Language.UNKNOWN`. Before v5 a bug accidentally indexed these as plain text — users found this useful. The fix removed the behavior; this design adds it back as an explicit, opt-in flag.
+
+## Goal
+
+A single flag that, when enabled:
+1. Causes unknown-extension files to be **discovered** during directory scan
+2. Causes them to be **parsed as plain text** (via `TextMapping`)
+3. Skips files that are **binary** (null-byte heuristic) to avoid polluting the index
+
+---
+
+## Customer-Facing Interfaces
+
+All three surfaces must expose the flag:
+
+| Interface | Key / Flag | Default |
+|---|---|---|
+| CLI | `--index-unknown-files` | off (store_true) |
+| `.chunkhound.json` | `"indexing": { "index_unknown_files": true }` | `false` |
+| Environment variable | `CHUNKHOUND_INDEXING__INDEX_UNKNOWN_FILES=true` | unset |
+
+---
+
+## Architecture
+
+### 1. `IndexingConfig` — new public field
+
+**File:** `chunkhound/core/config/indexing_config.py`
+
+Add to the public fields section (alongside `detect_embedded_sql`, `per_file_timeout_seconds`, etc.):
+
+```python
+index_unknown_files: bool = Field(
+    default=False,
+    description="Index files with unrecognized extensions as plain text",
+)
+```
+
+### 2. Discovery — append `**/*` when flag is on
+
+**File:** `chunkhound/core/config/indexing_config.py` — `model_validator(mode="after")`
+
+When `index_unknown_files=True`, append `**/*` to the `include` list (if not already present). This ensures files like `Dockerfile` and `schema.graphql` are picked up during the directory walk. Existing `exclude` patterns (`node_modules`, `.git`, `.env`, etc.) continue to apply and filter them out.
+
+The `**/*` pattern is appended regardless of whether the user has a custom or default `include` list.
+
+### 3. Parsing — binary guard + TEXT fallback
+
+**File:** `chunkhound/services/batch_processor.py`
+
+Replace the current unconditional skip at line 224:
+
+```python
+# Current:
+if language == Language.UNKNOWN:
+    # ... skip with status="skipped"
+
+# New:
+if language == Language.UNKNOWN:
+    if not config_dict.get("index_unknown_files"):
+        # ... skip (unchanged behaviour when flag is off)
+    else:
+        # Binary guard: read first 8 KB, check for null bytes
+        try:
+            with open(file_path, "rb") as fh:
+                sample = fh.read(8192)
+            if b"\x00" in sample:
+                # ... skip with status="skipped", error="binary_file"
+                continue
+        except OSError:
+            # ... skip with status="error"
+            continue
+        language = Language.TEXT  # treat as plain text, fall through to normal parse path
+```
+
+No changes needed to `config_dict` propagation — `index_unknown_files` flows automatically via the existing `model_dump()` path.
+
+### 4. CLI flag
+
+**File:** `chunkhound/core/config/indexing_config.py` — `add_cli_arguments()`
+
+```python
+parser.add_argument(
+    "--index-unknown-files",
+    action="store_true",
+    default=False,
+    dest="index_unknown_files",
+    help="Index files with unrecognized extensions as plain text (binary files are still skipped)",
+)
+```
+
+This is picked up automatically by all three commands that call `add_config_arguments(..., ["indexing", ...])`: `index`, `mcp`, `_daemon`.
+
+### 5. Environment variable
+
+**File:** `chunkhound/core/config/indexing_config.py` — `load_from_env()`
+
+```python
+if val := os.getenv("CHUNKHOUND_INDEXING__INDEX_UNKNOWN_FILES"):
+    overrides["index_unknown_files"] = val.lower() in ("1", "true", "yes")
+```
+
+---
+
+## Data Flow
+
+```
+Directory scan
+  └─ include patterns  ← **/* appended when flag=on
+       └─ exclude patterns (unchanged)
+            └─ discovered files
+                 └─ batch_processor.py
+                      ├─ Language.UNKNOWN + flag=off  → skip (status="skipped")
+                      ├─ Language.UNKNOWN + flag=on + binary  → skip (status="skipped", error="binary_file")
+                      ├─ Language.UNKNOWN + flag=on + text  → Language.TEXT → TextMapping parse
+                      └─ Language.known  → normal parse path (unchanged)
+```
+
+---
+
+## Error Handling
+
+- `OSError` reading the 8 KB sample → skip with `status="error"`
+- Binary detection is conservative: any null byte in the first 8 KB is treated as binary
+- Log message on text path: `logger.debug("Indexing unknown file as text: {}", file_path)`
+- Log message on binary skip: `logger.debug("Skipping binary file: {}", file_path)`
+
+---
+
+## Testing
+
+- Unit test in `tests/` asserting:
+  - `Dockerfile` (text) is indexed when flag=on, skipped when flag=off
+  - A binary file (contains null bytes) is skipped even when flag=on
+  - The `**/*` pattern is appended to include list when flag=on
+  - CLI `--index-unknown-files` sets the field to `True`
+  - Env var `CHUNKHOUND_INDEXING__INDEX_UNKNOWN_FILES=true` sets the field to `True`
+- Add to smoke tests: index a directory containing an unknown-extension text file and verify it appears in results
+
+---
+
+## Out of Scope
+
+- Adding new extensions to the `EXTENSION_TO_LANGUAGE` map (separate concern)
+- Detecting file encoding (UTF-8 vs Latin-1) — `TextMapping` already handles this gracefully
+- MCP tool parameters — indexing config is set at server startup, not per-tool-call

--- a/docs/superpowers/specs/2026-05-13-index-unknown-files-design.md
+++ b/docs/superpowers/specs/2026-05-13-index-unknown-files-design.md
@@ -139,13 +139,105 @@ Directory scan
 
 ## Testing
 
-- Unit test in `tests/` asserting:
-  - `Dockerfile` (text) is indexed when flag=on, skipped when flag=off
-  - A binary file (contains null bytes) is skipped even when flag=on
-  - The `**/*` pattern is appended to include list when flag=on
-  - CLI `--index-unknown-files` sets the field to `True`
-  - Env var `CHUNKHOUND_INDEXING__INDEX_UNKNOWN_FILES=true` sets the field to `True`
-- Add to smoke tests: index a directory containing an unknown-extension text file and verify it appears in results
+Tests are split into two phases: **before fix** (written first, verify current behaviour is preserved) and **after fix** (written first as failing tests that drive the implementation).
+
+### Before fix — regression guard (must pass now and after)
+
+These confirm the default "flag-off" path is untouched by the implementation.
+
+**File:** `tests/test_index_unknown_files.py`
+
+```python
+# Verify unknown files are skipped when flag=off (existing behaviour)
+def test_unknown_file_skipped_by_default(tmp_path):
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text("FROM python:3.12\n")
+    config = IndexingConfig()                         # flag defaults to False
+    assert "**/*" not in config.include               # no wildcard injected
+    results = process_file_batch([dockerfile], config.model_dump())
+    assert results[0].status == "skipped"
+    assert results[0].error == "Unknown file type"
+
+# Verify known-extension files are unaffected
+def test_known_extension_unaffected_when_flag_off(tmp_path):
+    pyfile = tmp_path / "main.py"
+    pyfile.write_text("x = 1\n")
+    config = IndexingConfig()
+    results = process_file_batch([pyfile], config.model_dump())
+    assert results[0].status != "skipped"
+
+# Verify **/* is NOT added to include when flag=off
+def test_wildcard_not_injected_when_flag_off():
+    config = IndexingConfig()
+    assert "**/*" not in config.include
+```
+
+### After fix — new behaviour (failing before implementation, passing after)
+
+**File:** `tests/test_index_unknown_files.py` (same file, separate class)
+
+```python
+# Text unknown file is indexed when flag=on
+def test_unknown_text_file_indexed_when_flag_on(tmp_path):
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text("FROM python:3.12\nRUN pip install uv\n")
+    config = IndexingConfig(index_unknown_files=True)
+    results = process_file_batch([dockerfile], config.model_dump())
+    assert results[0].status == "parsed"
+    assert len(results[0].chunks) > 0
+
+# Binary unknown file is still skipped even when flag=on
+def test_binary_unknown_file_skipped_when_flag_on(tmp_path):
+    binfile = tmp_path / "model.bin"
+    binfile.write_bytes(b"\x00\x01\x02" * 100)
+    config = IndexingConfig(index_unknown_files=True)
+    results = process_file_batch([binfile], config.model_dump())
+    assert results[0].status == "skipped"
+    assert results[0].error == "binary_file"
+
+# **/* is appended to include when flag=on
+def test_wildcard_injected_when_flag_on():
+    config = IndexingConfig(index_unknown_files=True)
+    assert "**/*" in config.include
+
+# **/* is appended even when user has custom include list
+def test_wildcard_appended_to_custom_include():
+    config = IndexingConfig(index_unknown_files=True, include=["**/*.py"])
+    assert "**/*" in config.include
+    assert "**/*.py" in config.include
+
+# CLI flag sets the field
+def test_cli_flag_sets_index_unknown_files():
+    parser = argparse.ArgumentParser()
+    IndexingConfig.add_cli_arguments(parser)
+    args = parser.parse_args(["--index-unknown-files"])
+    assert args.index_unknown_files is True
+
+# Env var sets the field
+def test_env_var_sets_index_unknown_files(monkeypatch):
+    monkeypatch.setenv("CHUNKHOUND_INDEXING__INDEX_UNKNOWN_FILES", "true")
+    config = IndexingConfig.load_from_env()
+    assert config.index_unknown_files is True
+
+# JSON config sets the field
+def test_json_config_sets_index_unknown_files():
+    config = IndexingConfig.model_validate({"index_unknown_files": True})
+    assert config.index_unknown_files is True
+```
+
+### Smoke test addition
+
+**File:** `tests/test_smoke.py` — add to the existing `TestIndexing` class (or equivalent):
+
+```python
+def test_index_unknown_extension_file(tmp_path):
+    """End-to-end: unknown-extension text file appears in results when flag=on."""
+    feature_file = tmp_path / "login.feature"
+    feature_file.write_text("Feature: Login\n  Scenario: Valid user\n")
+    config_file = tmp_path / ".chunkhound.json"
+    config_file.write_text('{"indexing": {"index_unknown_files": true}}')
+    # Run indexer, query for "Login", assert at least one result references login.feature
+```
 
 ---
 

--- a/docs/superpowers/specs/index-unknown-files-design.html
+++ b/docs/superpowers/specs/index-unknown-files-design.html
@@ -1,0 +1,855 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Design: index_unknown_files Flag — ChunkHound</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #0f1117;
+      --surface: #1a1d27;
+      --surface2: #222636;
+      --border: #2e3350;
+      --accent: #7c6af7;
+      --accent2: #5eead4;
+      --text: #e2e4f0;
+      --muted: #8b90b0;
+      --code-bg: #141720;
+      --tag-skip: #ff6b6b;
+      --tag-parse: #5eead4;
+      --tag-binary: #fbbf24;
+      --tag-before: #fb923c;
+      --tag-after: #34d399;
+      --radius: 10px;
+      --font: 'Segoe UI', system-ui, -apple-system, sans-serif;
+      --mono: 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+    }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: var(--font);
+      font-size: 15px;
+      line-height: 1.7;
+    }
+
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    /* ── Layout ── */
+    .wrapper {
+      display: grid;
+      grid-template-columns: 250px 1fr;
+      min-height: 100vh;
+    }
+
+    /* ── Sidebar / TOC ── */
+    nav.toc {
+      position: sticky;
+      top: 0;
+      height: 100vh;
+      overflow-y: auto;
+      background: var(--surface);
+      border-right: 1px solid var(--border);
+      padding: 32px 20px;
+    }
+
+    nav.toc h2 {
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: .12em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 16px;
+    }
+
+    nav.toc ul { list-style: none; }
+    nav.toc li { margin-bottom: 2px; }
+
+    nav.toc a {
+      display: block;
+      padding: 5px 10px;
+      border-radius: 6px;
+      font-size: 13px;
+      color: var(--muted);
+      transition: background .15s, color .15s;
+    }
+    nav.toc a:hover, nav.toc a.active {
+      background: var(--surface2);
+      color: var(--text);
+      text-decoration: none;
+    }
+    nav.toc .toc-sub { padding-left: 20px; }
+    nav.toc .toc-sub2 { padding-left: 36px; }
+
+    /* ── Main content ── */
+    main {
+      padding: 48px 56px;
+      max-width: 920px;
+    }
+
+    /* ── Header ── */
+    header {
+      margin-bottom: 48px;
+      padding-bottom: 32px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .logo-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 20px;
+      padding: 4px 14px 4px 8px;
+      font-size: 12px;
+      color: var(--muted);
+      margin-bottom: 20px;
+    }
+    .logo-badge .dot {
+      width: 8px; height: 8px;
+      border-radius: 50%;
+      background: var(--accent);
+    }
+
+    header h1 {
+      font-size: 28px;
+      font-weight: 700;
+      color: #fff;
+      line-height: 1.3;
+      margin-bottom: 16px;
+    }
+    header h1 code {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 2px 8px;
+      font-size: 24px;
+      color: var(--accent);
+    }
+
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+    .meta-item {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      color: var(--muted);
+    }
+    .meta-item .label {
+      font-weight: 600;
+      color: var(--text);
+    }
+
+    /* ── Sections ── */
+    section { margin-bottom: 52px; }
+
+    h2 {
+      font-size: 18px;
+      font-weight: 700;
+      color: #fff;
+      margin-bottom: 20px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    h2 .section-icon { font-size: 20px; }
+
+    h3 {
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--accent2);
+      margin: 24px 0 10px;
+      letter-spacing: .04em;
+      text-transform: uppercase;
+    }
+
+    p { margin-bottom: 14px; color: var(--text); }
+
+    /* ── Card ── */
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 24px;
+      margin-bottom: 16px;
+    }
+
+    /* ── Problem callout ── */
+    .callout {
+      background: rgba(124,106,247,.1);
+      border: 1px solid rgba(124,106,247,.3);
+      border-left: 4px solid var(--accent);
+      border-radius: var(--radius);
+      padding: 18px 20px;
+      margin-bottom: 20px;
+    }
+    .callout p { margin: 0; }
+
+    /* ── Goal list ── */
+    .goal-list { list-style: none; margin-bottom: 16px; }
+    .goal-list li {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      padding: 8px 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .goal-list li:last-child { border-bottom: none; }
+    .goal-icon { font-size: 18px; flex-shrink: 0; margin-top: 2px; }
+
+    /* ── Interfaces table ── */
+    .iface-grid {
+      display: grid;
+      grid-template-columns: 1fr 1.4fr 100px;
+      gap: 1px;
+      background: var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+    .iface-head, .iface-cell {
+      background: var(--surface);
+      padding: 12px 16px;
+      font-size: 13px;
+    }
+    .iface-head {
+      background: var(--surface2);
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: .1em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+    .iface-cell code {
+      font-family: var(--mono);
+      font-size: 12px;
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 2px 6px;
+      color: var(--accent2);
+    }
+    .badge-off {
+      display: inline-block;
+      background: rgba(139,144,176,.15);
+      color: var(--muted);
+      border-radius: 4px;
+      padding: 2px 8px;
+      font-size: 11px;
+      font-weight: 600;
+    }
+
+    /* ── Architecture steps ── */
+    .arch-step {
+      display: grid;
+      grid-template-columns: 40px 1fr;
+      gap: 16px;
+      margin-bottom: 28px;
+    }
+    .step-num {
+      width: 40px; height: 40px;
+      border-radius: 50%;
+      background: var(--surface2);
+      border: 2px solid var(--accent);
+      color: var(--accent);
+      font-weight: 700;
+      font-size: 14px;
+      display: grid;
+      place-items: center;
+      flex-shrink: 0;
+      margin-top: 2px;
+    }
+    .step-body h3 { margin-top: 2px; }
+    .file-ref {
+      display: inline-block;
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 3px 10px;
+      font-family: var(--mono);
+      font-size: 11px;
+      color: var(--muted);
+      margin-bottom: 12px;
+    }
+    .file-ref span { color: var(--accent2); }
+
+    /* ── Code blocks ── */
+    pre {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 18px 20px;
+      overflow-x: auto;
+      margin: 12px 0 16px;
+    }
+    pre code {
+      font-family: var(--mono);
+      font-size: 12.5px;
+      line-height: 1.6;
+      color: #c9d1e9;
+    }
+    .kw { color: #c792ea; }
+    .fn { color: #82aaff; }
+    .st { color: #c3e88d; }
+    .cm { color: #546e7a; font-style: italic; }
+    .nu { color: #f78c6c; }
+    .dec { color: #ffcb6b; }
+
+    /* ── Data flow diagram ── */
+    .flow {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 24px 28px;
+      font-family: var(--mono);
+      font-size: 12.5px;
+      line-height: 2;
+    }
+    .flow .flow-root { color: var(--accent2); font-weight: 600; }
+    .flow .flow-branch { color: var(--muted); }
+    .flow .flow-skip { color: var(--tag-skip); }
+    .flow .flow-parse { color: var(--tag-parse); }
+    .flow .flow-binary { color: var(--tag-binary); }
+    .flow .flow-normal { color: #82aaff; }
+
+    /* ── Error handling list ── */
+    .err-list { list-style: none; margin-bottom: 0; }
+    .err-list li {
+      display: flex;
+      gap: 12px;
+      padding: 10px 0;
+      border-bottom: 1px solid var(--border);
+      font-size: 14px;
+    }
+    .err-list li:last-child { border-bottom: none; }
+    .err-tag {
+      flex-shrink: 0;
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 2px 8px;
+      font-size: 11px;
+      font-family: var(--mono);
+      color: var(--tag-binary);
+      white-space: nowrap;
+    }
+
+    /* ── Testing phase tabs ── */
+    .phase-header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin: 28px 0 14px;
+    }
+    .phase-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border-radius: 6px;
+      padding: 4px 12px;
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: .04em;
+    }
+    .phase-before {
+      background: rgba(251,146,60,.12);
+      border: 1px solid rgba(251,146,60,.35);
+      color: var(--tag-before);
+    }
+    .phase-after {
+      background: rgba(52,211,153,.12);
+      border: 1px solid rgba(52,211,153,.35);
+      color: var(--tag-after);
+    }
+    .phase-smoke {
+      background: rgba(124,106,247,.12);
+      border: 1px solid rgba(124,106,247,.35);
+      color: var(--accent);
+    }
+    .phase-title {
+      font-size: 15px;
+      font-weight: 600;
+      color: var(--text);
+    }
+    .phase-desc {
+      font-size: 13px;
+      color: var(--muted);
+      margin-bottom: 0;
+    }
+
+    .test-cases {
+      display: grid;
+      gap: 10px;
+      margin-bottom: 8px;
+    }
+    .test-case {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+    .test-case-header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 16px;
+      border-bottom: 1px solid var(--border);
+      background: var(--surface2);
+    }
+    .test-fn {
+      font-family: var(--mono);
+      font-size: 12px;
+      color: var(--accent2);
+      flex: 1;
+    }
+    .test-status {
+      font-size: 11px;
+      font-weight: 700;
+      border-radius: 4px;
+      padding: 2px 8px;
+    }
+    .status-pass-now {
+      background: rgba(52,211,153,.15);
+      color: var(--tag-after);
+    }
+    .status-fail-now {
+      background: rgba(255,107,107,.15);
+      color: var(--tag-skip);
+    }
+    .test-case-body {
+      padding: 12px 16px;
+      font-size: 13px;
+      color: var(--muted);
+    }
+    .test-case-body strong { color: var(--text); }
+
+    /* ── Out of scope ── */
+    .oos-list { list-style: none; }
+    .oos-list li {
+      padding: 8px 0;
+      border-bottom: 1px solid var(--border);
+      font-size: 14px;
+      color: var(--muted);
+      display: flex;
+      gap: 10px;
+      align-items: center;
+    }
+    .oos-list li::before { content: "✕"; color: var(--tag-skip); font-size: 12px; flex-shrink: 0; }
+    .oos-list li:last-child { border-bottom: none; }
+
+    /* ── Footer ── */
+    footer {
+      margin-top: 60px;
+      padding: 24px 0;
+      border-top: 1px solid var(--border);
+      font-size: 12px;
+      color: var(--muted);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    code {
+      font-family: var(--mono);
+      font-size: 12.5px;
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 1px 5px;
+      color: var(--accent2);
+    }
+
+    @media (max-width: 768px) {
+      .wrapper { grid-template-columns: 1fr; }
+      nav.toc { display: none; }
+      main { padding: 24px 20px; }
+      .iface-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+<div class="wrapper">
+
+  <!-- ── Sidebar TOC ── -->
+  <nav class="toc" aria-label="Table of contents">
+    <h2>Contents</h2>
+    <ul>
+      <li><a href="#problem">Problem</a></li>
+      <li><a href="#goal">Goal</a></li>
+      <li><a href="#interfaces">Customer Interfaces</a></li>
+      <li><a href="#architecture">Architecture</a></li>
+      <li class="toc-sub"><a href="#field">1. Config Field</a></li>
+      <li class="toc-sub"><a href="#discovery">2. File Discovery</a></li>
+      <li class="toc-sub"><a href="#parsing">3. Parsing + Binary Guard</a></li>
+      <li class="toc-sub"><a href="#cli">4. CLI Flag</a></li>
+      <li class="toc-sub"><a href="#envvar">5. Environment Variable</a></li>
+      <li><a href="#dataflow">Data Flow</a></li>
+      <li><a href="#errors">Error Handling</a></li>
+      <li><a href="#testing">Testing</a></li>
+      <li class="toc-sub"><a href="#test-before">Before fix</a></li>
+      <li class="toc-sub"><a href="#test-after">After fix</a></li>
+      <li class="toc-sub"><a href="#test-smoke">Smoke test</a></li>
+      <li><a href="#oos">Out of Scope</a></li>
+    </ul>
+  </nav>
+
+  <!-- ── Main ── -->
+  <main>
+    <header>
+      <div class="logo-badge">
+        <div class="dot"></div>
+        ChunkHound · Issue&nbsp;<a href="https://github.com/chunkhound/chunkhound/issues/277" style="color:var(--accent)">#277</a>&nbsp;·&nbsp;Branch: <code style="background:none;border:none;padding:0;color:var(--accent2)">unknown_files</code>
+      </div>
+      <h1>Design: <code>index_unknown_files</code> Flag</h1>
+      <div class="meta">
+        <div class="meta-item"><span class="label">Date</span> 2026-05-13</div>
+        <div class="meta-item"><span class="label">Status</span> Approved — pending implementation</div>
+        <div class="meta-item"><span class="label">Approach</span> C — flag + binary guard</div>
+      </div>
+    </header>
+
+    <!-- Problem -->
+    <section id="problem">
+      <h2><span class="section-icon">🐛</span> Problem</h2>
+      <div class="callout">
+        <p>In v5, files with unrecognized extensions (<code>Dockerfile</code>, <code>.proto</code>, <code>.feature</code>, etc.) are silently skipped at <code>batch_processor.py:224</code> when <code>language == Language.UNKNOWN</code>. Before v5 a bug accidentally indexed these as plain text — users found this useful. The fix removed the behavior; this design adds it back as an <strong>explicit, opt-in flag</strong>.</p>
+      </div>
+    </section>
+
+    <!-- Goal -->
+    <section id="goal">
+      <h2><span class="section-icon">🎯</span> Goal</h2>
+      <ul class="goal-list">
+        <li><span class="goal-icon">🔍</span><span>Unknown-extension files are <strong>discovered</strong> during the directory scan when the flag is on</span></li>
+        <li><span class="goal-icon">📄</span><span>Discovered unknown files are <strong>parsed as plain text</strong> via <code>TextMapping</code></span></li>
+        <li><span class="goal-icon">🛡️</span><span>Binary files (null-byte heuristic) are <strong>still skipped</strong> to protect the index</span></li>
+      </ul>
+    </section>
+
+    <!-- Customer-Facing Interfaces -->
+    <section id="interfaces">
+      <h2><span class="section-icon">🖥️</span> Customer-Facing Interfaces</h2>
+      <p>All three surfaces expose the flag. MCP tools don't expose indexing params (set at server startup).</p>
+      <div class="iface-grid">
+        <div class="iface-head">Interface</div>
+        <div class="iface-head">Key / Flag</div>
+        <div class="iface-head">Default</div>
+
+        <div class="iface-cell">CLI (<code>index</code>, <code>mcp</code>, <code>_daemon</code>)</div>
+        <div class="iface-cell"><code>--index-unknown-files</code></div>
+        <div class="iface-cell"><span class="badge-off">off</span></div>
+
+        <div class="iface-cell"><code>.chunkhound.json</code></div>
+        <div class="iface-cell"><code>"indexing": { "index_unknown_files": true }</code></div>
+        <div class="iface-cell"><span class="badge-off">false</span></div>
+
+        <div class="iface-cell">Environment variable</div>
+        <div class="iface-cell"><code>CHUNKHOUND_INDEXING__INDEX_UNKNOWN_FILES=true</code></div>
+        <div class="iface-cell"><span class="badge-off">unset</span></div>
+      </div>
+    </section>
+
+    <!-- Architecture -->
+    <section id="architecture">
+      <h2><span class="section-icon">⚙️</span> Architecture</h2>
+
+      <div class="arch-step" id="field">
+        <div class="step-num">1</div>
+        <div class="step-body">
+          <h3>IndexingConfig — new public field</h3>
+          <div class="file-ref">chunkhound/core/config/<span>indexing_config.py</span></div>
+          <p>Add alongside <code>detect_embedded_sql</code>, <code>per_file_timeout_seconds</code>, etc.:</p>
+          <pre><code><span class="kw">index_unknown_files</span>: <span class="fn">bool</span> = <span class="fn">Field</span>(
+    default=<span class="kw">False</span>,
+    description=<span class="st">"Index files with unrecognized extensions as plain text"</span>,
+)</code></pre>
+          <p>Flows automatically into <code>config_dict</code> via the existing <code>model_dump()</code> path — no extra wiring needed.</p>
+        </div>
+      </div>
+
+      <div class="arch-step" id="discovery">
+        <div class="step-num">2</div>
+        <div class="step-body">
+          <h3>File Discovery — append <code>**/*</code> when flag is on</h3>
+          <div class="file-ref">chunkhound/core/config/<span>indexing_config.py</span> — <span>model_validator(mode="after")</span></div>
+          <p>When <code>index_unknown_files=True</code>, append <code>**/*</code> to the <code>include</code> list (if not already present). Applies to both default and custom include lists. Existing <code>exclude</code> patterns (<code>node_modules</code>, <code>.git</code>, <code>.env</code>) still apply.</p>
+        </div>
+      </div>
+
+      <div class="arch-step" id="parsing">
+        <div class="step-num">3</div>
+        <div class="step-body">
+          <h3>Parsing — binary guard + TEXT fallback</h3>
+          <div class="file-ref">chunkhound/services/<span>batch_processor.py</span> — line 224</div>
+          <pre><code><span class="cm"># Current (unconditional skip):</span>
+<span class="kw">if</span> language == Language.UNKNOWN:
+    <span class="cm"># ... skip with status="skipped"</span>
+
+<span class="cm"># New:</span>
+<span class="kw">if</span> language == Language.UNKNOWN:
+    <span class="kw">if not</span> config_dict.get(<span class="st">"index_unknown_files"</span>):
+        <span class="cm"># ... skip (unchanged when flag=off)</span>
+    <span class="kw">else</span>:
+        <span class="cm"># Binary guard: read first 8 KB, check for null bytes</span>
+        <span class="kw">try</span>:
+            <span class="kw">with</span> <span class="fn">open</span>(file_path, <span class="st">"rb"</span>) <span class="kw">as</span> fh:
+                sample = fh.read(<span class="nu">8192</span>)
+            <span class="kw">if</span> <span class="st">b"\x00"</span> <span class="kw">in</span> sample:
+                <span class="cm"># ... skip, error="binary_file"</span>
+                <span class="kw">continue</span>
+        <span class="kw">except</span> OSError:
+            <span class="cm"># ... skip, status="error"</span>
+            <span class="kw">continue</span>
+        language = Language.TEXT  <span class="cm"># fall through to normal parse path</span></code></pre>
+        </div>
+      </div>
+
+      <div class="arch-step" id="cli">
+        <div class="step-num">4</div>
+        <div class="step-body">
+          <h3>CLI Flag</h3>
+          <div class="file-ref">chunkhound/core/config/<span>indexing_config.py</span> — <span>add_cli_arguments()</span></div>
+          <pre><code>parser.add_argument(
+    <span class="st">"--index-unknown-files"</span>,
+    action=<span class="st">"store_true"</span>,
+    default=<span class="kw">False</span>,
+    dest=<span class="st">"index_unknown_files"</span>,
+    help=<span class="st">"Index files with unrecognized extensions as plain text"
+         " (binary files are still skipped)"</span>,
+)</code></pre>
+          <p>Auto-registered on all three commands via <code>add_config_arguments(..., ["indexing", ...])</code>: <code>index</code>, <code>mcp</code>, <code>_daemon</code>.</p>
+        </div>
+      </div>
+
+      <div class="arch-step" id="envvar">
+        <div class="step-num">5</div>
+        <div class="step-body">
+          <h3>Environment Variable</h3>
+          <div class="file-ref">chunkhound/core/config/<span>indexing_config.py</span> — <span>load_from_env()</span></div>
+          <pre><code><span class="kw">if</span> val := os.getenv(<span class="st">"CHUNKHOUND_INDEXING__INDEX_UNKNOWN_FILES"</span>):
+    overrides[<span class="st">"index_unknown_files"</span>] = val.lower() <span class="kw">in</span> (<span class="st">"1"</span>, <span class="st">"true"</span>, <span class="st">"yes"</span>)</code></pre>
+        </div>
+      </div>
+    </section>
+
+    <!-- Data Flow -->
+    <section id="dataflow">
+      <h2><span class="section-icon">🔀</span> Data Flow</h2>
+      <div class="flow">
+        <div class="flow-root">Directory scan</div>
+        <div>  └─ include patterns &nbsp;<span style="color:var(--accent)">← **/* appended when flag=on</span></div>
+        <div>       └─ exclude patterns <span class="flow-branch">(unchanged)</span></div>
+        <div>            └─ discovered files</div>
+        <div>                 └─ batch_processor.py</div>
+        <div>                      ├─ Language.known &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; → <span class="flow-normal">normal parse path (no change)</span></div>
+        <div>                      ├─ Language.UNKNOWN + flag=<span class="flow-skip">off</span> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; → <span class="flow-skip">skip (status="skipped")</span></div>
+        <div>                      ├─ Language.UNKNOWN + flag=<span class="flow-parse">on</span> + <span class="flow-binary">binary</span> &nbsp; → <span class="flow-skip">skip (error="binary_file")</span></div>
+        <div>                      └─ Language.UNKNOWN + flag=<span class="flow-parse">on</span> + text &nbsp;&nbsp; → <span class="flow-parse">Language.TEXT → TextMapping parse</span></div>
+      </div>
+    </section>
+
+    <!-- Error Handling -->
+    <section id="errors">
+      <h2><span class="section-icon">⚠️</span> Error Handling</h2>
+      <div class="card">
+        <ul class="err-list">
+          <li><span class="err-tag">OSError</span><span>Reading the 8 KB sample fails → skip with <code>status="error"</code></span></li>
+          <li><span class="err-tag">binary</span><span>Any null byte in first 8 KB → skip with <code>error="binary_file"</code>; conservative by design</span></li>
+          <li><span class="err-tag">log:text</span><span><code>logger.debug("Indexing unknown file as text: {}", file_path)</code></span></li>
+          <li><span class="err-tag">log:bin</span><span><code>logger.debug("Skipping binary file: {}", file_path)</code></span></li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- Testing -->
+    <section id="testing">
+      <h2><span class="section-icon">🧪</span> Testing</h2>
+      <p>Tests are written in two phases. <strong>Before-fix</strong> tests pass right now and must continue to pass — they are the regression guard. <strong>After-fix</strong> tests are written first, fail until the implementation is done, then pass. Both live in <code>tests/test_index_unknown_files.py</code>.</p>
+
+      <!-- Before fix -->
+      <div id="test-before">
+        <div class="phase-header">
+          <span class="phase-badge phase-before">● BEFORE FIX</span>
+          <span class="phase-title">Regression guard</span>
+        </div>
+        <p class="phase-desc" style="margin-bottom:14px">These pass today. They prove the default (flag-off) path is untouched after the implementation lands.</p>
+
+        <div class="test-cases">
+          <div class="test-case">
+            <div class="test-case-header">
+              <span class="test-fn">test_unknown_file_skipped_by_default</span>
+              <span class="test-status status-pass-now">passes now</span>
+            </div>
+            <div class="test-case-body">
+              Creates a <code>Dockerfile</code> in a temp dir, instantiates <code>IndexingConfig()</code> (flag defaults <code>False</code>), calls <code>process_file_batch</code>.<br>
+              <strong>Assert:</strong> <code>status == "skipped"</code>, <code>error == "Unknown file type"</code>, <code>"**/*" not in config.include</code>
+            </div>
+          </div>
+          <div class="test-case">
+            <div class="test-case-header">
+              <span class="test-fn">test_known_extension_unaffected_when_flag_off</span>
+              <span class="test-status status-pass-now">passes now</span>
+            </div>
+            <div class="test-case-body">
+              Known file (<code>main.py</code>) with flag off.<br>
+              <strong>Assert:</strong> <code>status != "skipped"</code> — existing parse path unaffected.
+            </div>
+          </div>
+          <div class="test-case">
+            <div class="test-case-header">
+              <span class="test-fn">test_wildcard_not_injected_when_flag_off</span>
+              <span class="test-status status-pass-now">passes now</span>
+            </div>
+            <div class="test-case-body">
+              <code>IndexingConfig()</code> with no arguments.<br>
+              <strong>Assert:</strong> <code>"**/*" not in config.include</code>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- After fix -->
+      <div id="test-after">
+        <div class="phase-header">
+          <span class="phase-badge phase-after">● AFTER FIX</span>
+          <span class="phase-title">New behaviour — written first, fail until implementation</span>
+        </div>
+        <p class="phase-desc" style="margin-bottom:14px">These are written before touching any production code. They drive the implementation.</p>
+
+        <div class="test-cases">
+          <div class="test-case">
+            <div class="test-case-header">
+              <span class="test-fn">test_unknown_text_file_indexed_when_flag_on</span>
+              <span class="test-status status-fail-now">fails until impl</span>
+            </div>
+            <div class="test-case-body">
+              <code>Dockerfile</code> with plain-text content, <code>IndexingConfig(index_unknown_files=True)</code>.<br>
+              <strong>Assert:</strong> <code>status == "parsed"</code>, <code>len(chunks) &gt; 0</code>
+            </div>
+          </div>
+          <div class="test-case">
+            <div class="test-case-header">
+              <span class="test-fn">test_binary_unknown_file_skipped_when_flag_on</span>
+              <span class="test-status status-fail-now">fails until impl</span>
+            </div>
+            <div class="test-case-body">
+              Binary file with null bytes, flag on.<br>
+              <strong>Assert:</strong> <code>status == "skipped"</code>, <code>error == "binary_file"</code>
+            </div>
+          </div>
+          <div class="test-case">
+            <div class="test-case-header">
+              <span class="test-fn">test_wildcard_injected_when_flag_on</span>
+              <span class="test-status status-fail-now">fails until impl</span>
+            </div>
+            <div class="test-case-body">
+              <code>IndexingConfig(index_unknown_files=True)</code>.<br>
+              <strong>Assert:</strong> <code>"**/*" in config.include</code>
+            </div>
+          </div>
+          <div class="test-case">
+            <div class="test-case-header">
+              <span class="test-fn">test_wildcard_appended_to_custom_include</span>
+              <span class="test-status status-fail-now">fails until impl</span>
+            </div>
+            <div class="test-case-body">
+              <code>IndexingConfig(index_unknown_files=True, include=["**/*.py"])</code>.<br>
+              <strong>Assert:</strong> <code>"**/*" in config.include</code> AND <code>"**/*.py" in config.include</code>
+            </div>
+          </div>
+          <div class="test-case">
+            <div class="test-case-header">
+              <span class="test-fn">test_cli_flag_sets_index_unknown_files</span>
+              <span class="test-status status-fail-now">fails until impl</span>
+            </div>
+            <div class="test-case-body">
+              Parse <code>["--index-unknown-files"]</code> via <code>argparse</code>.<br>
+              <strong>Assert:</strong> <code>args.index_unknown_files is True</code>
+            </div>
+          </div>
+          <div class="test-case">
+            <div class="test-case-header">
+              <span class="test-fn">test_env_var_sets_index_unknown_files</span>
+              <span class="test-status status-fail-now">fails until impl</span>
+            </div>
+            <div class="test-case-body">
+              <code>monkeypatch.setenv("CHUNKHOUND_INDEXING__INDEX_UNKNOWN_FILES", "true")</code><br>
+              <strong>Assert:</strong> <code>IndexingConfig.load_from_env().index_unknown_files is True</code>
+            </div>
+          </div>
+          <div class="test-case">
+            <div class="test-case-header">
+              <span class="test-fn">test_json_config_sets_index_unknown_files</span>
+              <span class="test-status status-fail-now">fails until impl</span>
+            </div>
+            <div class="test-case-body">
+              <code>IndexingConfig.model_validate({"index_unknown_files": True})</code><br>
+              <strong>Assert:</strong> <code>config.index_unknown_files is True</code>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Smoke test -->
+      <div id="test-smoke">
+        <div class="phase-header">
+          <span class="phase-badge phase-smoke">● SMOKE</span>
+          <span class="phase-title">End-to-end — added to <code>tests/test_smoke.py</code></span>
+        </div>
+        <div class="card" style="margin-top:0">
+          <div class="test-case-header" style="background:transparent;border:none;padding:0 0 10px 0">
+            <span class="test-fn">test_index_unknown_extension_file</span>
+            <span class="test-status status-fail-now">fails until impl</span>
+          </div>
+          <p style="margin:0;font-size:13px;color:var(--muted)">
+            Creates a temp dir with a <code>login.feature</code> (Gherkin text file) and a <code>.chunkhound.json</code> with <code>"index_unknown_files": true</code>. Runs the indexer, queries for <code>"Login"</code>.<br>
+            <strong style="color:var(--text)">Assert:</strong> at least one result references <code>login.feature</code>.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Out of Scope -->
+    <section id="oos">
+      <h2><span class="section-icon">🚫</span> Out of Scope</h2>
+      <div class="card">
+        <ul class="oos-list">
+          <li>Adding new extensions to the <code>EXTENSION_TO_LANGUAGE</code> map (separate concern)</li>
+          <li>Detecting file encoding (UTF-8 vs Latin-1) — <code>TextMapping</code> handles this gracefully</li>
+          <li>MCP tool parameters — indexing config is set at server startup, not per-tool-call</li>
+        </ul>
+      </div>
+    </section>
+
+    <footer>
+      <span>ChunkHound · Design Spec · 2026-05-13</span>
+      <span>Branch: <code>unknown_files</code> · Issue <a href="https://github.com/chunkhound/chunkhound/issues/277">#277</a></span>
+    </footer>
+  </main>
+</div>
+
+<script>
+  const sections = document.querySelectorAll('section[id], div[id^="test-"], div.arch-step[id]');
+  const links = document.querySelectorAll('nav.toc a');
+  const obs = new IntersectionObserver(entries => {
+    entries.forEach(e => {
+      if (e.isIntersecting) {
+        links.forEach(l => l.classList.remove('active'));
+        const active = document.querySelector(`nav.toc a[href="#${e.target.id}"]`);
+        if (active) active.classList.add('active');
+      }
+    });
+  }, { rootMargin: '-20% 0px -70% 0px' });
+  sections.forEach(s => obs.observe(s));
+</script>
+</body>
+</html>

--- a/tests/test_index_unknown_files.py
+++ b/tests/test_index_unknown_files.py
@@ -1,0 +1,108 @@
+"""Tests for index_unknown_files feature (issue #277).
+
+Before-fix tests: regression guards that pass today and must stay passing.
+After-fix tests: written first, fail until implementation is done.
+"""
+import argparse
+from pathlib import Path
+
+import pytest
+
+from chunkhound.core.config.indexing_config import IndexingConfig
+from chunkhound.core.types.common import Language
+from chunkhound.services.batch_processor import process_file_batch
+
+
+def _cfg(**overrides) -> dict:
+    """Minimal config_dict for process_file_batch with timeout disabled."""
+    base = {"per_file_timeout_seconds": 0.0}
+    base.update(overrides)
+    return base
+
+
+def _write_text_unknown(tmp_path: Path, name: str = "myfile.xyzunknown") -> Path:
+    """Create a text file with an extension unknown to ChunkHound."""
+    path = tmp_path / name
+    # 20 lines so TextMapping has enough content to produce chunks
+    path.write_text("\n".join(f"line {i}: some content here" for i in range(20)) + "\n")
+    return path
+
+
+def _write_binary_unknown(tmp_path: Path) -> Path:
+    path = tmp_path / "model.xyzunknown"
+    path.write_bytes(b"\x00\x01\x02" * 1000)
+    return path
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# BEFORE FIX — regression guard
+# These pass right now. They must continue to pass after implementation.
+# ════════════════════════════════════════════════════════════════════════════
+
+class TestDefaultBehaviourPreserved:
+    """Existing behaviour: unknown files skipped, no wildcard injected by default."""
+
+    def test_unknown_file_skipped_by_default(self, tmp_path: Path):
+        unknown = _write_text_unknown(tmp_path)
+        results = process_file_batch([unknown], _cfg())
+        assert len(results) == 1
+        assert results[0].status == "skipped"
+        assert results[0].error == "Unknown file type"
+
+    def test_wildcard_not_in_default_include(self):
+        config = IndexingConfig()
+        assert "**/*" not in config.include
+
+    def test_known_python_file_not_skipped_as_unknown(self, tmp_path: Path):
+        pyfile = tmp_path / "hello.py"
+        pyfile.write_text("x = 1\n")
+        results = process_file_batch([pyfile], _cfg())
+        assert len(results) == 1
+        assert not (results[0].status == "skipped" and results[0].error == "Unknown file type")
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# AFTER FIX — new behaviour
+# Written first. Fail until implementation lands.
+# ════════════════════════════════════════════════════════════════════════════
+
+class TestIndexUnknownFilesFlag:
+    """Flag-on: text unknown files indexed; binary files still skipped."""
+
+    def test_unknown_text_file_indexed_when_flag_on(self, tmp_path: Path):
+        unknown = _write_text_unknown(tmp_path)
+        results = process_file_batch([unknown], _cfg(index_unknown_files=True))
+        assert len(results) == 1
+        assert results[0].status == "success"
+        assert len(results[0].chunks) > 0
+
+    def test_binary_unknown_file_skipped_when_flag_on(self, tmp_path: Path):
+        binfile = _write_binary_unknown(tmp_path)
+        results = process_file_batch([binfile], _cfg(index_unknown_files=True))
+        assert len(results) == 1
+        assert results[0].status == "skipped"
+        assert results[0].error == "binary_file"
+
+    def test_wildcard_injected_when_flag_on(self):
+        config = IndexingConfig(index_unknown_files=True)
+        assert "**/*" in config.include
+
+    def test_wildcard_appended_to_custom_include(self):
+        config = IndexingConfig(index_unknown_files=True, include=["**/*.py"])
+        assert "**/*" in config.include
+        assert "**/*.py" in config.include
+
+    def test_cli_flag_sets_index_unknown_files(self):
+        parser = argparse.ArgumentParser()
+        IndexingConfig.add_cli_arguments(parser)
+        args = parser.parse_args(["--index-unknown-files"])
+        assert args.index_unknown_files is True
+
+    def test_env_var_sets_index_unknown_files(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("CHUNKHOUND_INDEXING__INDEX_UNKNOWN_FILES", "true")
+        overrides = IndexingConfig.load_from_env()
+        assert overrides.get("index_unknown_files") is True
+
+    def test_json_config_sets_index_unknown_files(self):
+        config = IndexingConfig.model_validate({"index_unknown_files": True})
+        assert config.index_unknown_files is True

--- a/tests/test_language_extensions.py
+++ b/tests/test_language_extensions.py
@@ -378,7 +378,7 @@ class TestIssue277UnknownExtensions:
     )
     def test_common_extensionless_files_indexed(self, filename, description):
         """Extensionless files like Dockerfile must be discoverable."""
-        factory_filenames = {k.lower() for k in EXTENSION_TO_LANGUAGE if not k.startswith(".")}
+        factory_filenames = Language.get_all_filename_patterns()
         assert filename.lower() in factory_filenames, (
             f"{filename} ({description}) not in EXTENSION_TO_LANGUAGE — "
             f"this file will never be indexed"


### PR DESCRIPTION
Context

ChunkHound v5 fixed a bug where Language.UNKNOWN files were accidentally indexed as text. The fix was correct but broke real user workflows (Gherkin .feature, custom DSLs, etc.). A prior commit on this branch partially addressed this by adding specific files (Dockerfile, Jenkinsfile, .proto, .graphql, .xml, .ini, .conf, .cfg, .properties) to EXTENSION_TO_LANGUAGE. This PR adds the general-purpose escape hatch.

Changes

chunkhound/core/config/indexing_config.py

New field (IndexingConfig, Pydantic BaseModel):

index_unknown_files: bool = Field(default=False, ...)


New model_validator(mode="after") — _inject_wildcard_for_unknown_files:


When index_unknown_files=True and "**/*" not already in self.include, appends "**/*" to the include list.

Required because the default include list is extension-specific; without this, unknown-extension files are never discovered by the directory walker regardless of the parse-time flag.

Applied after all field validators, so it sees the final resolved include list (including any user-supplied custom list).


add_cli_arguments() — new --index-unknown-files (store_true, dest="index_unknown_files"). Auto-registered on index, mcp, and _daemon commands via the shared add_config_arguments() call pattern.

load_from_env() — reads CHUNKHOUND_INDEXING__INDEX_UNKNOWN_FILES, accepts "true"/"1"/"yes".

extract_cli_overrides() — copies args.index_unknown_files into the overrides dict when truthy.

chunkhound/services/batch_processor.py — process_file_batch()

The Language.UNKNOWN block at line ~224 is now conditional:

Language.UNKNOWN + flag=off  →  skip (status="skipped", error="Unknown file type")  [unchanged]
Language.UNKNOWN + flag=on   →  binary guard (read 8 KB, check b"\x00")
    null bytes found          →  skip (status="skipped", error="binary_file")
    OSError reading sample    →  skip (status="error", error=str(e))
    clean text                →  language = Language.TEXT  →  fall through to normal parse path


The Language.TEXT promotion happens in-place before the existing parse logic, so it reuses create_parser_for_language(Language.TEXT, ...) → TextMapping (line-by-line chunking) with no other code changes.

config_dict propagation is automatic — IndexingConfig.model_dump() already serialises all fields.

tests/test_index_unknown_files.py (new file, 108 lines)

Two test classes:

TestDefaultBehaviourPreserved (3 tests) — regression guards written against current behaviour. Use .xyzunknown extension (not Dockerfile, which was added to EXTENSION_TO_LANGUAGE in the prior commit and now returns Language.TEXT).

TestIndexUnknownFilesFlag (7 tests) — written before implementation (TDD). Cover: text indexing, binary guard, wildcard injection into default and custom include lists, CLI flag, env var, JSON config path.

Invariants


index_unknown_files=False (default): zero behaviour change. The Language.UNKNOWN early-continue path is identical.

Binary detection: conservative — any null byte in first 8 KB → treated as binary. Matches the heuristic used by most UNIX tools (git, file, grep -I).

**/* injection does not duplicate if already present (checked with not in).

The flag has no effect on files that already have a registered language — they never reach the Language.UNKNOWN block.


No breaking changes

Default is false. Existing configs, CLI invocations, and env var sets are unaffected.
