### PR TITLE
fix(indexing): record skipped files in DB to prevent re-scanning on each run

### DIFF
--- a/chunkhound/interfaces/database_provider.py
+++ b/chunkhound/interfaces/database_provider.py
@@ -131,6 +131,20 @@ class DatabaseProvider(Protocol):
         """Update file record with new values (asynchronous)."""
         ...
 
+    async def record_skipped_file_async(
+        self,
+        path: str,
+        name: str,
+        extension: str,
+        size: int,
+        mtime: float,
+        language: str | None,
+        content_hash: str | None,
+        skip_reason: str,
+    ) -> None:
+        """Upsert a file record with skip_reason to prevent re-scanning (asynchronous)."""
+        ...
+
     # Chunk Operations
     def insert_chunk(self, chunk: Chunk) -> int:
         """Insert chunk record and return chunk ID."""

--- a/chunkhound/providers/database/duckdb_provider.py
+++ b/chunkhound/providers/database/duckdb_provider.py
@@ -2082,7 +2082,7 @@ class DuckDBProvider(SerialDatabaseProvider):
         if updates:
             # Clear skip_reason whenever a file is successfully re-indexed
             updates.append("skip_reason = NULL")
-            updates.append("updated_at = CURRENT_TIMESTAMP")
+            updates.append("updated_at = now()")  # CURRENT_TIMESTAMP parses as a column name in SET clauses; use now() instead
             query = f"UPDATE files SET {', '.join(updates)} WHERE id = ?"
             params.append(file_id)
             conn.execute(query, params)
@@ -2129,7 +2129,7 @@ class DuckDBProvider(SerialDatabaseProvider):
                 modified_time = EXCLUDED.modified_time,
                 content_hash = EXCLUDED.content_hash,
                 skip_reason = EXCLUDED.skip_reason,
-                updated_at = CURRENT_TIMESTAMP
+                updated_at = now()  -- CURRENT_TIMESTAMP parses as a column name in ON CONFLICT SET; use now() instead
             """,
             [path, name, extension, size, mtime, content_hash, language, skip_reason],
         )

--- a/chunkhound/providers/database/duckdb_provider.py
+++ b/chunkhound/providers/database/duckdb_provider.py
@@ -828,8 +828,9 @@ class DuckDBProvider(SerialDatabaseProvider):
                 )
             """)
 
-            # Ensure content_hash exists for existing DBs
+            # Ensure content_hash and skip_reason exist for existing DBs
             conn.execute("ALTER TABLE files ADD COLUMN IF NOT EXISTS content_hash TEXT")
+            conn.execute("ALTER TABLE files ADD COLUMN IF NOT EXISTS skip_reason TEXT")
 
             # Create sequence for chunks table
             conn.execute("CREATE SEQUENCE IF NOT EXISTS chunks_id_seq")
@@ -998,6 +999,9 @@ class DuckDBProvider(SerialDatabaseProvider):
 
             # Add metadata column if it doesn't exist (for databases without size/signature migration)
             conn.execute("ALTER TABLE chunks ADD COLUMN IF NOT EXISTS metadata TEXT")
+
+            # Add skip_reason column for tracking files skipped during parsing
+            conn.execute("ALTER TABLE files ADD COLUMN IF NOT EXISTS skip_reason TEXT")
 
             for (table_name,) in conn.execute(
                 """
@@ -2076,10 +2080,59 @@ class DuckDBProvider(SerialDatabaseProvider):
             params.append(content_hash)
 
         if updates:
+            # Clear skip_reason whenever a file is successfully re-indexed
+            updates.append("skip_reason = NULL")
             updates.append("updated_at = CURRENT_TIMESTAMP")
             query = f"UPDATE files SET {', '.join(updates)} WHERE id = ?"
             params.append(file_id)
             conn.execute(query, params)
+
+    def record_skipped_file(
+        self,
+        path: str,
+        name: str,
+        extension: str,
+        size: int,
+        mtime: float,
+        language: str | None,
+        content_hash: str | None,
+        skip_reason: str,
+    ) -> None:
+        """Upsert a file record with skip_reason to prevent re-scanning on next run."""
+        self._execute_in_db_thread_sync(
+            "record_skipped_file",
+            path, name, extension, size, mtime, language, content_hash, skip_reason,
+        )
+
+    def _executor_record_skipped_file(
+        self,
+        conn: Any,
+        state: dict[str, Any],
+        path: str,
+        name: str,
+        extension: str,
+        size: int,
+        mtime: float,
+        language: str | None,
+        content_hash: str | None,
+        skip_reason: str,
+    ) -> None:
+        """Executor method for record_skipped_file - runs in DB thread."""
+        track_operation(state)
+        conn.execute(
+            """
+            INSERT INTO files
+                (path, name, extension, size, modified_time, content_hash, language, skip_reason)
+            VALUES (?, ?, ?, ?, to_timestamp(?), ?, ?, ?)
+            ON CONFLICT (path) DO UPDATE SET
+                size = EXCLUDED.size,
+                modified_time = EXCLUDED.modified_time,
+                content_hash = EXCLUDED.content_hash,
+                skip_reason = EXCLUDED.skip_reason,
+                updated_at = NOW()
+            """,
+            [path, name, extension, size, mtime, content_hash, language, skip_reason],
+        )
 
     def delete_file_completely(self, file_path: str) -> bool:
         """Delete a file and all its chunks/embeddings completely - delegate to file repository."""

--- a/chunkhound/providers/database/duckdb_provider.py
+++ b/chunkhound/providers/database/duckdb_provider.py
@@ -2129,7 +2129,7 @@ class DuckDBProvider(SerialDatabaseProvider):
                 modified_time = EXCLUDED.modified_time,
                 content_hash = EXCLUDED.content_hash,
                 skip_reason = EXCLUDED.skip_reason,
-                updated_at = CURRENT_TIMESTAMP
+                updated_at = now()
             """,
             [path, name, extension, size, mtime, content_hash, language, skip_reason],
         )

--- a/chunkhound/providers/database/duckdb_provider.py
+++ b/chunkhound/providers/database/duckdb_provider.py
@@ -2129,7 +2129,7 @@ class DuckDBProvider(SerialDatabaseProvider):
                 modified_time = EXCLUDED.modified_time,
                 content_hash = EXCLUDED.content_hash,
                 skip_reason = EXCLUDED.skip_reason,
-                updated_at = now()
+                updated_at = CURRENT_TIMESTAMP
             """,
             [path, name, extension, size, mtime, content_hash, language, skip_reason],
         )

--- a/chunkhound/providers/database/duckdb_provider.py
+++ b/chunkhound/providers/database/duckdb_provider.py
@@ -2129,7 +2129,7 @@ class DuckDBProvider(SerialDatabaseProvider):
                 modified_time = EXCLUDED.modified_time,
                 content_hash = EXCLUDED.content_hash,
                 skip_reason = EXCLUDED.skip_reason,
-                updated_at = NOW()
+                updated_at = CURRENT_TIMESTAMP
             """,
             [path, name, extension, size, mtime, content_hash, language, skip_reason],
         )

--- a/chunkhound/providers/database/lancedb_provider.py
+++ b/chunkhound/providers/database/lancedb_provider.py
@@ -564,6 +564,10 @@ class LanceDBProvider(SerialDatabaseProvider):
             ),
             "encoding": "utf-8",
             "line_count": 0,
+            # Explicitly clear skip_reason so re-indexing a previously-skipped file
+            # doesn't leave stale skip_reason in the row (when_matched_update_all only
+            # updates columns present in the source dict).
+            "skip_reason": None,
         }
 
         # Use merge_insert for atomic upsert based on path
@@ -802,8 +806,16 @@ class LanceDBProvider(SerialDatabaseProvider):
         if not self._files_table:
             self._executor_create_schema(conn, state)
 
+        # Preserve existing id so chunks.file_id references are not orphaned
+        # when a previously-indexed file transitions to skipped.
+        try:
+            existing = self._files_table.search().where(f"path = '{path}'").limit(1).to_list()
+            file_id = existing[0]["id"] if existing else int(time.time() * 1000000)
+        except Exception:
+            file_id = int(time.time() * 1000000)
+
         file_data = {
-            "id": int(time.time() * 1000000),
+            "id": file_id,
             "path": path,
             "size": size,
             "modified_time": mtime,

--- a/chunkhound/providers/database/lancedb_provider.py
+++ b/chunkhound/providers/database/lancedb_provider.py
@@ -42,6 +42,7 @@ def get_files_schema() -> pa.Schema:
             ("language", pa.string()),
             ("encoding", pa.string()),
             ("line_count", pa.int64()),
+            ("skip_reason", pa.string()),
         ]
     )
 
@@ -354,6 +355,13 @@ class LanceDBProvider(SerialDatabaseProvider):
         # Create files table if it doesn't exist
         try:
             self._files_table = conn.open_table("files")
+            # Migrate: add skip_reason column to existing tables
+            if "skip_reason" not in self._files_table.schema.names:
+                try:
+                    self._files_table.add_columns({"skip_reason": "cast(null as varchar)"})
+                    logger.info("Migrated files table: added skip_reason column")
+                except Exception as e:
+                    logger.warning(f"Could not add skip_reason column to files table: {e}")
         except Exception:
             # Table doesn't exist, create it
             # Create table using PyArrow schema
@@ -748,6 +756,8 @@ class LanceDBProvider(SerialDatabaseProvider):
             if content_hash is not None:
                 updated_file["content_hash"] = content_hash
             updated_file["indexed_time"] = time.time()
+            # Clear skip_reason whenever a file is successfully re-indexed
+            updated_file["skip_reason"] = None
 
             # LanceDB doesn't support in-place updates, so we use merge_insert
             # This updates the record by matching on the 'id' field
@@ -757,6 +767,57 @@ class LanceDBProvider(SerialDatabaseProvider):
 
         except Exception as e:
             logger.error(f"Error updating file {file_id}: {e}")
+
+    def record_skipped_file(
+        self,
+        path: str,
+        name: str,
+        extension: str,
+        size: int,
+        mtime: float,
+        language: str | None,
+        content_hash: str | None,
+        skip_reason: str,
+    ) -> None:
+        """Upsert a file record with skip_reason to prevent re-scanning on next run."""
+        self._execute_in_db_thread_sync(
+            "record_skipped_file",
+            path, name, extension, size, mtime, language, content_hash, skip_reason,
+        )
+
+    def _executor_record_skipped_file(
+        self,
+        conn: Any,
+        state: dict[str, Any],
+        path: str,
+        name: str,
+        extension: str,
+        size: int,
+        mtime: float,
+        language: str | None,
+        content_hash: str | None,
+        skip_reason: str,
+    ) -> None:
+        """Executor method for record_skipped_file - runs in DB thread."""
+        if not self._files_table:
+            self._executor_create_schema(conn, state)
+
+        file_data = {
+            "id": int(time.time() * 1000000),
+            "path": path,
+            "size": size,
+            "modified_time": mtime,
+            "content_hash": content_hash or "",
+            "indexed_time": time.time(),
+            "language": language or "",
+            "encoding": "utf-8",
+            "line_count": 0,
+            "skip_reason": skip_reason,
+        }
+
+        self._files_table.merge_insert(
+            "path"
+        ).when_matched_update_all().when_not_matched_insert_all().execute([file_data])
 
     def delete_file_completely(self, file_path: str) -> bool:
         """Delete a file and all its chunks/embeddings completely."""

--- a/chunkhound/providers/database/serial_database_provider.py
+++ b/chunkhound/providers/database/serial_database_provider.py
@@ -353,6 +353,23 @@ class SerialDatabaseProvider(ABC):
         """Async variant of insert_file."""
         return cast(int, await self._execute_in_db_thread("insert_file", file))
 
+    async def record_skipped_file_async(
+        self,
+        path: str,
+        name: str,
+        extension: str,
+        size: int,
+        mtime: float,
+        language: str | None,
+        content_hash: str | None,
+        skip_reason: str,
+    ) -> None:
+        """Async variant of record_skipped_file."""
+        await self._execute_in_db_thread(
+            "record_skipped_file",
+            path, name, extension, size, mtime, language, content_hash, skip_reason,
+        )
+
     async def get_chunks_by_file_id_async(
         self, file_id: int, as_model: bool = False
     ) -> list[dict[str, Any] | Chunk]:

--- a/chunkhound/services/indexing_coordinator.py
+++ b/chunkhound/services/indexing_coordinator.py
@@ -529,6 +529,24 @@ class IndexingCoordinator(BaseService):
                 return {"status": "error", "chunks": 0, "error": result.error}
 
             if result.status == "skipped":
+                try:
+                    rel = self._get_relative_path(file_path).as_posix()
+                    p = Path(file_path)
+                    await self._db.record_skipped_file_async(
+                        rel,
+                        p.name,
+                        p.suffix,
+                        result.file_size,
+                        result.file_mtime,
+                        result.language.value if result.language else None,
+                        getattr(result, "content_hash", None),
+                        result.error or "skipped",
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to record skipped file in DB; next run will re-evaluate",
+                        exc_info=True,
+                    )
                 return {"status": "skipped", "reason": result.error, "chunks": 0}
 
             # Store the single file result

--- a/chunkhound/services/indexing_coordinator.py
+++ b/chunkhound/services/indexing_coordinator.py
@@ -1009,7 +1009,10 @@ class IndexingCoordinator(BaseService):
                         (str(result.file_path), result.error)
                     )
                 except Exception:
-                    pass  # best-effort; next run will re-evaluate
+                    logger.warning(
+                        "Failed to record skipped file in DB; next run will re-evaluate",
+                        exc_info=True,
+                    )
                 if file_task is not None and self.progress:
                     self.progress.advance(file_task, 1)
                     if cumulative_counters is not None:

--- a/chunkhound/services/indexing_coordinator.py
+++ b/chunkhound/services/indexing_coordinator.py
@@ -991,6 +991,25 @@ class IndexingCoordinator(BaseService):
                 # Track skip reason in stats for single-file case
                 if "skip_reason" not in stats:
                     stats["skip_reason"] = result.error
+                # Record in DB so change detection bypasses this file on next run
+                try:
+                    rel = self._get_relative_path(result.file_path).as_posix()
+                    p = Path(result.file_path)
+                    await self._db.record_skipped_file_async(
+                        rel,
+                        p.name,
+                        p.suffix,
+                        result.file_size,
+                        result.file_mtime,
+                        result.language.value if result.language else None,
+                        getattr(result, "content_hash", None),
+                        result.error or "skipped",
+                    )
+                    stats.setdefault("skipped_paths", []).append(
+                        (str(result.file_path), result.error)
+                    )
+                except Exception:
+                    pass  # best-effort; next run will re-evaluate
                 if file_task is not None and self.progress:
                     self.progress.advance(file_task, 1)
                     if cumulative_counters is not None:
@@ -1396,6 +1415,7 @@ class IndexingCoordinator(BaseService):
             agg_errors: list[dict[str, Any]] = []
             agg_skipped = 0
             agg_skipped_timeout: list[str] = []
+            agg_skipped_paths: list[tuple[str, str]] = []
 
             store_progress_counters = {
                 "chunks": 0,
@@ -1411,7 +1431,8 @@ class IndexingCoordinator(BaseService):
                     agg_total_chunks, \
                     agg_errors, \
                     agg_skipped, \
-                    agg_skipped_timeout
+                    agg_skipped_timeout, \
+                    agg_skipped_paths
                 # Update skip counters from parse results
                 for r in batch:
                     if r.status == "skipped":
@@ -1427,6 +1448,7 @@ class IndexingCoordinator(BaseService):
                 agg_total_files += stats_part.get("total_files", 0)
                 agg_total_chunks += stats_part.get("total_chunks", 0)
                 agg_errors.extend(stats_part.get("errors", []))
+                agg_skipped_paths.extend(stats_part.get("skipped_paths", []))
 
             # Parse files (streaming progress as batches complete and store concurrently)
             # Pass files_to_process directly - preserves hash for each file
@@ -1498,6 +1520,20 @@ class IndexingCoordinator(BaseService):
             skipped_due_to_timeout = agg_skipped_timeout
             # Split parse-time skips into timeout vs other (filtered/unsupported/config)
             skipped_filtered = max(0, skipped_total - len(skipped_due_to_timeout))
+
+            # Report newly-skipped files so users can add ignore patterns
+            if agg_skipped_paths:
+                reason_counts: dict[str, int] = {}
+                for _, reason in agg_skipped_paths:
+                    reason_counts[reason or "unknown"] = reason_counts.get(reason or "unknown", 0) + 1
+                breakdown = ", ".join(f"{r}: {c}" for r, c in sorted(reason_counts.items()))
+                logger.info(
+                    f"Skipped {len(agg_skipped_paths)} file(s) during parsing ({breakdown}). "
+                    f"These are now recorded in the DB and won't be re-scanned unless their content changes. "
+                    f"Add paths to .gitignore or set ignore patterns to exclude them permanently."
+                )
+                for path, reason in agg_skipped_paths:
+                    logger.debug(f"Skipped file: {path} (reason: {reason})")
 
             total_files = stats["total_files"]
             total_chunks = stats["total_chunks"]

--- a/tests/integration/test_lancedb_skip_parity.py
+++ b/tests/integration/test_lancedb_skip_parity.py
@@ -1,0 +1,159 @@
+"""LanceDB parity and state-transition tests for skipped-file recording (issue #297).
+
+Covers:
+- LanceDB records skipped files the same way DuckDB does
+- indexed → skipped: existing file id is preserved (chunks not orphaned)
+- skipped → indexed: skip_reason is cleared on re-index
+"""
+import asyncio
+from pathlib import Path
+
+import pytest
+
+
+# Use explicit extensions rather than **/* — LanceDB stores its database under
+# tmp_path/lancedb.lancedb/ which would otherwise be scanned as unknown-type files.
+_PY_PATTERNS = ["**/*.py"]
+_ALL_PATTERNS = ["**/*.py", "**/*.xyzunk"]
+
+
+@pytest.fixture
+def coordinator(lancedb_provider, tmp_path):
+    from chunkhound.core.types.common import Language
+    from chunkhound.parsers.parser_factory import create_parser_for_language
+    from chunkhound.services.indexing_coordinator import IndexingCoordinator
+
+    parser = create_parser_for_language(Language.PYTHON)
+    return IndexingCoordinator(
+        lancedb_provider, tmp_path, None, {Language.PYTHON: parser}
+    )
+
+
+# ---------------------------------------------------------------------------
+# LanceDB parity: basic skip recording
+# ---------------------------------------------------------------------------
+
+
+def test_lancedb_skipped_file_recorded(coordinator, tmp_path):
+    """Skipped file gets a DB record with skip_reason in LanceDB (parity with DuckDB)."""
+    (tmp_path / "data.xyzunk").write_text("binary\n")
+
+    asyncio.run(coordinator.process_directory(tmp_path, patterns=_ALL_PATTERNS))
+
+    rows = coordinator._db.execute_query(
+        "SELECT path, skip_reason FROM files WHERE skip_reason IS NOT NULL"
+    )
+    assert rows, "Skipped file should be recorded in the LanceDB files table"
+    assert rows[0]["skip_reason"] == "Unknown file type"
+
+
+def test_lancedb_skipped_file_not_reparsed_on_second_run(coordinator, tmp_path):
+    """Previously-skipped file must not be re-queued on second run (LanceDB parity)."""
+    (tmp_path / "main.py").write_text("def hello(): pass\n")
+    (tmp_path / "data.xyzunk").write_text("binary\n")
+
+    result1 = asyncio.run(coordinator.process_directory(tmp_path, patterns=_ALL_PATTERNS))
+    assert result1["status"] == "success"
+    assert result1.get("skipped_filtered", 0) >= 1
+
+    result2 = asyncio.run(coordinator.process_directory(tmp_path, patterns=_ALL_PATTERNS))
+    assert result2["status"] == "success"
+    assert result2.get("skipped_filtered", 0) == 0, (
+        "Skipped file must not be re-parsed on run 2 in LanceDB"
+    )
+    assert result2.get("skipped_unchanged", 0) >= 1
+
+
+# ---------------------------------------------------------------------------
+# State transition: indexed → skipped preserves file id
+# ---------------------------------------------------------------------------
+
+
+def test_indexed_to_skipped_preserves_file_id(lancedb_provider, tmp_path):
+    """record_skipped_file on a previously-indexed path must keep the same file id.
+
+    If the id changes, existing chunks.file_id rows become orphaned.
+    """
+    from chunkhound.core.types.common import Language
+    from chunkhound.parsers.parser_factory import create_parser_for_language
+    from chunkhound.services.indexing_coordinator import IndexingCoordinator
+
+    pyfile = tmp_path / "code.py"
+    pyfile.write_text("x = 1\n")
+
+    parser = create_parser_for_language(Language.PYTHON)
+    coord = IndexingCoordinator(
+        lancedb_provider, tmp_path, None, {Language.PYTHON: parser}
+    )
+    asyncio.run(coord.process_directory(tmp_path, patterns=_PY_PATTERNS))
+
+    rel = "code.py"
+    file_record_before = lancedb_provider.get_file_by_path(rel, as_model=False)
+    assert file_record_before is not None
+    original_id = file_record_before["id"]
+
+    chunks_before = lancedb_provider.get_chunks_by_file_id(original_id)
+    assert len(chunks_before) > 0, "Should have chunks after indexing"
+
+    # Simulate the file becoming unrecognised/binary — record it as skipped
+    lancedb_provider.record_skipped_file(
+        rel, pyfile.name, pyfile.suffix,
+        pyfile.stat().st_size, pyfile.stat().st_mtime,
+        None, None, "test skip reason",
+    )
+
+    file_record_after = lancedb_provider.get_file_by_path(rel, as_model=False)
+    assert file_record_after is not None
+    assert file_record_after["id"] == original_id, (
+        "File id must not change when transitioning indexed → skipped; "
+        "changing it orphans existing chunks"
+    )
+    assert file_record_after["skip_reason"] == "test skip reason"
+
+    chunks_after = lancedb_provider.get_chunks_by_file_id(original_id)
+    assert len(chunks_after) == len(chunks_before), (
+        "Chunks must not be orphaned after indexed → skipped transition"
+    )
+
+
+# ---------------------------------------------------------------------------
+# State transition: skipped → indexed clears skip_reason
+# ---------------------------------------------------------------------------
+
+
+def test_skipped_to_indexed_clears_skip_reason(lancedb_provider, tmp_path):
+    """Re-indexing a file whose skip record has a stale mtime must clear skip_reason.
+
+    We record a skip with mtime=0 (deliberately stale) so change-detection
+    re-queues the file on the next process_directory call.
+    """
+    from chunkhound.core.types.common import Language
+    from chunkhound.parsers.parser_factory import create_parser_for_language
+    from chunkhound.services.indexing_coordinator import IndexingCoordinator
+
+    pyfile = tmp_path / "code.py"
+    pyfile.write_text("x = 1\n")
+
+    rel = "code.py"
+    # Record skip with stale mtime=0 so change detection will re-queue the file
+    lancedb_provider.record_skipped_file(
+        rel, pyfile.name, pyfile.suffix,
+        pyfile.stat().st_size, 0.0,  # mtime=0 forces mtime mismatch
+        None, None, "old skip reason",
+    )
+
+    pre = lancedb_provider.get_file_by_path(rel, as_model=False)
+    assert pre is not None
+    assert pre["skip_reason"] == "old skip reason"
+
+    parser = create_parser_for_language(Language.PYTHON)
+    coord = IndexingCoordinator(
+        lancedb_provider, tmp_path, None, {Language.PYTHON: parser}
+    )
+    asyncio.run(coord.process_directory(tmp_path, patterns=_PY_PATTERNS))
+
+    post = lancedb_provider.get_file_by_path(rel, as_model=False)
+    assert post is not None
+    assert post["skip_reason"] is None, (
+        "skip_reason must be cleared after successful re-indexing"
+    )

--- a/tests/test_skipped_files_recorded.py
+++ b/tests/test_skipped_files_recorded.py
@@ -1,0 +1,85 @@
+"""Tests for issue #297: skipped files are recorded in DB to prevent re-scanning.
+
+Contract: a file that is skipped during parsing (binary, unknown type, etc.)
+must be persisted in the `files` table with a `skip_reason`.  On the next run,
+change-detection finds the record, sees the metadata is unchanged, and does NOT
+re-queue the file for parsing — eliminating the repeated re-scan penalty.
+"""
+import pytest
+from pathlib import Path
+
+from chunkhound.core.types.common import Language
+from chunkhound.parsers.parser_factory import create_parser_for_language
+from chunkhound.providers.database.duckdb_provider import DuckDBProvider
+from chunkhound.services.indexing_coordinator import IndexingCoordinator
+
+_PATTERNS = ["**/*"]  # discover all files; binary/unknown filtering happens in batch_processor
+
+
+@pytest.fixture
+def coordinator(tmp_path):
+    db = DuckDBProvider(":memory:", base_directory=tmp_path)
+    db.connect()
+    parser = create_parser_for_language(Language.PYTHON)
+    return IndexingCoordinator(db, tmp_path, None, {Language.PYTHON: parser})
+
+
+@pytest.mark.asyncio
+async def test_skipped_file_is_recorded_in_db(coordinator, tmp_path):
+    """A file skipped at parse time (unknown extension) gets a DB record with skip_reason."""
+    # .xyzunk has no registered parser → Language.UNKNOWN → skip with "Unknown file type"
+    unknown = tmp_path / "data.xyzunk"
+    unknown.write_text("some content\n")
+
+    await coordinator.process_directory(tmp_path, patterns=_PATTERNS)
+
+    rows = coordinator._db.execute_query(
+        "SELECT path, skip_reason FROM files WHERE skip_reason IS NOT NULL"
+    )
+    assert rows, "Skipped file should be recorded in the files table"
+    assert rows[0]["skip_reason"] == "Unknown file type"
+
+
+@pytest.mark.asyncio
+async def test_skipped_file_not_reparsed_on_second_run(coordinator, tmp_path):
+    """A previously-skipped file whose content hasn't changed must not be
+    re-queued for parsing on subsequent runs (fix for issue #297)."""
+    (tmp_path / "main.py").write_text("def hello(): pass\n")
+    unknown = tmp_path / "data.xyzunk"
+    unknown.write_text("some content\n")
+
+    # Run 1: unknown-extension file is parsed-and-skipped, then recorded in DB.
+    result1 = await coordinator.process_directory(tmp_path, patterns=_PATTERNS)
+    assert result1["status"] == "success"
+    assert result1.get("skipped_filtered", 0) >= 1, (
+        "Unknown-type file should be counted as a parse-time skip on run 1"
+    )
+
+    # Run 2: no file changes — binary should be caught by change detection,
+    # NOT re-sent to the parser.  Parse-time skip count must be 0.
+    result2 = await coordinator.process_directory(tmp_path, patterns=_PATTERNS)
+    assert result2["status"] == "success"
+    assert result2.get("skipped_filtered", 0) == 0, (
+        "Binary file must not be re-parsed on run 2 (should be skipped by "
+        "change detection, not by the parser)"
+    )
+    assert result2.get("skipped_unchanged", 0) >= 1, (
+        "Binary file should appear in skipped_unchanged (caught by change detection)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_successfully_indexed_file_has_no_skip_reason(coordinator, tmp_path):
+    """A file that is successfully indexed must not have skip_reason set."""
+    pyfile = tmp_path / "code.py"
+    pyfile.write_text("x = 1\n")
+
+    await coordinator.process_directory(tmp_path, patterns=_PATTERNS)
+
+    rows = coordinator._db.execute_query(
+        "SELECT path, skip_reason FROM files WHERE path LIKE '%code.py'"
+    )
+    assert rows, "Indexed file should have a DB record"
+    assert rows[0]["skip_reason"] is None, (
+        "Successfully indexed file must not have skip_reason"
+    )

--- a/tests/unit/test_json_filtering.py
+++ b/tests/unit/test_json_filtering.py
@@ -79,9 +79,10 @@ async def test_json_size_threshold_filtering(tmp_path, real_components):
     
     # Small file should be in DB
     assert small_file is not None, "Small JSON should be indexed"
-    
-    # Large file should NOT be in DB
-    assert large_file is None, "Large JSON should not be indexed"
+
+    # Large file should have a skip record in DB (content_hash=None) but not be chunked
+    assert large_file is not None, "Large JSON should have a skip record in DB"
+    assert large_file["content_hash"] is None, "Large JSON skip record must have no content_hash"
 
 
 @pytest.mark.asyncio
@@ -151,7 +152,8 @@ dependencies:
     large_file = db.get_file_by_path(str(large_yaml_path))
 
     assert small_file is not None, "Small YAML should be indexed"
-    assert large_file is None, "Large YAML should not be indexed"
+    assert large_file is not None, "Large YAML should have a skip record in DB"
+    assert large_file["content_hash"] is None, "Large YAML skip record must have no content_hash"
 
 
 @pytest.mark.asyncio
@@ -200,7 +202,8 @@ package-3 = "3.0.0"
     large_file = db.get_file_by_path(str(large_toml_path))
 
     assert small_file is not None, "Small TOML should be indexed"
-    assert large_file is None, "Large TOML should not be indexed"
+    assert large_file is not None, "Large TOML should have a skip record in DB"
+    assert large_file["content_hash"] is None, "Large TOML skip record must have no content_hash"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_json_filtering.py
+++ b/tests/unit/test_json_filtering.py
@@ -312,6 +312,9 @@ async def test_json_filtering_in_directory_processing(tmp_path, real_components)
     assert eslint_file is not None, "ESLint config should be indexed"
     assert python_file is not None, "Python file should be indexed"
     
-    # Should NOT be indexed
-    assert cache_file is None, "Large JSON should not be indexed (>20KB)"
+    # Large JSON: recorded in DB as a skip record (content_hash=None) but not chunked.
+    # This is intentional — skipped files are persisted to avoid re-scanning on each run.
+    assert cache_file is not None, "Large JSON should have a skip record in DB (>20KB)"
+    assert cache_file["content_hash"] is None, "Large JSON skip record must have no content_hash"
+    # Excluded-by-pattern files are never processed at all, so no DB record is created.
     assert lock_file is None, "Lock file should not be indexed (excluded pattern)"


### PR DESCRIPTION
## Summary

Fixes #297.

Files skipped during parsing (binary, unknown type, oversized config, parse timeout) were never written to the `files` table. On every subsequent run, change detection found them absent from the DB and re-queued them for full parsing — only to skip them again. For large codebases this wasted ~10 minutes per run.

- Add `skip_reason TEXT` column to the `files` table (with migration for existing DBs)
- Upsert a minimal file record with `skip_reason` whenever a file is skipped at parse time
- Change detection finds the record on the next run, compares size+mtime, and bypasses the parser entirely (`skipped_unchanged` counter)
- `skip_reason` is cleared to `NULL` when a file is subsequently indexed successfully
- Log a per-reason breakdown of newly-skipped files at the end of each run so users can add them to `.gitignore` or ignore patterns

## Test plan

- [ ] `test_skipped_file_is_recorded_in_db` — verifies `skip_reason` is written to DB after a parse-time skip
- [ ] `test_skipped_file_not_reparsed_on_second_run` — verifies run 2 has `skipped_filtered == 0` (parser never sees the file) and `skipped_unchanged >= 1` (change detection handles it)
- [ ] `test_successfully_indexed_file_has_no_skip_reason` — verifies successfully indexed files have `skip_reason = NULL`
- [ ] `uv run pytest tests/test_smoke.py -v -n auto` — smoke tests pass (3 pre-existing MCP stdio timeout failures unrelated to this change)
- [ ] `uv run pytest tests/ -v` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)