### PR TITLE
fix(db): handle explicit file path in --db flag to prevent nested directory (issue #215)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,6 @@ PyPI trusted publisher required for `release-rc.yml`:
 - **For MCP:** `chunkhound mcp --db /path/to/project/.chunkhound` (the path from `.chunkhound.json`'s `database.path`)
 - **`--db` with wrong subpath silently returns 0 results** — no error, just empty. Always verify with a regex search first.
 - Default DB path: `.chunkhound/db/chunks.db` (directory structure, not flat file)
-- When using `--db` flag, pass the **directory** path (e.g. `--db .chunkhound/db`), not the full file path — passing `--db .../chunks.db` creates a nested `chunks.db/chunks.db` directory
 - Old-style flat `.chunkhound` files (pre-v4) block directory creation — move aside before re-indexing
 - Project-local `.chunkhound.json` with relative `"path": ".chunkhound"` resolves to CWD, not the project dir — use `--db` with absolute paths when indexing remote projects
 - `--config` does NOT override a project-local `.chunkhound.json` for DB path — always use explicit `--db` when the target project has its own config

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,7 @@ PyPI trusted publisher required for `release-rc.yml`:
 - **Preferred: pass project directory as positional arg** — `chunkhound search "query" /path/to/project` — this reads `.chunkhound.json` and resolves the DB correctly
 - **For MCP:** `chunkhound mcp --db /path/to/project/.chunkhound` (the path from `.chunkhound.json`'s `database.path`)
 - **`--db` with wrong subpath silently returns 0 results** — no error, just empty. Always verify with a regex search first.
+- `--db` accepts either a directory (uses `.../chunks.db` internally) or an explicit file path (`.db` / `.duckdb` extension returned as-is)
 - Default DB path: `.chunkhound/db/chunks.db` (directory structure, not flat file)
 - Old-style flat `.chunkhound` files (pre-v4) block directory creation — move aside before re-indexing
 - Project-local `.chunkhound.json` with relative `"path": ".chunkhound"` resolves to CWD, not the project dir — use `--db` with absolute paths when indexing remote projects

--- a/chunkhound/core/config/database_config.py
+++ b/chunkhound/core/config/database_config.py
@@ -11,6 +11,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
+_EXPLICIT_DB_SUFFIXES = {".db", ".duckdb"}
+
 
 class DatabaseConfig(BaseModel):
     """Database configuration with support for multiple providers.
@@ -92,9 +94,9 @@ class DatabaseConfig(BaseModel):
         if self.provider == "duckdb" and not is_memory:
             if self.path.exists() and self.path.is_file():
                 return self.path
-            # User explicitly supplied a file path (e.g. --db .../chunks.db or .../my.duckdb).
-            # Create only the parent directory and return the path as-is.
-            if self.path.suffix:
+            # Path ends with a known DB extension (.db / .duckdb) — treat as an explicit
+            # database file rather than a directory layout. Create the parent and return as-is.
+            if self.path.suffix.lower() in _EXPLICIT_DB_SUFFIXES:
                 self.path.parent.mkdir(parents=True, exist_ok=True)
                 return self.path
 

--- a/chunkhound/core/config/database_config.py
+++ b/chunkhound/core/config/database_config.py
@@ -92,6 +92,11 @@ class DatabaseConfig(BaseModel):
         if self.provider == "duckdb" and not is_memory:
             if self.path.exists() and self.path.is_file():
                 return self.path
+            # User explicitly supplied a file path (e.g. --db .../chunks.db or .../my.duckdb).
+            # Create only the parent directory and return the path as-is.
+            if self.path.suffix:
+                self.path.parent.mkdir(parents=True, exist_ok=True)
+                return self.path
 
         if not is_memory:
             # For directory-style layouts, ensure the base path exists.

--- a/tests/unit/test_database_path_consistency.py
+++ b/tests/unit/test_database_path_consistency.py
@@ -106,3 +106,24 @@ def test_lancedb_path_transformation_matches_provider(tmp_path):
     # DatabaseConfig should return the same result
     assert db_path == legacy_transform
     assert db_path == test_db_path / "lancedb.lancedb"
+
+
+def test_get_db_path_explicit_db_file_path_not_nested(tmp_path):
+    """--db /path/chunks.db must NOT create a nested chunks.db/chunks.db dir (issue #215)."""
+    explicit_path = tmp_path / "mydb" / "chunks.db"
+    config = DatabaseConfig(path=explicit_path, provider="duckdb")
+    result = config.get_db_path()
+
+    assert result == explicit_path
+    assert result.parent.is_dir()
+    assert not result.exists()  # parent dir created, file itself not yet
+
+
+def test_get_db_path_explicit_duckdb_extension(tmp_path):
+    """--db /path/custom.duckdb must return the path directly (issue #215)."""
+    explicit_path = tmp_path / "store" / "custom.duckdb"
+    config = DatabaseConfig(path=explicit_path, provider="duckdb")
+    result = config.get_db_path()
+
+    assert result == explicit_path
+    assert result.parent.is_dir()

--- a/tests/unit/test_database_path_consistency.py
+++ b/tests/unit/test_database_path_consistency.py
@@ -127,3 +127,12 @@ def test_get_db_path_explicit_duckdb_extension(tmp_path):
 
     assert result == explicit_path
     assert result.parent.is_dir()
+
+
+def test_get_db_path_versioned_dir_not_treated_as_file(tmp_path):
+    """--db /data/v2.1 (directory intent) must still append /chunks.db."""
+    versioned_dir = tmp_path / "v2.1"
+    config = DatabaseConfig(path=versioned_dir, provider="duckdb")
+    result = config.get_db_path()
+
+    assert result == versioned_dir / "chunks.db"


### PR DESCRIPTION

When --db is passed a path with a file extension (e.g. .../chunks.db or .../my.duckdb), get_db_path() now creates only the parent directory and returns the path directly instead of calling mkdir() on the file path and nesting chunks.db/chunks.db. Adds two regression tests and removes the now-stale AGENTS.md workaround bullet.