### PR TITLE
Websearch: system Chrome + more robust PDF handling

### DIFF
--- a/chunkhound/utils/websearch_core.py
+++ b/chunkhound/utils/websearch_core.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from playwright.async_api import BrowserContext, Request, Route
+    from playwright.async_api import BrowserContext
 
 from chunkhound.core.config.config import Config
 
@@ -188,73 +188,46 @@ def _fetch_url(url: str) -> tuple[str, str | bytes]:
 
 
 async def _fetch_page(context: BrowserContext, url: str) -> tuple[str, str | bytes]:
-    """Fetch a single URL using an existing Playwright browser context."""
+    """Fetch a single URL.
+
+    HTML is fetched through Chromium's network stack. PDFs go through
+    Playwright's APIRequestContext because headless Chromium cannot reliably
+    expose PDF bytes to page.content()/response.body() — see Playwright #6342
+    and scrapy-playwright #243.
+    """
     page = await context.new_page()
     try:
-        pdf_body: bytes | None = None
-        fetch_error: Exception | None = None
+        # commit resolves once response headers are parsed — before Chromium
+        # hands a PDF to its viewer or starts rendering HTML.
+        response = await page.goto(url, timeout=30000, wait_until="commit")
+        if response is None:
+            raise ValueError("Navigation failed: no response")
 
-        async def handle(route: Route, request: Request) -> None:
-            nonlocal pdf_body, fetch_error
-            if request.resource_type != "document":
-                await route.continue_()
-                return
-            try:
-                resp = await route.fetch()
-            except Exception as e:
-                fetch_error = e
-                await route.abort()
-                return
-            ct = resp.headers.get("content-type", "").split(";")[0].strip()
-            if ct == "application/pdf":
-                pdf_body = await resp.body()
-                await resp.dispose()
-                # Fulfill with empty HTML so page.goto completes without error
-                await route.fulfill(body=b"", content_type="text/html")
-            else:
-                try:
-                    await route.fulfill(response=resp)
-                finally:
-                    await resp.dispose()
+        ct = response.headers.get("content-type", "").split(";")[0].strip()
 
-        await page.route("**/*", handle)
-        try:
-            response = await page.goto(url, timeout=30000)
-        except Exception:
-            if fetch_error is not None:
-                raise fetch_error
-            raise
-        if fetch_error is not None:
-            raise fetch_error
-
-        if pdf_body is not None:
-            if pdf_body[:4] == b"%PDF":
-                return ".pdf", pdf_body
-            # Chromium's PDF viewer can consume the response before the route
-            # handler receives the full body — re-fetch directly to bypass it.
+        if ct == "application/pdf":
+            await page.close()
             direct = await context.request.get(url)
             try:
                 if not direct.ok:
-                    raise ValueError(
-                        f"PDF fallback fetch failed: HTTP {direct.status}"
-                    )
+                    raise ValueError(f"PDF fetch failed: HTTP {direct.status}")
                 direct_ct = direct.headers.get("content-type", "").split(";")[0].strip()
                 if direct_ct != "application/pdf":
                     raise ValueError(
-                        f"PDF magic bytes missing and direct fetch returned {direct_ct!r}"
+                        f"Expected application/pdf, got {direct_ct!r}"
                     )
                 return ".pdf", await direct.body()
             finally:
                 await direct.dispose()
 
-        if response is None:
-            raise ValueError("Navigation failed: no response")
-        ct = response.headers.get("content-type", "").split(";")[0].strip()
         if ct and ct != "text/html":
             raise ValueError(f"Unsupported content-type: {ct!r}")
+
+        await page.wait_for_load_state("load")
         return ".md", _html_to_markdown(await page.content())
     finally:
-        await page.close()
+        if not page.is_closed():
+            await page.close()
 
 
 async def _fetch_one(
@@ -322,7 +295,14 @@ async def fetch_and_save(
                 )
             await _run(None)
             return
-        browser = await pw.chromium.launch()
+        # New headless mode is required for the PDF path: legacy --headless
+        # hands PDFs to an internal viewer and never exposes the response to
+        # _fetch_page. --headless=new keeps the navigation visible so we can
+        # branch on content-type at commit time.
+        browser = await pw.chromium.launch(
+            args=["--headless=new"],
+            ignore_default_args=["--headless"],
+        )
         try:
             context = await browser.new_context()
             try:

--- a/chunkhound/utils/websearch_core.py
+++ b/chunkhound/utils/websearch_core.py
@@ -190,14 +190,14 @@ def _fetch_url(url: str) -> tuple[str, str | bytes]:
 async def _fetch_page(context: BrowserContext, url: str) -> tuple[str, str | bytes]:
     """Fetch a single URL.
 
-    HTML is fetched through Chromium's network stack. PDFs go through
-    Playwright's APIRequestContext because headless Chromium cannot reliably
+    HTML is fetched through Chrome's network stack. PDFs go through
+    Playwright's APIRequestContext because headless Chrome cannot reliably
     expose PDF bytes to page.content()/response.body() — see Playwright #6342
     and scrapy-playwright #243.
     """
     page = await context.new_page()
     try:
-        # commit resolves once response headers are parsed — before Chromium
+        # commit resolves once response headers are parsed — before Chrome
         # hands a PDF to its viewer or starts rendering HTML.
         response = await page.goto(url, timeout=30000, wait_until="commit")
         if response is None:
@@ -280,29 +280,38 @@ async def fetch_and_save(
         await asyncio.gather(*tasks)
 
     try:
+        from playwright.async_api import Error as PlaywrightError
         from playwright.async_api import async_playwright
     except ImportError:
         await _run(None)
         return
 
     async with async_playwright() as pw:
-        exe = pw.chromium.executable_path
-        if not (exe and Path(exe).exists()):
-            if warning_callback:
-                warning_callback(
-                    "Chromium not installed — run: playwright install chromium."
-                    " Falling back to urllib."
-                )
-            await _run(None)
-            return
+        # channel="chrome" drives the system-installed Google Chrome instead
+        # of Playwright's bundled Chromium. The `chunkhound[browser]` extra
+        # only installs the Playwright Python package; users must also have
+        # Google Chrome installed system-wide — otherwise launch() fails and
+        # we fall through to the urllib path below.
+        #
         # New headless mode is required for the PDF path: legacy --headless
         # hands PDFs to an internal viewer and never exposes the response to
         # _fetch_page. --headless=new keeps the navigation visible so we can
         # branch on content-type at commit time.
-        browser = await pw.chromium.launch(
-            args=["--headless=new"],
-            ignore_default_args=["--headless"],
-        )
+        try:
+            browser = await pw.chromium.launch(
+                channel="chrome",
+                args=["--headless=new"],
+                ignore_default_args=["--headless"],
+            )
+        except PlaywrightError as e:
+            if warning_callback:
+                warning_callback(
+                    f"Browser launch failed: {e}. Falling back to urllib."
+                    " (If Google Chrome is not installed, install it to"
+                    " enable rich page fetches.)"
+                )
+            await _run(None)
+            return
         try:
             context = await browser.new_context()
             try:

--- a/chunkhound/utils/websearch_core.py
+++ b/chunkhound/utils/websearch_core.py
@@ -174,20 +174,39 @@ def _html_to_markdown(html_text: str) -> str:
     ).convert(html_text)
 
 
-def _fetch_url(url: str) -> tuple[str, str | bytes]:
+def _normalize_ct(raw: str | None) -> str:
+    """Parse the bare MIME type out of a Content-Type header.
+
+    Returns ``"text/html"`` when the header is missing. ``urllib``'s
+    ``get_content_type()`` synthesizes ``"text/plain"`` for header-less
+    responses, which would reject real HTML served by misconfigured
+    servers; defaulting to ``text/html`` here matches the browser path,
+    which has always rendered header-less responses as HTML.
+    """
+    if not raw:
+        return "text/html"
+    return raw.split(";", 1)[0].strip().lower()
+
+
+def _decode_pdf_or_fallback_html(body: bytes, charset: str) -> tuple[str, str | bytes]:
+    """Handle a body whose Content-Type claimed application/pdf.
+
+    Some endpoints (paywalls, error pages, auth walls) return HTML under an
+    application/pdf Content-Type. Trust the magic bytes, not the header.
+    """
+    if body.startswith(b"%PDF-"):
+        return ".pdf", body
+    return ".md", _html_to_markdown(body.decode(charset, errors="replace"))
+
+
+def _fetch_url(url: str) -> tuple[str, bytes, str]:
     req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
     with urllib.request.urlopen(req, timeout=30) as resp:
-        ct = resp.headers.get_content_type() or ""
-        raw = resp.read()
-        if ct == "application/pdf":
-            return ".pdf", raw
-        if ct == "text/html" or not ct:
-            charset = resp.headers.get_content_charset() or "utf-8"
-            return ".md", _html_to_markdown(raw.decode(charset, errors="replace"))
-        raise ValueError(f"Unsupported content-type: {ct!r}")
+        ct = _normalize_ct(resp.headers.get("Content-Type"))
+        return ct, resp.read(), resp.headers.get_content_charset() or "utf-8"
 
 
-async def _fetch_page(context: BrowserContext, url: str) -> tuple[str, str | bytes]:
+async def _fetch_page(context: BrowserContext, url: str) -> tuple[str, bytes, str]:
     """Fetch a single URL.
 
     HTML is fetched through Chrome's network stack. PDFs go through
@@ -203,7 +222,7 @@ async def _fetch_page(context: BrowserContext, url: str) -> tuple[str, str | byt
         if response is None:
             raise ValueError("Navigation failed: no response")
 
-        ct = response.headers.get("content-type", "").split(";")[0].strip()
+        ct = _normalize_ct(response.headers.get("content-type"))
 
         if ct == "application/pdf":
             await page.close()
@@ -211,20 +230,15 @@ async def _fetch_page(context: BrowserContext, url: str) -> tuple[str, str | byt
             try:
                 if not direct.ok:
                     raise ValueError(f"PDF fetch failed: HTTP {direct.status}")
-                direct_ct = direct.headers.get("content-type", "").split(";")[0].strip()
-                if direct_ct != "application/pdf":
-                    raise ValueError(
-                        f"Expected application/pdf, got {direct_ct!r}"
-                    )
-                return ".pdf", await direct.body()
+                return "application/pdf", await direct.body(), "utf-8"
             finally:
                 await direct.dispose()
 
-        if ct and ct != "text/html":
+        if ct != "text/html":
             raise ValueError(f"Unsupported content-type: {ct!r}")
 
         await page.wait_for_load_state("load")
-        return ".md", _html_to_markdown(await page.content())
+        return ct, (await page.content()).encode("utf-8"), "utf-8"
     finally:
         if not page.is_closed():
             await page.close()
@@ -244,9 +258,22 @@ async def _fetch_one(
             progress_callback(f"Fetching {url}...")
         try:
             if context is not None:
-                ext, content = await _fetch_page(context, url)
+                ct, body, charset = await _fetch_page(context, url)
             else:
-                ext, content = await asyncio.to_thread(_fetch_url, url)
+                ct, body, charset = await asyncio.to_thread(_fetch_url, url)
+            if ct == "application/pdf":
+                ext, content = _decode_pdf_or_fallback_html(body, charset)
+            elif ct == "text/html":
+                ext, content = ".md", _html_to_markdown(
+                    body.decode(charset, errors="replace")
+                )
+            else:
+                raise ValueError(f"Unsupported content-type: {ct!r}")
+            # Auth walls and error pages often render to whitespace-only
+            # markdown; surface that as a fetch failure rather than writing
+            # an empty file that consumes a result slot.
+            if not content.strip():
+                raise ValueError(f"{ct!r} body rendered empty ({len(body)} bytes)")
             path = tmpdir / (_url_to_filename(url) + ext)
             if isinstance(content, bytes):
                 path.write_bytes(content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ dependencies = [
 
 [project.optional-dependencies]
 browser = [
-    "playwright>=1.48.0",
+    "playwright>=1.49.0",
 ]
 dev = [
     "pytest>=7.4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -509,7 +509,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=21.0" },
     { name = "pandas", specifier = ">=2.3.0" },
     { name = "pathspec", specifier = ">=0.12.1" },
-    { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.48.0" },
+    { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.49.0" },
     { name = "psutil", specifier = ">=5.8.0" },
     { name = "pydantic", specifier = ">=2.11.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },


### PR DESCRIPTION
**Note**: This PR was generated by an AI agent. If you'd like to talk with other humans, drop by our [Discord](https://discord.gg/BAepHEXXnX)!

---

# Websearch: system Chrome + more robust PDF handling

This PR rework the websearch fetch path in `chunkhound/utils/websearch_core.py` along three axes. First, the browser path now drives the **system-installed Google Chrome** via Playwright's `channel="chrome"` instead of the bundled Chromium. The `chunkhound[browser]` extra has always installed only the Python bindings, leaving users to run `playwright install chromium` separately; piggy-backing on the OS Chrome that most developers already have removes that step (and the ~300 MB bundled binary), with a clean fallback to urllib when Chrome isn't present.

Second, PDF detection is dramatically simpler. The previous code intercepted every navigation through a `page.route` handler, sniffed the Content-Type, captured the PDF body inline, and frequently had to **re-fetch the URL out-of-band** when Chromium consumed the response before the handler saw the full body. The new path uses `page.goto(..., wait_until="commit")` so we can inspect the real response headers before Chrome decides whether to hand the bytes to its PDF viewer; on `application/pdf` we close the page and pull bytes via `context.request.get(url)`. This required `--headless=new`, since legacy headless silently routes PDFs to an internal viewer — hence the playwright `>=1.49.0` bump.

Third, content-type is no longer blindly trusted. Some endpoints (paywalls, auth walls, error pages) return HTML under an `application/pdf` Content-Type; we now verify the `%PDF-` magic bytes and fall back to HTML→markdown when they're missing. We also fail fetches whose rendered markdown is whitespace-only, which previously wrote zero-byte files into the result set and burned a result slot. No public API changes; the only breaking change is the playwright minimum version.

[AGENT_REVIEW.md](https://github.com/user-attachments/files/28307075/AGENT_REVIEW.md)