### PR TITLE
Fix orphaned MCP proxy shutdown

### DIFF
--- a/chunkhound/daemon/client_proxy.py
+++ b/chunkhound/daemon/client_proxy.py
@@ -124,14 +124,14 @@ class ClientProxy:
         if sys.platform == "win32":
             return False
         current_ppid = os.getppid()
-        return current_ppid == 1 or current_ppid != self._initial_ppid
+        return current_ppid != self._initial_ppid
 
     async def _orphan_watchdog(self) -> None:
         """Poll parent PID; signal shutdown when orphaned.
 
-        Completes cleanly when the parent dies — the caller's asyncio.wait
-        (FIRST_COMPLETED) will then cancel stdin/stdout forwarding and
-        trigger normal cleanup.
+        Sets the shutdown event and completes cleanly when the parent dies —
+        the caller's asyncio.wait (FIRST_COMPLETED) will then cancel
+        stdin/stdout forwarding and trigger normal cleanup.
         """
         while True:
             await asyncio.sleep(self._ORPHAN_POLL_INTERVAL)
@@ -166,9 +166,10 @@ class ClientProxy:
             stdin_task = asyncio.create_task(self._forward_stdin_to_socket(writer))
             stdout_task = asyncio.create_task(self._forward_socket_to_stdout(reader))
             watchdog_task = asyncio.create_task(self._orphan_watchdog())
+            shutdown_task = asyncio.create_task(self._shutdown_event.wait())
 
-            done, pending = await asyncio.wait(
-                {stdin_task, stdout_task, watchdog_task},
+            _, pending = await asyncio.wait(
+                {stdin_task, stdout_task, watchdog_task, shutdown_task},
                 return_when=asyncio.FIRST_COMPLETED,
             )
 

--- a/chunkhound/daemon/client_proxy.py
+++ b/chunkhound/daemon/client_proxy.py
@@ -36,10 +36,13 @@ class _SocketForwardResult:
 class ClientProxy:
     """Bridge between Claude's stdio and the ChunkHound daemon IPC socket."""
 
+    _ORPHAN_POLL_INTERVAL = 5.0
+
     def __init__(self, project_dir: Path, args: Any) -> None:
         self._project_dir = project_dir.resolve()
         self._args = args
         self._discovery = DaemonDiscovery(self._project_dir)
+        self._initial_ppid = None if sys.platform == "win32" else os.getppid()
 
     async def _connect_or_startup_failure(
         self, address: str
@@ -111,6 +114,35 @@ class ClientProxy:
         if not isinstance(ack, dict) or ack.get("type") != "registered":
             raise RuntimeError(f"Unexpected registration response from daemon: {ack}")
 
+    def _is_orphaned(self) -> bool:
+        """Return True if the original parent process no longer owns this proxy.
+
+        On Unix, an orphaned process may be reparented to PID 1 (init/launchd)
+        or to a child subreaper. Treat any parent PID change from startup as
+        orphaning. On Windows, the existing pipe-close detection is sufficient.
+        """
+        if sys.platform == "win32":
+            return False
+        current_ppid = os.getppid()
+        return current_ppid == 1 or current_ppid != self._initial_ppid
+
+    async def _orphan_watchdog(self) -> None:
+        """Poll parent PID; signal shutdown when orphaned.
+
+        Completes cleanly when the parent dies — the caller's asyncio.wait
+        (FIRST_COMPLETED) will then cancel stdin/stdout forwarding and
+        trigger normal cleanup.
+        """
+        while True:
+            await asyncio.sleep(self._ORPHAN_POLL_INTERVAL)
+            if self._is_orphaned():
+                print(
+                    "Parent process died — shutting down orphaned proxy",
+                    file=sys.stderr,
+                )
+                self._shutdown_event.set()
+                return
+
     async def run(self) -> None:
         """Connect to the daemon and relay messages until stdin closes."""
         address = await self._discovery.find_or_start_daemon(self._args)
@@ -124,16 +156,20 @@ class ClientProxy:
         try:
             await self._register_with_daemon(reader, writer)
 
-            # Bidirectional forwarding
-            # Use wait() with FIRST_COMPLETED so when stdin closes, we immediately
-            # close the socket connection rather than waiting for both tasks.
+            # Bidirectional forwarding with orphan watchdog
+            # Use wait() with FIRST_COMPLETED so when stdin closes or the parent
+            # dies, we immediately close the socket connection rather than waiting
+            # for both tasks.
             # This is critical on Windows where proc.terminate() may not cleanly
             # close stdin, leaving the stdin reader blocked.
+            self._shutdown_event = asyncio.Event()
             stdin_task = asyncio.create_task(self._forward_stdin_to_socket(writer))
             stdout_task = asyncio.create_task(self._forward_socket_to_stdout(reader))
+            watchdog_task = asyncio.create_task(self._orphan_watchdog())
 
             done, pending = await asyncio.wait(
-                {stdin_task, stdout_task}, return_when=asyncio.FIRST_COMPLETED
+                {stdin_task, stdout_task, watchdog_task},
+                return_when=asyncio.FIRST_COMPLETED,
             )
 
             for task in pending:

--- a/tests/unit/test_client_proxy.py
+++ b/tests/unit/test_client_proxy.py
@@ -442,6 +442,21 @@ def test_is_orphaned_ignores_live_parent_on_unix(
     assert proxy._is_orphaned() is False
 
 
+def test_is_orphaned_allows_pid_1_when_initial_parent_was_pid_1(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(
+        client_proxy_module.os,
+        "getppid",
+        Mock(side_effect=[1, 1]),
+    )
+    proxy = ClientProxy(tmp_path / "repo", SimpleNamespace())
+
+    assert proxy._is_orphaned() is False
+
+
 @pytest.mark.asyncio
 async def test_orphan_watchdog_triggers_shutdown_when_orphaned(
     tmp_path: Path,
@@ -479,6 +494,53 @@ async def test_orphan_watchdog_triggers_shutdown_when_orphaned(
 
     assert stdin_cancelled.is_set()
     assert "Parent process died" in stderr.getvalue()
+    assert writer.closed
+    assert writer.wait_closed_called
+
+
+@pytest.mark.asyncio
+async def test_run_observes_shutdown_event_when_watchdog_signals(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """run exits when the watchdog sets the shutdown event."""
+    proxy, _, writer = _make_proxy(tmp_path, monkeypatch)
+
+    stdin_cancelled = asyncio.Event()
+    stdout_cancelled = asyncio.Event()
+    watchdog_cancelled = asyncio.Event()
+
+    async def blocked_stdin(_writer: asyncio.StreamWriter) -> None:
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            stdin_cancelled.set()
+            raise
+
+    async def blocked_stdout(_reader: asyncio.StreamReader) -> _SocketForwardResult:
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            stdout_cancelled.set()
+            raise
+
+    async def event_only_watchdog() -> None:
+        proxy._shutdown_event.set()
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            watchdog_cancelled.set()
+            raise
+
+    proxy._orphan_watchdog = event_only_watchdog
+    proxy._forward_stdin_to_socket = blocked_stdin
+    proxy._forward_socket_to_stdout = blocked_stdout
+
+    await asyncio.wait_for(proxy.run(), timeout=1.0)
+
+    assert stdin_cancelled.is_set()
+    assert stdout_cancelled.is_set()
+    assert watchdog_cancelled.is_set()
     assert writer.closed
     assert writer.wait_closed_called
 

--- a/tests/unit/test_client_proxy.py
+++ b/tests/unit/test_client_proxy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -379,3 +380,150 @@ async def test_run_wraps_registration_write_failures(
     discovery.format_startup_failure.assert_called_once()
     assert writer.closed
     assert writer.wait_closed_called
+
+
+# ---------------------------------------------------------------------------
+# Orphan watchdog
+# ---------------------------------------------------------------------------
+
+
+def test_client_proxy_captures_initial_parent_pid_on_unix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    getppid = Mock(return_value=2000)
+    monkeypatch.setattr(client_proxy_module.os, "getppid", getppid)
+
+    proxy = ClientProxy(tmp_path / "repo", SimpleNamespace())
+
+    assert proxy._initial_ppid == 2000
+    getppid.assert_called_once_with()
+
+
+def test_is_orphaned_detects_pid_1_reparent_on_unix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(client_proxy_module.os, "getppid", Mock(side_effect=[2000, 1]))
+    proxy = ClientProxy(tmp_path / "repo", SimpleNamespace())
+
+    assert proxy._is_orphaned() is True
+
+
+def test_is_orphaned_detects_non_pid_1_parent_change_on_unix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(
+        client_proxy_module.os,
+        "getppid",
+        Mock(side_effect=[2000, 3000]),
+    )
+    proxy = ClientProxy(tmp_path / "repo", SimpleNamespace())
+
+    assert proxy._is_orphaned() is True
+
+
+def test_is_orphaned_ignores_live_parent_on_unix(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(
+        client_proxy_module.os,
+        "getppid",
+        Mock(side_effect=[2000, 2000]),
+    )
+    proxy = ClientProxy(tmp_path / "repo", SimpleNamespace())
+
+    assert proxy._is_orphaned() is False
+
+
+@pytest.mark.asyncio
+async def test_orphan_watchdog_triggers_shutdown_when_orphaned(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When _is_orphaned returns True, the watchdog triggers clean shutdown."""
+    proxy, discovery, writer = _make_proxy(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        client_proxy_module.ClientProxy, "_ORPHAN_POLL_INTERVAL", 0.0
+    )
+    monkeypatch.setattr(proxy, "_is_orphaned", lambda: True)
+
+    stdin_cancelled = asyncio.Event()
+
+    async def blocked_stdin(_writer: asyncio.StreamWriter) -> None:
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            stdin_cancelled.set()
+            raise
+
+    async def blocked_stdout(_reader: asyncio.StreamReader) -> _SocketForwardResult:
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            raise
+
+    proxy._forward_stdin_to_socket = blocked_stdin
+    proxy._forward_socket_to_stdout = blocked_stdout
+
+    stderr = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", stderr)
+
+    await proxy.run()
+
+    assert stdin_cancelled.is_set()
+    assert "Parent process died" in stderr.getvalue()
+    assert writer.closed
+    assert writer.wait_closed_called
+
+
+@pytest.mark.asyncio
+async def test_orphan_watchdog_canceled_on_clean_shutdown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Watchdog is cancelled when stdin closes first (normal operation)."""
+    proxy, _, writer = _make_proxy(tmp_path, monkeypatch)
+    monkeypatch.setattr(proxy, "_is_orphaned", lambda: False)
+
+    watchdog_cancelled = asyncio.Event()
+
+    async def cancellable_watchdog() -> None:
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            watchdog_cancelled.set()
+            raise
+
+    proxy._orphan_watchdog = cancellable_watchdog
+    proxy._forward_stdin_to_socket = AsyncMock()
+    proxy._forward_socket_to_stdout = AsyncMock(
+        return_value=_SocketForwardResult(message_count=1)
+    )
+
+    await proxy.run()
+
+    assert watchdog_cancelled.is_set()
+    assert writer.closed
+    assert writer.wait_closed_called
+
+
+def test_is_orphaned_returns_false_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_is_orphaned returns False on Windows regardless of PPID."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    getppid = Mock(return_value=1)
+    monkeypatch.setattr(client_proxy_module.os, "getppid", getppid)
+
+    proxy = ClientProxy(Path("."), SimpleNamespace())
+
+    assert proxy._initial_ppid is None
+    assert proxy._is_orphaned() is False
+    getppid.assert_not_called()


### PR DESCRIPTION
## Summary

Ensures `chunkhound mcp` proxy processes shut down when their launching parent process dies ungracefully, so orphaned MCP sessions do not survive indefinitely consuming CPU/RSS or leave stale daemon clients behind.

## Original tickets

- Issue #272: https://github.com/chunkhound/chunkhound/issues/272

## Requirements

- Detect ungraceful parent death for MCP proxy users on macOS and Linux, including PID 1 reparenting and non-PID1 reparenting under supervisors/subreapers.
- Preserve normal MCP operation while the original parent process is still alive.
- Keep clean shutdown behavior via stdin EOF working for normal exits.
- Avoid false-positive orphan shutdown on Windows, where existing pipe-close behavior remains responsible for shutdown.
- Keep the `chunkhound mcp` CLI contract unchanged.

## Acceptance criteria

- On Unix, a proxy whose parent is killed and reparented to PID 1 exits within the watchdog interval and does not remain orphaned.
- On Unix, a proxy whose parent changes to a different non-PID1 process also treats itself as orphaned and exits.
- Orphan-triggered shutdown writes `Parent process died — shutting down orphaned proxy` to stderr, leaving stdout reserved for JSON-RPC traffic.
- A proxy with a live, unchanged parent continues stdin/stdout forwarding normally.
- Clean parent exits still shut down through the existing stdin-close path and cancel the orphan watchdog cleanly.
- In multi-client daemon sessions, shutting down one orphaned proxy removes only that client/session while other clients continue to operate.
- Windows orphan detection remains a no-op and continues to rely on existing pipe-close detection.
- Existing unit and smoke coverage continue to pass without CLI-surface regressions.

## Out of scope

- Daemon-side orphan eviction changes.
- New CLI flags or configurable watchdog settings.
- Native platform-specific parent-death APIs.
- Parent/launcher cooperation mechanisms such as sentinels, heartbeats, or protocol changes.
- Windows-specific parent-handle watching.
- Daemon configuration UX, dashboards, or status-surface changes.

## How to verify

- Run `uv run python -m pytest tests/unit/test_client_proxy.py -v` to verify parent-death, live-parent, clean-shutdown, and Windows behavior.
- Run `uv run python -m pytest tests/test_smoke.py -v` or the full suite to confirm no regressions.
- On Unix, manually start `chunkhound mcp`, kill its launching parent ungracefully, wait longer than the watchdog interval, and confirm the proxy process is gone and stderr contains `Parent process died — shutting down orphaned proxy`.

## Epic reference

- Epic: chunkhound-daemon
- Story: 01 — Fix orphaned `chunkhound mcp` proxy when parent dies ungracefully
- Step file: agent_coordination/epics/chunkhound-daemon/01_fix_orphaned_mcp_proxy.md
