### PR TITLE
OpenCode CLI: ARG_MAX stdin piping

### DIFF
--- a/chunkhound/providers/llm/opencode_cli_provider.py
+++ b/chunkhound/providers/llm/opencode_cli_provider.py
@@ -297,14 +297,16 @@ class OpenCodeCLIProvider(BaseCLIProvider):
             "OpenCode CLI command failed after retries"
         )
 
-    def _build_cmd(self, model: str, use_json: bool, message: str) -> list[str]:
-        """Build the opencode run command list (extracted for testability)."""
+    def _build_cmd(self, model: str, use_json: bool) -> list[str]:
+        """Build the opencode run command list without the prompt.
+
+        The prompt is sent via stdin to avoid ARG_MAX limits on large inputs.
+        """
         cmd = ["opencode", "run", "--model", model]
         if use_json:
             cmd.extend(["--format", "json"])
         if self._reasoning_effort:
             cmd.extend(["--variant", self._reasoning_effort])
-        cmd.append(message)
         return cmd
 
     def _ndjson_parse_stdout(self, stdout: bytes) -> tuple[list[str], str | None]:
@@ -427,12 +429,12 @@ class OpenCodeCLIProvider(BaseCLIProvider):
         readable while the per-attempt subprocess/parse/exception handling
         lives in one focused method.
         """
-        cmd = self._build_cmd(model, use_json, message)
+        cmd = self._build_cmd(model, use_json)
         process = None
         try:
             process = await asyncio.create_subprocess_exec(
                 *cmd,
-                stdin=subprocess.DEVNULL,
+                stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=os.environ.copy(),
@@ -440,7 +442,7 @@ class OpenCodeCLIProvider(BaseCLIProvider):
             )
 
             stdout, stderr = await asyncio.wait_for(
-                process.communicate(),
+                process.communicate(input=message.encode("utf-8")),
                 timeout=request_timeout,
             )
             stderr_msg = (
@@ -462,7 +464,8 @@ class OpenCodeCLIProvider(BaseCLIProvider):
                 if json_result.action == "retry_plain":
                     return _PhaseResult(action="retry_plain", attempts_used=1)
                 if json_result.action == "failure":
-                    if json_result.error_message is None:  # defensive — should never happen
+                    # Defensive guard — should never happen.
+                    if json_result.error_message is None:
                         raise RuntimeError(
                             "_parse_json_output returned failure without error_message"
                         )

--- a/tests/unit/llm/test_opencode_cli_provider.py
+++ b/tests/unit/llm/test_opencode_cli_provider.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import json
-import subprocess
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -499,7 +498,9 @@ class TestOpenCodeCLIProvider:
             assert "--format" in first_args
 
     @pytest.mark.asyncio
-    async def test_run_cli_command_json_fallback_preserves_remaining_attempt_budget(self):
+    async def test_run_cli_command_json_fallback_preserves_remaining_attempt_budget(
+        self,
+    ):
         """JSON fallback should only spend the primary model's remaining attempts."""
         status_event = json.dumps({"type": "status", "data": "running"})
         with patch.object(
@@ -778,8 +779,11 @@ class TestOpenCodeCLIProvider:
             assert result == "OK"
 
     @pytest.mark.asyncio
-    async def test_run_cli_command_passes_prompt_as_positional_message(self, provider):
-        """OpenCode CLI expects the prompt as the trailing positional arg."""
+    async def test_run_cli_command_passes_prompt_via_stdin(
+        self, provider, monkeypatch: pytest.MonkeyPatch
+    ):
+        """OpenCode CLI reads the prompt from stdin to avoid ARG_MAX limits."""
+        monkeypatch.setenv("CHUNKHOUND_OPENCODE_JSON", "0")
         with patch("asyncio.create_subprocess_exec") as mock_subprocess:
             mock_process = AsyncMock()
             mock_process.communicate.return_value = (b"Plain output", b"")
@@ -789,11 +793,14 @@ class TestOpenCodeCLIProvider:
             result = await provider._run_cli_command("Test prompt")
 
             assert result == "Plain output"
-            assert mock_subprocess.call_args[0][-1] == "Test prompt"
+            mock_process.communicate.assert_called_once_with(input=b"Test prompt")
 
     @pytest.mark.asyncio
-    async def test_run_cli_command_detaches_stdin(self, provider):
-        """Non-interactive runs must never inherit the caller's stdin."""
+    async def test_run_cli_command_pipes_stdin(
+        self, provider, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Non-interactive runs pipe the prompt via stdin instead of argv."""
+        monkeypatch.setenv("CHUNKHOUND_OPENCODE_JSON", "0")
         with patch("asyncio.create_subprocess_exec") as mock_subprocess:
             mock_process = AsyncMock()
             mock_process.communicate.return_value = (b"Plain output", b"")
@@ -803,7 +810,9 @@ class TestOpenCodeCLIProvider:
             result = await provider._run_cli_command("Test prompt")
 
             assert result == "Plain output"
-            assert mock_subprocess.call_args.kwargs["stdin"] is subprocess.DEVNULL
+            assert mock_subprocess.call_args.kwargs["stdin"] is asyncio.subprocess.PIPE
+            assert "Test prompt" not in mock_subprocess.call_args.args
+            mock_process.communicate.assert_called_once_with(input=b"Test prompt")
 
     @pytest.mark.asyncio
     async def test_run_cli_command_includes_variant_flag(self, provider):
@@ -881,21 +890,23 @@ class TestOpenCodeCLIProvider:
             assert result == "OK"
 
     @pytest.mark.asyncio
-    async def test_run_cli_command_system_prompt_format(self, provider):
-        """Test that system and user prompts are concatenated into argv."""
+    async def test_run_cli_command_system_prompt_format(
+        self, provider, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Test that system and user prompts are concatenated and sent via stdin."""
+        monkeypatch.setenv("CHUNKHOUND_OPENCODE_JSON", "0")
         with patch("asyncio.create_subprocess_exec") as mock_subprocess:
             mock_process = AsyncMock()
-            mock_process.communicate.return_value = (b"", b"")
-            mock_process.returncode = 1
+            mock_process.communicate.return_value = (b"OK", b"")
+            mock_process.returncode = 0
             mock_subprocess.return_value = mock_process
 
-            with pytest.raises(RuntimeError):
-                await provider._run_cli_command("Test prompt", system="System message")
+            await provider._run_cli_command("Test prompt", system="System message")
 
-            argv = mock_subprocess.call_args[0]
-            assert argv[-1] == (
-                "System Instructions:\nSystem message\n\nUser Request:\nTest prompt"
+            expected_prompt = (
+                b"System Instructions:\nSystem message\n\nUser Request:\nTest prompt"
             )
+            mock_process.communicate.assert_called_once_with(input=expected_prompt)
 
     def test_format_json_flag_unsupported_markers(self, provider):
         """Test predicate recognizes all unsupported-flag marker strings."""


### PR DESCRIPTION
## Summary
OpenCode-backed ChunkHound sessions can now handle large codebase prompts without crashing on OS argument-length limits. The OpenCode CLI provider sends the full prompt through stdin and keeps argv limited to stable command flags, matching the safer transport pattern already used by the other CLI-backed providers.

## Requirements
- Remove the OpenCode provider's `[Errno 7] Argument list too long` failure path for large prompts, long conversations, and large codebase context.
- Make prompt delivery size-independent by using stdin instead of command-line positional prompt arguments.
- Keep OpenCode structured-output behavior intact; NDJSON parsing hardening already landed separately in PR #266 and remains regression coverage for this change.
- Preserve the shared `LLMProvider` interface and avoid new user configuration.
- Keep Codex CLI and Claude Code CLI behavior unchanged because they are already stdin-safe.

## Why this is needed
- Large ChunkHound prompts routinely combine system instructions, repository context, retrieved code, and conversation history. On Linux these can exceed the roughly 2 MB `ARG_MAX` process-spawn limit before the OpenCode CLI ever starts.
- The previous OpenCode transport put the prompt in argv, so the failure happened at subprocess creation time with no useful recovery path.
- Codex CLI and Claude Code CLI already avoid this class of bug by piping prompts through stdin; OpenCode was the remaining CLI provider with an argv prompt transport risk.

## Acceptance criteria
- The OpenCode subprocess is spawned with stdin attached to a pipe.
- The full prompt bytes are written through stdin during subprocess communication.
- The generated OpenCode command contains only command flags and options such as model, JSON format, and reasoning variant.
- Prompt text never appears in argv, regardless of prompt size.
- System and user prompt composition is preserved before the combined prompt is sent through stdin.
- Existing OpenCode NDJSON edge-case parsing tests continue to pass unchanged as regression coverage.

## Product and design decisions
- **Always use stdin for OpenCode prompts.** There is no prompt-size threshold because `ARG_MAX` varies by OS and environment, and threshold-based routing would leave edge cases.
- **No argv fallback for OpenCode.** `opencode run` is a 1.x subcommand and all supported 1.x versions read stdin, so a dual-mode fallback would add complexity without supporting a real ChunkHound target.
- **No OpenCode 0.x compatibility path.** Older 0.x OpenCode used a different CLI shape (`opencode -p`) and is not the CLI surface ChunkHound targets.
- **No shared provider-interface change.** This is a transport fix inside the OpenCode CLI provider, not a new LLM provider capability or user-facing configuration surface.
- **No Codex/Claude changes.** Those providers were inspected and already use stdin-safe prompt transport, so expanding scope would increase risk without improving this story's outcome.
- **No NDJSON parser change.** Parser hardening was already merged in PR #266; this PR only verifies that coverage remains green while fixing prompt transport.

## Contract changes
- OpenCode CLI prompt transport changes from argv to stdin.
- The user-visible outcome is that large OpenCode prompts should no longer fail before subprocess startup due to OS argv-size limits.
- No CLI flags, config keys, environment variables, public Python interfaces, or persisted formats are added or changed.

## Out of scope
- Changes to Codex CLI or Claude Code CLI providers.
- Changes to the shared `LLMProvider` interface.
- New configuration fields or environment variables.
- Integration or end-to-end tests that require OpenCode authentication.
- Timeout/retry normalization across providers.
- Reasoning-effort validation changes.
- OpenCode 0.x syntax fallback.
- Additional NDJSON parsing hardening beyond the already-merged PR #266 work.

## How to verify
- Run `uv run python -m pytest tests/unit/llm/test_opencode_cli_provider.py -v` and confirm the OpenCode provider suite passes.
- Confirm the stdin-focused tests cover:
  - prompt bytes are sent via stdin,
  - subprocess stdin is a pipe,
  - prompt text is absent from argv,
  - system and user prompts are combined correctly before stdin delivery.
- Optional smoke check: `uv run python -m pytest tests/test_smoke.py -v -n auto`.

## Verification run for this PR
- `uv run python -m pytest tests/test_smoke.py -v -n auto` → 17 passed.
- `uv run python -m pytest tests/unit/llm/test_opencode_cli_provider.py -v` → 60 passed.
- `uv run ruff check chunkhound/providers/llm/opencode_cli_provider.py tests/unit/llm/test_opencode_cli_provider.py` → all checks passed.
- Full suite was attempted; unrelated existing/environment failures remain outside this PR's scope, including site tests requiring missing `astro` plus unrelated autodoc/daemon tests.

## Epic reference
- Epic: llm-provider-integration
- Story: 1 — OpenCode CLI: ARG_MAX stdin piping
- Step file: `agent_coordination/epics/llm-provider-integration/story-01-opencode-cli-stdin-ndjson-hardening.md`
