### PR TITLE
remove redundant deploy job concurrency to fix deadlock with top-level group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,9 +170,6 @@ jobs:
   deploy:
     needs: pages-artifact
     if: github.ref == 'refs/heads/main'
-    concurrency:
-      group: ch-test-deploy
-      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/tests/unit/test_docs_version_workflow_contract.py
+++ b/tests/unit/test_docs_version_workflow_contract.py
@@ -564,14 +564,22 @@ class TestDocsVersionWorkflowContract:
         assert upload_step["with"]["path"] == "site/dist/"
         assert permissions["contents"] == "read"
 
+    def test_workflow_concurrency_contract(self) -> None:
+        workflow = _load_workflow(".github/workflows/ci.yml")
+        concurrency = cast(dict[str, Any], workflow.get("concurrency", {}))
+
+        assert concurrency["group"] == (
+            "${{ github.ref == 'refs/heads/main' && 'ch-test-deploy' || github.run_id }}"
+        )
+        assert concurrency["cancel-in-progress"] is False
+
     def test_deploy_job_contract(self) -> None:
         job = _job(".github/workflows/ci.yml", "deploy")
         permissions = cast(dict[str, Any], job.get("permissions", {}))
-        concurrency = cast(dict[str, Any], job.get("concurrency", {}))
 
         assert job["needs"] == "pages-artifact"
         assert job["if"] == "github.ref == 'refs/heads/main'"
-        assert concurrency["group"] == "ch-test-deploy"
-        assert concurrency["cancel-in-progress"] is False
+        assert "concurrency" not in job
+        assert permissions["contents"] == "read"
         assert permissions["pages"] == "write"
         assert permissions["id-token"] == "write"


### PR DESCRIPTION
**Note**: This PR was generated by an AI agent. If you'd like to talk with other humans, drop by our Discord!

---

**What:** Removes the redundant `concurrency` block from the `deploy` job in `ci.yml`.

**Why:** The workflow already has a top-level `concurrency` group (`ch-test-deploy` on main, `github.run_id` on PRs). Nesting an identical group on the deploy job was redundant and created a subtle deadlock path: when the top-level group serializes execution, the deploy job's own group is a second lock participants must acquire, and under certain conditions (e.g., rapid re-triggers with overlapping `needs` resolution) the deploy job could be left waiting on itself. The top-level group alone correctly serializes deploy runs on main.

**Value:** Eliminates a real (if rare) CI deadlock hazard, removes dead config — the deploy job concurrency was never doing distinct work from the top-level group — and simplifies the workflow contract. The corresponding test now asserts the job has no concurrency and validates the top-level group separately.

---

Attached is an agent optimized description of the changes in this PR - [AGENT_REVIEW.md](https://github.com/user-attachments/files/28306322/AGENT_REVIEW.md)
