### PR TITLE
fix(embeddings): respect retry-after header and use exponential backoff on rate limits

### DIFF
--- a/chunkhound/providers/embeddings/openai_provider.py
+++ b/chunkhound/providers/embeddings/openai_provider.py
@@ -3,6 +3,8 @@
 import asyncio
 import heapq
 import math
+import random
+import re
 from collections.abc import AsyncIterator
 from typing import Any, cast
 
@@ -749,11 +751,41 @@ class OpenAIEmbeddingProvider:
                     and hasattr(openai, "RateLimitError")
                     and isinstance(rate_error, openai.RateLimitError)
                 ):
-                    logger.warning(
-                        f"Rate limit exceeded, retrying in {self._retry_delay * (attempt + 1)} seconds"
-                    )
+                    retry_after: float | None = None
+                    if (
+                        hasattr(rate_error, "response")
+                        and rate_error.response is not None
+                    ):
+                        header_val = rate_error.response.headers.get(
+                            "retry-after"
+                        ) or rate_error.response.headers.get(
+                            "x-ratelimit-reset-requests"
+                        )
+                        if header_val is not None:
+                            try:
+                                retry_after = float(header_val)
+                            except (ValueError, TypeError):
+                                pass
+                    if retry_after is None:
+                        match = re.search(
+                            r"try again in (\d+(?:\.\d+)?)\s*seconds?",
+                            str(rate_error),
+                            re.IGNORECASE,
+                        )
+                        if match:
+                            retry_after = float(match.group(1))
+                    if retry_after is None:
+                        retry_after = min(
+                            self._retry_delay * (2**attempt), 120.0
+                        )
+                    jitter = random.uniform(0, min(retry_after * 0.1, 5.0))
+                    total_delay = retry_after + jitter
                     if attempt < self._retry_attempts - 1:
-                        await asyncio.sleep(self._retry_delay * (attempt + 1))
+                        logger.warning(
+                            f"Rate limit exceeded, retrying in {total_delay:.1f}s"
+                            f" (attempt {attempt + 1}/{self._retry_attempts})"
+                        )
+                        await asyncio.sleep(total_delay)
                         continue
                     else:
                         raise

--- a/chunkhound/providers/embeddings/openai_provider.py
+++ b/chunkhound/providers/embeddings/openai_provider.py
@@ -763,17 +763,17 @@ class OpenAIEmbeddingProvider:
                         )
                         if header_val is not None:
                             try:
-                                retry_after = float(header_val)
+                                retry_after = min(float(header_val), 120.0)
                             except (ValueError, TypeError):
                                 pass
                     if retry_after is None:
-                        match = re.search(
+                        m = re.search(
                             r"try again in (\d+(?:\.\d+)?)\s*seconds?",
                             str(rate_error),
                             re.IGNORECASE,
                         )
-                        if match:
-                            retry_after = float(match.group(1))
+                        if m:
+                            retry_after = min(float(m.group(1)), 120.0)
                     if retry_after is None:
                         retry_after = min(
                             self._retry_delay * (2**attempt), 120.0

--- a/tests/unit/test_openai_provider_rate_limit.py
+++ b/tests/unit/test_openai_provider_rate_limit.py
@@ -1,0 +1,366 @@
+"""Tests for OpenAI embedding provider rate-limit retry logic.
+
+Covers the three delay-resolution paths in _embed_batch_internal:
+  1. retry-after / x-ratelimit-reset-requests response header
+  2. "try again in X seconds" body parse
+  3. exponential backoff fallback (capped at 120 s)
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Minimal fake exception hierarchy
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal stand-in for an HTTP response with a headers dict."""
+
+    def __init__(self, headers: dict[str, str] | None = None):
+        self.headers = headers or {}
+
+
+class _FakeRateLimitError(Exception):
+    """Fake openai.RateLimitError — the provider matches on isinstance()."""
+
+    def __init__(self, message: str = "429", response: _FakeResponse | None = None):
+        super().__init__(message)
+        self.response = response
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _make_provider(retry_attempts: int = 3, retry_delay: float = 1.0):
+    """Return (provider, fake_openai_module, real_mod) with _ensure_client no-op'd."""
+    import chunkhound.providers.embeddings.openai_provider as mod
+    from chunkhound.providers.embeddings.openai_provider import OpenAIEmbeddingProvider
+
+    fake_openai = MagicMock()
+    fake_openai.RateLimitError = _FakeRateLimitError
+    fake_openai.BadRequestError = type("BadRequestError", (Exception,), {})
+    fake_openai.APITimeoutError = type("APITimeoutError", (Exception,), {})
+    fake_openai.APIConnectionError = type("APIConnectionError", (Exception,), {})
+
+    provider = OpenAIEmbeddingProvider.__new__(OpenAIEmbeddingProvider)
+    provider._retry_attempts = retry_attempts
+    provider._retry_delay = retry_delay
+    provider._client = None
+    provider._model = "text-embedding-3-small"
+    provider._base_url = None
+    provider._azure_endpoint = None
+    provider._azure_deployment = None
+    provider._timeout = 30
+    provider._usage_stats = {
+        "requests_made": 0,
+        "embeddings_generated": 0,
+        "tokens_used": 0,
+    }
+
+    async def _noop_ensure_client():
+        pass
+
+    provider._ensure_client = _noop_ensure_client
+    return provider, fake_openai, mod
+
+
+def _ok_response(embedding: list[float] | None = None):
+    result = MagicMock()
+    result.data = [MagicMock(index=0, embedding=embedding or [0.1, 0.2])]
+    result.usage = MagicMock(total_tokens=10)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Tests: header path
+# ---------------------------------------------------------------------------
+
+
+class TestRetryAfterHeader:
+    @pytest.mark.asyncio
+    async def test_retry_after_header_used_as_delay(self):
+        """retry-after header value drives the sleep duration."""
+        provider, fake_openai, mod = _make_provider(retry_attempts=2, retry_delay=1.0)
+
+        call_count = 0
+
+        async def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise _FakeRateLimitError(
+                    "429", response=_FakeResponse({"retry-after": "30"})
+                )
+            return _ok_response()
+
+        provider._client = MagicMock()
+        provider._client.embeddings.create = side_effect
+
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(secs):
+            sleep_calls.append(secs)
+
+        with patch.object(mod, "openai", fake_openai), patch.object(
+            asyncio, "sleep", fake_sleep
+        ):
+            result = await provider._embed_batch_internal(["hello"])
+
+        assert len(result) == 1
+        assert len(sleep_calls) == 1
+        assert sleep_calls[0] >= 30.0
+        assert sleep_calls[0] <= 35.0  # 30 + max jitter (10 %, capped at 5 s)
+
+    @pytest.mark.asyncio
+    async def test_x_ratelimit_reset_requests_header_used_as_fallback(self):
+        """x-ratelimit-reset-requests is used when retry-after is absent."""
+        provider, fake_openai, mod = _make_provider(retry_attempts=2, retry_delay=1.0)
+
+        call_count = 0
+
+        async def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise _FakeRateLimitError(
+                    "429",
+                    response=_FakeResponse({"x-ratelimit-reset-requests": "20"}),
+                )
+            return _ok_response()
+
+        provider._client = MagicMock()
+        provider._client.embeddings.create = side_effect
+
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(secs):
+            sleep_calls.append(secs)
+
+        with patch.object(mod, "openai", fake_openai), patch.object(
+            asyncio, "sleep", fake_sleep
+        ):
+            await provider._embed_batch_internal(["hi"])
+
+        assert sleep_calls[0] >= 20.0
+        assert sleep_calls[0] <= 25.0
+
+    @pytest.mark.asyncio
+    async def test_header_value_capped_at_120s(self):
+        """A server returning a huge retry-after is capped at 120 s."""
+        provider, fake_openai, mod = _make_provider(retry_attempts=2, retry_delay=1.0)
+
+        call_count = 0
+
+        async def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise _FakeRateLimitError(
+                    "429", response=_FakeResponse({"retry-after": "3600"})
+                )
+            return _ok_response()
+
+        provider._client = MagicMock()
+        provider._client.embeddings.create = side_effect
+
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(secs):
+            sleep_calls.append(secs)
+
+        with patch.object(mod, "openai", fake_openai), patch.object(
+            asyncio, "sleep", fake_sleep
+        ):
+            await provider._embed_batch_internal(["hi"])
+
+        assert sleep_calls[0] <= 125.0  # 120 cap + max 5 s jitter
+
+
+# ---------------------------------------------------------------------------
+# Tests: body-parse path
+# ---------------------------------------------------------------------------
+
+
+class TestRetryAfterBodyParse:
+    @pytest.mark.asyncio
+    async def test_body_parse_seconds_used_when_no_header(self):
+        """'try again in X seconds' in the error body drives the sleep duration."""
+        provider, fake_openai, mod = _make_provider(retry_attempts=2, retry_delay=1.0)
+
+        call_count = 0
+
+        async def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise _FakeRateLimitError(
+                    "Rate limit exceeded. Please try again in 35 seconds."
+                )
+            return _ok_response()
+
+        provider._client = MagicMock()
+        provider._client.embeddings.create = side_effect
+
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(secs):
+            sleep_calls.append(secs)
+
+        with patch.object(mod, "openai", fake_openai), patch.object(
+            asyncio, "sleep", fake_sleep
+        ):
+            await provider._embed_batch_internal(["hello"])
+
+        assert sleep_calls[0] >= 35.0
+        assert sleep_calls[0] <= 40.0
+
+    @pytest.mark.asyncio
+    async def test_body_parse_fractional_seconds(self):
+        """Fractional values like '1.5 seconds' are parsed correctly."""
+        provider, fake_openai, mod = _make_provider(retry_attempts=2, retry_delay=1.0)
+
+        call_count = 0
+
+        async def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise _FakeRateLimitError("try again in 1.5 seconds")
+            return _ok_response()
+
+        provider._client = MagicMock()
+        provider._client.embeddings.create = side_effect
+
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(secs):
+            sleep_calls.append(secs)
+
+        with patch.object(mod, "openai", fake_openai), patch.object(
+            asyncio, "sleep", fake_sleep
+        ):
+            await provider._embed_batch_internal(["x"])
+
+        assert sleep_calls[0] >= 1.5
+
+    @pytest.mark.asyncio
+    async def test_body_parse_value_capped_at_120s(self):
+        """Parsed body values above 120 s are capped."""
+        provider, fake_openai, mod = _make_provider(retry_attempts=2, retry_delay=1.0)
+
+        call_count = 0
+
+        async def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise _FakeRateLimitError("try again in 9999 seconds")
+            return _ok_response()
+
+        provider._client = MagicMock()
+        provider._client.embeddings.create = side_effect
+
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(secs):
+            sleep_calls.append(secs)
+
+        with patch.object(mod, "openai", fake_openai), patch.object(
+            asyncio, "sleep", fake_sleep
+        ):
+            await provider._embed_batch_internal(["x"])
+
+        assert sleep_calls[0] <= 125.0
+
+
+# ---------------------------------------------------------------------------
+# Tests: exponential backoff fallback
+# ---------------------------------------------------------------------------
+
+
+class TestExponentialBackoffFallback:
+    @pytest.mark.asyncio
+    async def test_exponential_backoff_on_plain_rate_limit(self):
+        """No header, no body hint → exponential backoff (retry_delay * 2^attempt)."""
+        provider, fake_openai, mod = _make_provider(retry_attempts=3, retry_delay=2.0)
+
+        call_count = 0
+        sleep_calls: list[float] = []
+
+        async def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise _FakeRateLimitError("429 no details")
+            return _ok_response()
+
+        provider._client = MagicMock()
+        provider._client.embeddings.create = side_effect
+
+        async def fake_sleep(secs):
+            sleep_calls.append(secs)
+
+        with patch.object(mod, "openai", fake_openai), patch.object(
+            asyncio, "sleep", fake_sleep
+        ):
+            await provider._embed_batch_internal(["hello"])
+
+        # attempt 0: 2 * 2^0 = 2 s; attempt 1: 2 * 2^1 = 4 s
+        assert len(sleep_calls) == 2
+        assert sleep_calls[0] >= 2.0
+        assert sleep_calls[1] >= 4.0
+
+    @pytest.mark.asyncio
+    async def test_exponential_backoff_capped_at_120s(self):
+        """Exponential backoff never exceeds 120 s + jitter regardless of retry_delay."""
+        provider, fake_openai, mod = _make_provider(retry_attempts=2, retry_delay=200.0)
+
+        call_count = 0
+
+        async def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise _FakeRateLimitError("429 no details")
+            return _ok_response()
+
+        provider._client = MagicMock()
+        provider._client.embeddings.create = side_effect
+
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(secs):
+            sleep_calls.append(secs)
+
+        with patch.object(mod, "openai", fake_openai), patch.object(
+            asyncio, "sleep", fake_sleep
+        ):
+            await provider._embed_batch_internal(["x"])
+
+        assert sleep_calls[0] <= 125.0  # 120 cap + max 5 s jitter
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_raised_after_all_attempts_exhausted(self):
+        """RateLimitError propagates once all retry attempts are consumed."""
+        provider, fake_openai, mod = _make_provider(retry_attempts=2, retry_delay=0.0)
+
+        async def always_fail(*args, **kwargs):
+            raise _FakeRateLimitError("429")
+
+        provider._client = MagicMock()
+        provider._client.embeddings.create = always_fail
+
+        async def fake_sleep(_):
+            pass
+
+        with patch.object(mod, "openai", fake_openai), patch.object(
+            asyncio, "sleep", fake_sleep
+        ):
+            with pytest.raises(_FakeRateLimitError):
+                await provider._embed_batch_internal(["x"])


### PR DESCRIPTION
## Summary

- Parse `retry-after` / `x-ratelimit-reset-requests` response headers to determine the exact server-specified wait time before retrying a 429 rate limit error
- Fall back to parsing "try again in X seconds" from the error body, then to exponential backoff capped at 120s
- Add small random jitter (0–10% of delay, max 5s) to spread concurrent worker retries and avoid thundering-herd re-bursts
- Log the actual delay and attempt count so the warning is actionable rather than noisy

Fixes #298.

## Test plan

- [ ] Run a large index job against an endpoint with tight TPM/RPM limits and confirm retries now wait the server-specified interval instead of 1–3s
- [ ] Confirm log output shows `retrying in Xs (attempt N/M)` once per batch retry, not a spray of ERROR messages
- [ ] `uv run pytest tests/test_smoke.py -v -n auto` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)