### PR TITLE
fix(ci): rename concurrency group to avoid pages collision; add workflow_dispatch

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -5,12 +5,13 @@ on:
     branches: [main]
   pull_request:
   merge_group:
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.ref == 'refs/heads/main' && 'pages' || github.run_id }}
+  group: ${{ github.ref == 'refs/heads/main' && 'ch-test-deploy' || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -170,7 +171,7 @@ jobs:
     needs: pages-artifact
     if: github.ref == 'refs/heads/main'
     concurrency:
-      group: pages
+      group: ch-test-deploy
       cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Problem

The CI pipeline is completely blocked — no pushes to `main` trigger the Tests workflow. Root cause: the top-level `concurrency: group: 'pages'` (introduced in #300) collides with GitHub's internal `pages-build-deployment` workflow which also uses the `pages` concurrency group. With `cancel-in-progress: false`, our workflow is queued behind it and never starts.

PR events still work because they use `github.run_id` (unique per run).

## Fix

Three changes to `.github/workflows/smoke-tests.yml`:

1. **Rename top-level concurrency group** from `'pages'` to `'ch-test-deploy'` — unique to this project, won't collide with GitHub internals
2. **Rename deploy job concurrency group** from `'pages'` to `'ch-test-deploy'` — same rationale
3. **Add `workflow_dispatch:` trigger** — permanent escape hatch to manually run the workflow from the Actions UI

## Deployment

After merge, the push to main will trigger CI with the fixed concurrency group. The pipeline will build and deploy, and `sync-changelog.mjs` will generate the correct changelog (including v5.0.0 and v5.1.0) at build time.