### PR TITLE
Improve Markdown semantic doc chunking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,27 @@ PyPI trusted publisher required for `release-rc.yml`:
 - Project-local `.chunkhound.json` with relative `"path": ".chunkhound"` resolves to CWD, not the project dir — use `--db` with absolute paths when indexing remote projects
 - `--config` does NOT override a project-local `.chunkhound.json` for DB path — always use explicit `--db` when the target project has its own config
 
+## ELEIRIS_LOCAL_BRANCH_POLICY
+This checkout carries Eleiris-local ChunkHound changes that are not yet merged upstream.
+
+- Keep working on local branch: `fix-overlapping-chunk-merge`.
+- `origin` is upstream: `https://github.com/chunkhound/chunkhound.git`.
+- `john-fork` is the writable fork: `https://github.com/jtac/chunkhound.git`.
+- The local branch tracks `john-fork/fix-overlapping-chunk-merge`, not upstream `origin/main`.
+- When upstream ChunkHound changes land, merge them into the Eleiris local branch before continuing substantial work:
+  ```bash
+  git fetch origin main
+  git merge --no-edit origin/main
+  git push
+  ```
+- A local convenience alias is configured for this checkout:
+  ```bash
+  git sync-origin-main
+  ```
+  It runs the fetch/merge/push sequence above.
+- If conflicts occur, resolve them on `fix-overlapping-chunk-merge`, run smoke tests, then push to `john-fork`.
+- Do not assume direct push or merge access to `chunkhound/chunkhound`; upstream PRs may require maintainer/merge-queue permissions.
+
 ## PROJECT_MAINTENANCE
 - Smoke tests are mandatory guardrails
 - Run `uv run mypy chunkhound` during reviews to catch Optional/type boundary issues

--- a/chunkhound/api/cli/commands/search.py
+++ b/chunkhound/api/cli/commands/search.py
@@ -92,6 +92,9 @@ async def search_command(args: argparse.Namespace, config: Config) -> None:
                 page_size=args.page_size,
                 offset=args.offset,
                 path=args.path_filter,
+                doc_type=args.doc_type,
+                status=args.status,
+                owner=args.owner,
             )
             result_dict = cast(dict[str, Any], result)
         else:
@@ -128,6 +131,16 @@ async def search_command(args: argparse.Namespace, config: Config) -> None:
                 model=model_name,
                 path_filter=args.path_filter,
                 force_strategy=force_strategy,
+                metadata_filters={
+                    key: value
+                    for key, value in {
+                        "type": args.doc_type,
+                        "status": args.status,
+                        "owner": args.owner,
+                    }.items()
+                    if value
+                }
+                or None,
             )
             result_dict = {"results": results, "pagination": pagination}
 

--- a/chunkhound/api/cli/parsers/search_parser.py
+++ b/chunkhound/api/cli/parsers/search_parser.py
@@ -78,6 +78,21 @@ def add_search_subparser(subparsers: Any) -> argparse.ArgumentParser:
         type=str,
         help="Optional path filter (e.g., 'src/', 'tests/')",
     )
+    search_parser.add_argument(
+        "--doc-type",
+        type=str,
+        help="Optional Markdown frontmatter type filter for semantic doc search",
+    )
+    search_parser.add_argument(
+        "--status",
+        type=str,
+        help="Optional Markdown frontmatter status filter for semantic doc search",
+    )
+    search_parser.add_argument(
+        "--owner",
+        type=str,
+        help="Optional Markdown frontmatter owner filter for semantic doc search",
+    )
 
     # Add common arguments
     add_common_arguments(search_parser)

--- a/chunkhound/core/utils/embedding_utils.py
+++ b/chunkhound/core/utils/embedding_utils.py
@@ -10,6 +10,7 @@ def format_chunk_for_embedding(
     language: str | None = None,
     constants: list[dict[str, str]] | None = None,
     rule_target: str | None = None,
+    doc_metadata: dict | None = None,
 ) -> str:
     """Prepend path, language, and constants metadata to chunk content for embedding.
 
@@ -41,7 +42,7 @@ def format_chunk_for_embedding(
         >>> format_chunk_for_embedding("def foo(): pass")
         'def foo(): pass'
     """
-    if not file_path and not language and not constants and not rule_target:
+    if not file_path and not language and not constants and not rule_target and not doc_metadata:
         return code
 
     if file_path and language:
@@ -67,4 +68,27 @@ def format_chunk_for_embedding(
             const_str += f", +{len(constants) - MAX_CONSTANTS_IN_HEADER} more"
         header += f" [{const_str}]"
 
+    doc_lines = []
+    if doc_metadata:
+        for key in ("doc_title", "doc_type", "doc_status", "doc_owner", "doc_summary"):
+            value = doc_metadata.get(key)
+            if isinstance(value, str) and value:
+                doc_lines.append(f"{key.removeprefix('doc_')}: {value}")
+        tags = doc_metadata.get("doc_tags")
+        if isinstance(tags, list) and tags:
+            doc_lines.append("tags: " + ", ".join(str(tag) for tag in tags[:12]))
+        heading_path = doc_metadata.get("heading_path")
+        if isinstance(heading_path, list) and heading_path:
+            doc_lines.append("heading_path: " + " > ".join(str(item) for item in heading_path))
+        relationships = []
+        for key in doc_metadata.get("relationship_keys") or []:
+            value = doc_metadata.get(key)
+            if isinstance(value, list):
+                relationships.append(f"{key}: {', '.join(str(item) for item in value[:8])}")
+            elif isinstance(value, str) and value:
+                relationships.append(f"{key}: {value}")
+        doc_lines.extend(relationships[:8])
+
+    if doc_lines:
+        return f"{header}\n" + "\n".join(doc_lines) + f"\n\n{code}"
     return f"{header}\n{code}"

--- a/chunkhound/database.py
+++ b/chunkhound/database.py
@@ -226,6 +226,7 @@ class Database:
         offset: int = 0,
         threshold: float | None = None,
         path_filter: str | None = None,
+        metadata_filters: dict[str, str] | None = None,
     ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
         """Perform semantic similarity search.
 
@@ -239,6 +240,7 @@ class Database:
             offset=offset,
             threshold=threshold,
             path_filter=path_filter,
+            metadata_filters=metadata_filters,
         )
 
     def search_regex(

--- a/chunkhound/interfaces/database_provider.py
+++ b/chunkhound/interfaces/database_provider.py
@@ -232,6 +232,7 @@ class DatabaseProvider(Protocol):
         offset: int = 0,
         threshold: float | None = None,
         path_filter: str | None = None,
+        metadata_filters: dict[str, str] | None = None,
     ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
         """Perform semantic vector search.
 
@@ -243,6 +244,7 @@ class DatabaseProvider(Protocol):
             offset: Starting position for pagination
             threshold: Optional similarity threshold
             path_filter: Optional relative path to limit search scope (e.g., 'src/', 'tests/')
+            metadata_filters: Optional exact metadata filters such as doc_type/status
 
         Returns:
             Tuple of (results, pagination_metadata)

--- a/chunkhound/mcp_server/tools.py
+++ b/chunkhound/mcp_server/tools.py
@@ -461,6 +461,9 @@ async def search_impl(
     path: str | None = None,
     page_size: int = 10,
     offset: int = 0,
+    doc_type: str | None = None,
+    status: str | None = None,
+    owner: str | None = None,
 ) -> SearchResponse:
     """Unified search dispatching to regex or semantic based on type.
 
@@ -472,6 +475,9 @@ async def search_impl(
         path: Optional relative subdirectory to restrict search scope, e.g. "src/auth" or "lib/payments" (no leading slash)
         page_size: Number of results per page (1-100)
         offset: Starting offset for pagination
+        doc_type: Optional Markdown frontmatter type filter for docs
+        status: Optional Markdown frontmatter status filter for docs
+        owner: Optional Markdown frontmatter owner filter for docs
 
     Returns:
         Dict with 'results' and 'pagination' keys
@@ -488,6 +494,11 @@ async def search_impl(
     # Validate and constrain parameters
     page_size = max(1, min(page_size, 100))
     offset = max(0, offset)
+    metadata_filters = {
+        key: value
+        for key, value in {"type": doc_type, "status": status, "owner": owner}.items()
+        if value
+    }
 
     if type == "semantic":
         # Validate embedding manager for semantic search
@@ -514,6 +525,7 @@ async def search_impl(
             provider=provider_name,
             model=model_name,
             path_filter=path,
+            metadata_filters=metadata_filters or None,
         )
     else:  # regex
         # Perform regex search

--- a/chunkhound/parsers/mappings/markdown.py
+++ b/chunkhound/parsers/mappings/markdown.py
@@ -5,6 +5,7 @@ for mapping Markdown AST nodes to semantic chunks. Supports CommonMark syntax
 and GitHub Flavored Markdown extensions.
 """
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -12,7 +13,7 @@ from tree_sitter import Node as TSNode
 
 from chunkhound.core.types.common import ChunkType, Language
 from chunkhound.parsers.mappings.base import BaseMapping
-from chunkhound.parsers.universal_engine import UniversalConcept
+from chunkhound.parsers.universal_engine import UniversalChunk, UniversalConcept
 
 
 class MarkdownMapping(BaseMapping):
@@ -680,7 +681,7 @@ class MarkdownMapping(BaseMapping):
         def_node = self._find_definition_node(captures)
         source = content.decode("utf-8", errors="replace")
 
-        metadata = {
+        metadata: dict[str, Any] = {
             "concept": concept.value,
             "language": self.language.value,
             "capture_names": list(captures.keys()),
@@ -741,6 +742,177 @@ class MarkdownMapping(BaseMapping):
             return list(captures.values())[0]
 
         return None
+
+    def extract_universal_chunks(
+        self, content: str, file_path: Path | None = None
+    ) -> list[UniversalChunk]:
+        """Extract knowledgebase-aware Markdown section chunks.
+
+        Markdown is most useful to semantic search when each embedded chunk
+        carries its frontmatter, heading path, and stable section identity. The
+        generic tree-sitter extraction sees headings and paragraphs separately;
+        this section extractor keeps the body attached to its heading context
+        and stores typed-document metadata for filtered doc retrieval.
+        """
+        frontmatter, body_start_line = self._parse_frontmatter(content)
+        lines = content.splitlines()
+        heading_matches = list(self._iter_heading_matches(lines, body_start_line))
+        doc_title = self._doc_title(frontmatter, heading_matches, file_path)
+        base_metadata = self._doc_metadata(frontmatter, doc_title)
+        chunks: list[UniversalChunk] = []
+
+        if body_start_line <= len(lines) and (
+            not heading_matches or heading_matches[0][0] > body_start_line
+        ):
+            preamble_end = heading_matches[0][0] - 1 if heading_matches else len(lines)
+            preamble = "\n".join(lines[body_start_line - 1 : preamble_end]).strip()
+            if preamble:
+                chunks.append(
+                    UniversalChunk(
+                        concept=UniversalConcept.BLOCK,
+                        name="preamble",
+                        content=preamble,
+                        start_line=body_start_line,
+                        end_line=preamble_end,
+                        metadata={
+                            **base_metadata,
+                            "chunk_type_hint": "paragraph",
+                            "heading_path": [],
+                            "section_anchor": "preamble",
+                            "markdown_section": True,
+                            "prevent_merge_across_concepts": True,
+                        },
+                        language_node_type="markdown_section",
+                    )
+                )
+
+        heading_stack: list[tuple[int, str, str]] = []
+        for idx, (line_no, level, title) in enumerate(heading_matches):
+            next_line = (
+                heading_matches[idx + 1][0]
+                if idx + 1 < len(heading_matches)
+                else len(lines) + 1
+            )
+            while heading_stack and heading_stack[-1][0] >= level:
+                heading_stack.pop()
+            anchor = self._slugify(title)
+            heading_stack.append((level, title, anchor))
+            section_lines = lines[line_no - 1 : next_line - 1]
+            section_content = "\n".join(section_lines).strip()
+            if not section_content:
+                continue
+            heading_path = [item[1] for item in heading_stack]
+            chunks.append(
+                UniversalChunk(
+                    concept=UniversalConcept.DEFINITION,
+                    name=f"heading_{anchor or line_no}",
+                    content=section_content,
+                    start_line=line_no,
+                    end_line=next_line - 1,
+                    metadata={
+                        **base_metadata,
+                        "chunk_type_hint": f"header_{level}",
+                        "heading_level": level,
+                        "heading_title": title,
+                        "heading_path": heading_path,
+                        "section_anchor": anchor,
+                        "markdown_section": True,
+                        "prevent_merge_across_concepts": True,
+                    },
+                    language_node_type="markdown_section",
+                )
+            )
+        return chunks
+
+    def _parse_frontmatter(self, content: str) -> tuple[dict[str, Any], int]:
+        lines = content.splitlines()
+        if not lines or lines[0].strip() != "---":
+            return {}, 1
+        end_idx = None
+        for idx, line in enumerate(lines[1:], start=1):
+            if line.strip() == "---":
+                end_idx = idx
+                break
+        if end_idx is None:
+            return {}, 1
+        return self._parse_frontmatter_lines(lines[1:end_idx]), end_idx + 2
+
+    def _parse_frontmatter_lines(self, lines: list[str]) -> dict[str, Any]:
+        data: dict[str, Any] = {}
+        current_key: str | None = None
+        for raw in lines:
+            line = raw.rstrip()
+            if not line.strip():
+                continue
+            if line.startswith("  - ") and current_key:
+                existing = data.setdefault(current_key, [])
+                if isinstance(existing, list):
+                    existing.append(self._parse_scalar(line[4:].strip()))
+                continue
+            if ":" not in line or line.startswith(" "):
+                continue
+            key, value = line.split(":", 1)
+            current_key = key.strip()
+            value = value.strip()
+            data[current_key] = [] if not value else self._parse_scalar(value)
+        return data
+
+    def _parse_scalar(self, value: str) -> Any:
+        value = value.strip().strip('"').strip("'")
+        if value.startswith("[") and value.endswith("]"):
+            inner = value[1:-1].strip()
+            if not inner:
+                return []
+            return [item.strip().strip('"').strip("'") for item in inner.split(",")]
+        return value
+
+    def _iter_heading_matches(
+        self, lines: list[str], start_line: int
+    ) -> list[tuple[int, int, str]]:
+        matches: list[tuple[int, int, str]] = []
+        for idx, line in enumerate(lines[start_line - 1 :], start=start_line):
+            match = re.match(r"^(#{1,6})\s+(.+?)\s*#*\s*$", line)
+            if not match:
+                continue
+            title = match.group(2).strip()
+            matches.append((idx, len(match.group(1)), title))
+        return matches
+
+    def _doc_title(
+        self,
+        frontmatter: dict[str, Any],
+        headings: list[tuple[int, int, str]],
+        file_path: Path | None,
+    ) -> str:
+        summary = frontmatter.get("title") or frontmatter.get("summary")
+        if isinstance(summary, str) and summary:
+            return summary
+        for _, level, title in headings:
+            if level == 1:
+                return title
+        return file_path.stem if file_path else "document"
+
+    def _doc_metadata(self, frontmatter: dict[str, Any], doc_title: str) -> dict[str, Any]:
+        relationship_keys = [
+            key for key in frontmatter if key.startswith("related_") or key in {"supersedes", "superseded_by"}
+        ]
+        metadata: dict[str, Any] = {
+            "concept": "structure",
+            "language": self.language.value,
+            "doc_title": doc_title,
+            "frontmatter": frontmatter,
+            "relationship_keys": relationship_keys,
+        }
+        for key in ("type", "status", "owner", "summary", "tags"):
+            if key in frontmatter:
+                metadata[f"doc_{key}"] = frontmatter[key]
+        for key in relationship_keys:
+            metadata[key] = frontmatter.get(key)
+        return metadata
+
+    def _slugify(self, text: str) -> str:
+        slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+        return slug or "section"
 
     def resolve_import_paths(
         self, import_text: str, base_dir: Path, source_file: Path

--- a/chunkhound/parsers/universal_parser.py
+++ b/chunkhound/parsers/universal_parser.py
@@ -210,6 +210,24 @@ class UniversalParser:
         if not content.strip():
             return []
 
+        # Some mappings have domain-specific semantic section extractors that
+        # provide better retrieval units than generic tree-sitter captures. For
+        # Markdown this preserves frontmatter and heading-path context in every
+        # chunk so documentation embeddings behave like knowledgebase sections.
+        if (
+            hasattr(self.base_mapping, "extract_universal_chunks")
+            and getattr(self.base_mapping, "language", None) == Language.MARKDOWN
+        ):
+            universal_chunks = self.base_mapping.extract_universal_chunks(
+                content, file_path
+            )
+            chunks = self._apply_cast_and_convert(
+                universal_chunks, None, content, file_path, file_id
+            )
+            self._total_files_parsed += 1
+            self._total_chunks_created += len(chunks)
+            return chunks
+
         # Special handling for non-tree-sitter parsers (no tree-sitter parsing)
         if self.engine is None:
             # Check if this is PDF content by looking at language mapping
@@ -657,6 +675,21 @@ class UniversalParser:
                 current_chunk = next_chunk
                 continue
 
+            # Don't merge chunks whose line ranges overlap. Overlapping chunks often
+            # come from nested language constructs extracted as separate concepts
+            # (for example an inner function and a nested object declaration). If
+            # those chunks are concatenated, the shared source lines appear twice in
+            # search results and embeddings. Boundary-touching ranges remain
+            # mergeable for parsers that model adjacent chunks with end == start.
+            line_ranges_overlap = (
+                next_chunk.start_line < current_chunk.end_line
+                and next_chunk.end_line > current_chunk.start_line
+            )
+            if line_ranges_overlap:
+                result.append(current_chunk)
+                current_chunk = next_chunk
+                continue
+
             # Don't merge if either chunk explicitly prevents merging.
             # This respects language-specific metadata that marks chunks as
             # semantically independent (e.g., HCL attributes and blocks).
@@ -888,6 +921,14 @@ class UniversalParser:
                 "namespace": ChunkType.NAMESPACE,
                 "embedded_sql": ChunkType.EMBEDDED_SQL,
                 "import": ChunkType.IMPORT,
+                "header_1": ChunkType.HEADER_1,
+                "header_2": ChunkType.HEADER_2,
+                "header_3": ChunkType.HEADER_3,
+                "header_4": ChunkType.HEADER_4,
+                "header_5": ChunkType.HEADER_5,
+                "header_6": ChunkType.HEADER_6,
+                "paragraph": ChunkType.PARAGRAPH,
+                "code_block": ChunkType.CODE_BLOCK,
             }
             if chunk_type_hint in hint_map:
                 return hint_map[chunk_type_hint]

--- a/chunkhound/providers/database/duckdb_provider.py
+++ b/chunkhound/providers/database/duckdb_provider.py
@@ -2916,6 +2916,7 @@ class DuckDBProvider(SerialDatabaseProvider):
         offset: int = 0,
         threshold: float | None = None,
         path_filter: str | None = None,
+        metadata_filters: dict[str, str] | None = None,
     ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
         """Perform semantic vector search using HNSW index with multi-dimension support.
 
@@ -2932,6 +2933,7 @@ class DuckDBProvider(SerialDatabaseProvider):
             offset,
             threshold,
             path_filter,
+            metadata_filters,
         )
 
     def _executor_search_semantic(
@@ -2945,6 +2947,7 @@ class DuckDBProvider(SerialDatabaseProvider):
         offset: int,
         threshold: float | None,
         path_filter: str | None,
+        metadata_filters: dict[str, str] | None,
     ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
         """Executor method for search_semantic - runs in DB thread."""
         try:
@@ -2998,11 +3001,28 @@ class DuckDBProvider(SerialDatabaseProvider):
                 params.append(query_embedding)
                 params.append(threshold)
 
+            metadata_filter_sql: list[str] = []
+            metadata_filter_params: list[str] = []
+            for key, value in (metadata_filters or {}).items():
+                if not value:
+                    continue
+                safe_key = key if key.startswith("doc_") else f"doc_{key}"
+                if safe_key not in {"doc_type", "doc_status", "doc_owner"}:
+                    continue
+                metadata_filter_sql.append(
+                    f"json_extract_string(c.metadata, '$.{safe_key}') = ?"
+                )
+                metadata_filter_params.append(value)
+
             if path_like is not None:
                 query += " AND f.path LIKE ? ESCAPE '\\'"
                 # Use substring match so callers can pass repo-relative paths
                 # even when the database base_directory is higher (e.g., monorepo root).
                 params.append(path_like)
+
+            for clause, value in zip(metadata_filter_sql, metadata_filter_params):
+                query += f" AND {clause}"
+                params.append(value)
 
             # Get total count for pagination
             # Build count query separately to avoid string replacement issues
@@ -3024,6 +3044,10 @@ class DuckDBProvider(SerialDatabaseProvider):
                 count_query += " AND f.path LIKE ? ESCAPE '\\'"
                 # Substring match for consistency with main query
                 count_params.append(path_like)
+
+            for clause, value in zip(metadata_filter_sql, metadata_filter_params):
+                count_query += f" AND {clause}"
+                count_params.append(value)
 
             total_count = conn.execute(count_query, count_params).fetchone()[0]
 

--- a/chunkhound/providers/database/lancedb_provider.py
+++ b/chunkhound/providers/database/lancedb_provider.py
@@ -1727,6 +1727,7 @@ class LanceDBProvider(SerialDatabaseProvider):
         offset: int = 0,
         threshold: float | None = None,
         path_filter: str | None = None,
+        metadata_filters: dict[str, str] | None = None,
     ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
         """Executor method for search_semantic - runs in DB thread."""
         if self._chunks_table is None:

--- a/chunkhound/providers/database/serial_database_provider.py
+++ b/chunkhound/providers/database/serial_database_provider.py
@@ -235,6 +235,7 @@ class SerialDatabaseProvider(ABC):
         offset: int = 0,
         threshold: float | None = None,
         path_filter: str | None = None,
+        metadata_filters: dict[str, str] | None = None,
     ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
         """Perform semantic vector search if supported."""
         if not hasattr(self, "_executor_search_semantic"):
@@ -249,6 +250,7 @@ class SerialDatabaseProvider(ABC):
             offset,
             threshold,
             path_filter,
+            metadata_filters,
         )
 
     def search_regex(

--- a/chunkhound/services/embedding_service.py
+++ b/chunkhound/services/embedding_service.py
@@ -250,7 +250,7 @@ class EmbeddingService(BaseService):
             # Load chunk content and generate embeddings
             chunks_data = self._get_chunks_by_ids(chunk_ids_without_embeddings)
             chunk_id_list = [chunk["id"] for chunk in chunks_data]
-            chunk_texts = [chunk["code"] for chunk in chunks_data]
+            chunk_texts = [self._format_chunk_text(chunk) for chunk in chunks_data]
 
             generated_count = await self.generate_embeddings_for_chunks(
                 chunk_id_list, chunk_texts, show_progress=True
@@ -321,7 +321,7 @@ class EmbeddingService(BaseService):
             )
 
             # Generate new embeddings
-            chunk_texts = [chunk["code"] for chunk in chunks_to_regenerate]
+            chunk_texts = [self._format_chunk_text(chunk) for chunk in chunks_to_regenerate]
             regenerated_count = await self.generate_embeddings_for_chunks(
                 chunk_ids_to_regenerate, chunk_texts
             )
@@ -897,6 +897,21 @@ class EmbeddingService(BaseService):
             return self._get_chunks_by_ids(chunk_ids)
         return []
 
+    def _format_chunk_text(self, chunk: dict[str, Any]) -> str:
+        """Format chunk text consistently with indexing-time embeddings."""
+        from chunkhound.core.utils import format_chunk_for_embedding
+        from chunkhound.utils.normalization import normalize_content
+
+        metadata = chunk.get("metadata") or {}
+        return format_chunk_for_embedding(
+            code=normalize_content(chunk.get("code", "")),
+            file_path=chunk.get("file_path") or chunk.get("path"),
+            language=chunk.get("language"),
+            constants=metadata.get("constants"),
+            rule_target=metadata.get("rule_target"),
+            doc_metadata=metadata,
+        )
+
     def _get_chunks_by_ids(self, chunk_ids: list[ChunkId]) -> list[dict[str, Any]]:
         """Get chunk data for specific chunk IDs."""
         if not chunk_ids:
@@ -925,6 +940,9 @@ class EmbeddingService(BaseService):
                         "name", chunk.get("symbol", "")
                     ),  # LanceDB uses 'name'
                     "path": chunk.get("file_path", ""),
+                    "file_path": chunk.get("file_path", ""),
+                    "language": chunk.get("language", ""),
+                    "metadata": chunk.get("metadata") or {},
                 }
                 filtered_chunks.append(filtered_chunk)
 
@@ -933,14 +951,31 @@ class EmbeddingService(BaseService):
     def _get_chunks_by_file_path(self, file_path: str) -> list[dict[str, Any]]:
         """Get all chunks for a specific file path."""
         query = """
-            SELECT c.id, c.code, c.symbol, f.path
+            SELECT
+                c.id,
+                c.code,
+                c.symbol,
+                f.path,
+                f.path AS file_path,
+                f.language,
+                c.metadata
             FROM chunks c
             JOIN files f ON c.file_id = f.id
             WHERE f.path = ?
             ORDER BY c.id
         """
 
-        return self._db.execute_query(query, [file_path])
+        chunks = self._db.execute_query(query, [file_path])
+        for chunk in chunks:
+            metadata = chunk.get("metadata")
+            if isinstance(metadata, str):
+                try:
+                    import json
+
+                    chunk["metadata"] = json.loads(metadata)
+                except json.JSONDecodeError:
+                    chunk["metadata"] = {}
+        return chunks
 
     def _delete_embeddings_for_chunks(
         self, chunk_ids: list[ChunkId], provider: str, model: str

--- a/chunkhound/services/indexing_coordinator.py
+++ b/chunkhound/services/indexing_coordinator.py
@@ -1769,6 +1769,7 @@ class IndexingCoordinator(BaseService):
                         language=chunk.get("language"),
                         constants=constants,
                         rule_target=rule_target,
+                        doc_metadata=metadata,
                     )
                     valid_chunk_data.append((chunk_id, chunk, text))
                 else:

--- a/chunkhound/services/search/single_hop_strategy.py
+++ b/chunkhound/services/search/single_hop_strategy.py
@@ -45,6 +45,7 @@ class SingleHopStrategy:
         provider: str,
         model: str,
         path_filter: str | None,
+        metadata_filters: dict[str, str] | None = None,
     ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
         """Perform standard single-hop semantic search.
 
@@ -76,6 +77,7 @@ class SingleHopStrategy:
             offset=offset,
             threshold=threshold,
             path_filter=path_filter,
+            metadata_filters=metadata_filters,
         )
 
         logger.info(f"Standard semantic search completed: {len(results)} results found")

--- a/chunkhound/services/search_service.py
+++ b/chunkhound/services/search_service.py
@@ -65,6 +65,7 @@ class SearchService(BaseService):
         force_strategy: str | None = None,
         time_limit: float | None = None,
         result_limit: int | None = None,
+        metadata_filters: dict[str, str] | None = None,
     ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
         """Perform semantic search using vector similarity.
 
@@ -129,6 +130,11 @@ class SearchService(BaseService):
                     )
                     use_multi_hop = False
 
+            if metadata_filters:
+                # Metadata filters are currently applied in the DB-backed
+                # single-hop query so doc frontmatter filters remain exact.
+                use_multi_hop = False
+
             if use_multi_hop:
                 logger.debug(f"Using multi-hop search with reranking for: '{query}'")
                 assert self._multi_hop_strategy is not None
@@ -154,6 +160,7 @@ class SearchService(BaseService):
                     provider=search_provider,
                     model=search_model,
                     path_filter=path_filter,
+                    metadata_filters=metadata_filters,
                 )
 
             # Enhance results with additional metadata

--- a/tests/test_markdown_doc_semantic_chunks.py
+++ b/tests/test_markdown_doc_semantic_chunks.py
@@ -1,0 +1,71 @@
+from chunkhound.core.types.common import ChunkType, Language
+from chunkhound.core.utils.embedding_utils import format_chunk_for_embedding
+from chunkhound.parsers.parser_factory import create_parser_for_language
+
+
+def test_markdown_sections_carry_frontmatter_and_heading_path_metadata():
+    content = """---
+type: decision
+status: accepted
+owner: docs
+summary: Documentation knowledgebase contract
+tags: [docs, agents]
+related_requirements:
+  - docs/requirements/REQ-agentic-doc-intelligence.md
+---
+
+# ADR-0001: Documentation knowledgebase contract
+
+## Decision
+
+Use typed Markdown frontmatter and explicit relationship fields.
+
+## Consequences
+
+Agents can retrieve docs by type, status, heading, and relationship.
+"""
+
+    parser = create_parser_for_language(Language.MARKDOWN)
+    chunks = parser.parse_content(content)
+
+    decision = next(chunk for chunk in chunks if chunk.symbol == "heading_decision")
+    assert decision.chunk_type == ChunkType.HEADER_2
+    assert decision.metadata["doc_type"] == "decision"
+    assert decision.metadata["doc_status"] == "accepted"
+    assert decision.metadata["doc_owner"] == "docs"
+    assert decision.metadata["doc_tags"] == ["docs", "agents"]
+    assert decision.metadata["heading_path"] == [
+        "ADR-0001: Documentation knowledgebase contract",
+        "Decision",
+    ]
+    assert decision.metadata["related_requirements"] == [
+        "docs/requirements/REQ-agentic-doc-intelligence.md"
+    ]
+
+
+def test_doc_embedding_context_includes_frontmatter_heading_and_relationships():
+    text = format_chunk_for_embedding(
+        code="## Decision\n\nUse typed Markdown frontmatter.",
+        file_path="docs/decisions/ADR-0001.md",
+        language="markdown",
+        doc_metadata={
+            "doc_title": "ADR-0001: Documentation knowledgebase contract",
+            "doc_type": "decision",
+            "doc_status": "accepted",
+            "doc_owner": "communityx",
+            "doc_summary": "Decision to model docs as a typed knowledgebase.",
+            "doc_tags": ["docs", "agents"],
+            "heading_path": [
+                "ADR-0001: Documentation knowledgebase contract",
+                "Decision",
+            ],
+            "relationship_keys": ["related_requirements"],
+            "related_requirements": ["docs/requirements/REQ-agentic-doc-intelligence.md"],
+        },
+    )
+
+    assert "type: decision" in text
+    assert "status: accepted" in text
+    assert "heading_path: ADR-0001: Documentation knowledgebase contract > Decision" in text
+    assert "related_requirements: docs/requirements/REQ-agentic-doc-intelligence.md" in text
+    assert text.endswith("Use typed Markdown frontmatter.")

--- a/tests/test_universal_parser_greedy_merge.py
+++ b/tests/test_universal_parser_greedy_merge.py
@@ -1,0 +1,43 @@
+from chunkhound.core.types.common import Language
+from chunkhound.parsers.parser_factory import create_parser_for_language
+from chunkhound.parsers.universal_engine import UniversalChunk, UniversalConcept
+
+
+def test_greedy_merge_does_not_duplicate_partially_overlapping_chunks():
+    parser = create_parser_for_language(Language.TSX)
+    outer = UniversalChunk(
+        concept=UniversalConcept.DEFINITION,
+        name="submitFeedback_part1",
+        content=(
+            "async function submitFeedback() {\n"
+            "  const payload = {\n"
+            "    route_query_keys: ["
+            "...new URLSearchParams(window.location.search).keys()"
+            "].sort(),\n"
+        ),
+        start_line=150,
+        end_line=172,
+        metadata={},
+        language_node_type="function_declaration",
+    )
+    nested = UniversalChunk(
+        concept=UniversalConcept.DEFINITION,
+        name="payload",
+        content=(
+            "const payload = {\n"
+            "    route_query_keys: ["
+            "...new URLSearchParams(window.location.search).keys()"
+            "].sort(),\n"
+            "    viewport: { width: window.innerWidth },\n"
+            "  };"
+        ),
+        start_line=166,
+        end_line=185,
+        metadata={},
+        language_node_type="lexical_declaration",
+    )
+
+    chunks = parser._greedy_merge_pass([outer, nested])
+
+    assert len(chunks) == 2
+    assert all(chunk.content.count("const payload = {") == 1 for chunk in chunks)


### PR DESCRIPTION
## Summary
- add first-class Markdown section extraction with frontmatter, heading-path, tag, status, owner, and relationship metadata
- enrich embedding text with documentation metadata for better semantic recall
- add semantic metadata filters for doc type/status/owner through native search/CLI plumbing
- prevent greedy chunk merging from duplicating partially-overlapping parser captures

## Validation
- `uv run python -m py_compile chunkhound/parsers/mappings/markdown.py chunkhound/parsers/universal_parser.py chunkhound/core/utils/embedding_utils.py chunkhound/services/indexing_coordinator.py chunkhound/services/embedding_service.py chunkhound/services/search_service.py chunkhound/services/search/single_hop_strategy.py chunkhound/interfaces/database_provider.py chunkhound/providers/database/serial_database_provider.py chunkhound/providers/database/duckdb_provider.py chunkhound/providers/database/lancedb_provider.py chunkhound/mcp_server/tools.py chunkhound/api/cli/parsers/search_parser.py chunkhound/api/cli/commands/search.py chunkhound/database.py`
- `uv run pytest tests/test_markdown_doc_semantic_chunks.py tests/test_universal_parser_greedy_merge.py tests/test_smoke.py -v -n auto`
