### PR TITLE
feat(mcp): progress notifications + protocol version 2025-06-18 (issue #309)

### DIFF
--- a/chunkhound/daemon/server.py
+++ b/chunkhound/daemon/server.py
@@ -21,7 +21,7 @@ from typing import Any
 
 from chunkhound.core.config.config import Config
 from chunkhound.mcp_server.base import MCPServerBase
-from chunkhound.mcp_server.common import handle_tool_call
+from chunkhound.mcp_server.common import MCP_PROTOCOL_VERSION, handle_tool_call
 from chunkhound.version import __version__
 
 from . import ipc
@@ -345,7 +345,7 @@ class ChunkHoundDaemon(MCPServerBase):
             "jsonrpc": "2.0",
             "id": msg.get("id"),
             "result": {
-                "protocolVersion": "2025-06-18",
+                "protocolVersion": MCP_PROTOCOL_VERSION,
                 "serverInfo": {
                     "name": "ChunkHound Code Search",
                     "version": __version__,
@@ -374,6 +374,8 @@ class ChunkHoundDaemon(MCPServerBase):
         tool_name: str = params.get("name", "")
         arguments: dict[str, Any] = params.get("arguments", {})
 
+        # progress_reporter intentionally omitted: the daemon transport uses its
+        # own raw JSON-RPC loop and does not yet implement progress token tracking.
         text_contents = await handle_tool_call(
             tool_name=tool_name,
             arguments=arguments,

--- a/chunkhound/daemon/server.py
+++ b/chunkhound/daemon/server.py
@@ -345,7 +345,7 @@ class ChunkHoundDaemon(MCPServerBase):
             "jsonrpc": "2.0",
             "id": msg.get("id"),
             "result": {
-                "protocolVersion": "2024-11-05",
+                "protocolVersion": "2025-06-18",
                 "serverInfo": {
                     "name": "ChunkHound Code Search",
                     "version": __version__,

--- a/chunkhound/mcp_server/common.py
+++ b/chunkhound/mcp_server/common.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:  # type-checkers only; avoid runtime hard dep
 
 from .tools import TOOL_REGISTRY, ProgressReporter, execute_tool
 
+MCP_PROTOCOL_VERSION = "2025-06-18"
+
 if TYPE_CHECKING:
     from chunkhound.database_factory import DatabaseServices
     from chunkhound.embeddings import EmbeddingManager

--- a/chunkhound/mcp_server/common.py
+++ b/chunkhound/mcp_server/common.py
@@ -8,15 +8,13 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Awaitable, Callable, Coroutine
+from collections.abc import Coroutine
 from typing import TYPE_CHECKING, Any, TypeVar
-
-ProgressReporter = Callable[[int, int | None, str], Awaitable[None]]
 
 if TYPE_CHECKING:  # type-checkers only; avoid runtime hard dep
     import mcp.types as types  # noqa: F401
 
-from .tools import TOOL_REGISTRY, execute_tool
+from .tools import TOOL_REGISTRY, ProgressReporter, execute_tool
 
 if TYPE_CHECKING:
     from chunkhound.database_factory import DatabaseServices

--- a/chunkhound/mcp_server/common.py
+++ b/chunkhound/mcp_server/common.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Coroutine
+from collections.abc import Awaitable, Callable, Coroutine
 from typing import TYPE_CHECKING, Any, TypeVar
+
+ProgressReporter = Callable[[int, int | None, str], Awaitable[None]]
 
 if TYPE_CHECKING:  # type-checkers only; avoid runtime hard dep
     import mcp.types as types  # noqa: F401
@@ -153,6 +155,7 @@ async def handle_tool_call(
     scan_progress: dict | None = None,
     llm_manager: LLMManager | None = None,
     config: Any = None,
+    progress_reporter: ProgressReporter | None = None,
 ) -> list[types.TextContent]:
     """Unified tool call handler for all MCP servers.
 
@@ -169,6 +172,7 @@ async def handle_tool_call(
         scan_progress: Optional scan progress from MCPServerBase
         llm_manager: Optional LLM manager for code_research
         config: Optional Config instance for research service factory
+        progress_reporter: Optional async callable for MCP progress notifications
 
     Returns:
         List containing a single TextContent with JSON-formatted response
@@ -211,6 +215,7 @@ async def handle_tool_call(
             scan_progress=scan_progress,
             llm_manager=llm_manager,
             config=config,
+            progress_reporter=progress_reporter,
         )
 
         # Format response based on result type

--- a/chunkhound/mcp_server/stdio.py
+++ b/chunkhound/mcp_server/stdio.py
@@ -160,6 +160,24 @@ class StdioMCPServer(MCPServerBase):
             tool_name: str, arguments: dict[str, Any]
         ) -> list[types.TextContent]:
             """Universal tool handler that routes to the unified handler."""
+            token = None
+            session = None
+            try:
+                ctx = self.server.request_context
+                token = ctx.meta.progressToken if ctx.meta else None
+                session = ctx.session
+            except LookupError:
+                pass
+
+            async def emit(progress: int, total: int | None, message: str) -> None:
+                if token is not None and session is not None:
+                    await session.send_progress_notification(
+                        progress_token=token,
+                        progress=progress,
+                        total=total,
+                        message=message,
+                    )
+
             return await handle_tool_call(
                 tool_name=tool_name,
                 arguments=arguments,
@@ -170,6 +188,7 @@ class StdioMCPServer(MCPServerBase):
                 scan_progress=self._scan_progress,
                 llm_manager=self.llm_manager,
                 config=self.config,
+                progress_reporter=emit,
             )
 
         self._register_list_tools()
@@ -274,7 +293,7 @@ class StdioMCPServer(MCPServerBase):
                     "jsonrpc": "2.0",
                     "id": request_id,  # Match client's request ID per JSON-RPC spec
                     "result": {
-                        "protocolVersion": "2024-11-05",
+                        "protocolVersion": "2025-06-18",
                         "serverInfo": {
                             "name": "ChunkHound Code Search",
                             "version": __version__,

--- a/chunkhound/mcp_server/stdio.py
+++ b/chunkhound/mcp_server/stdio.py
@@ -48,7 +48,7 @@ from chunkhound.utils.windows_constants import IS_WINDOWS  # noqa: E402
 from chunkhound.version import __version__  # noqa: E402
 
 from .base import MCPServerBase  # noqa: E402
-from .common import handle_tool_call  # noqa: E402
+from .common import MCP_PROTOCOL_VERSION, handle_tool_call  # noqa: E402
 
 # CRITICAL: Disable ALL logging to prevent JSON-RPC corruption
 logging.disable(logging.CRITICAL)
@@ -171,12 +171,15 @@ class StdioMCPServer(MCPServerBase):
 
             async def emit(progress: int, total: int | None, message: str) -> None:
                 if token is not None and session is not None:
-                    await session.send_progress_notification(
-                        progress_token=token,
-                        progress=progress,
-                        total=total,
-                        message=message,
-                    )
+                    try:
+                        await session.send_progress_notification(
+                            progress_token=token,
+                            progress=progress,
+                            total=total,
+                            message=message,
+                        )
+                    except Exception:
+                        pass  # session closed mid-call; progress is best-effort
 
             return await handle_tool_call(
                 tool_name=tool_name,
@@ -188,7 +191,9 @@ class StdioMCPServer(MCPServerBase):
                 scan_progress=self._scan_progress,
                 llm_manager=self.llm_manager,
                 config=self.config,
-                progress_reporter=emit,
+                progress_reporter=(
+                    emit if token is not None and session is not None else None
+                ),
             )
 
         self._register_list_tools()
@@ -293,7 +298,7 @@ class StdioMCPServer(MCPServerBase):
                     "jsonrpc": "2.0",
                     "id": request_id,  # Match client's request ID per JSON-RPC spec
                     "result": {
-                        "protocolVersion": "2025-06-18",
+                        "protocolVersion": MCP_PROTOCOL_VERSION,
                         "serverInfo": {
                             "name": "ChunkHound Code Search",
                             "version": __version__,

--- a/chunkhound/mcp_server/tools.py
+++ b/chunkhound/mcp_server/tools.py
@@ -15,7 +15,7 @@ import shutil
 import tempfile
 import types
 import urllib.error
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, TypedDict, Union, cast, get_args, get_origin
@@ -60,6 +60,15 @@ class Tool:
 
 # Tool registry - populated by @register_tool decorator
 TOOL_REGISTRY: dict[str, Tool] = {}
+
+ProgressReporter = Callable[[int, int | None, str], Awaitable[None]]
+
+
+async def _emit(
+    reporter: ProgressReporter | None, progress: int, total: int | None, message: str
+) -> None:
+    if reporter is not None:
+        await reporter(progress, total, message)
 
 
 def _python_type_to_json_schema_type(type_hint: Any) -> dict[str, Any]:
@@ -469,6 +478,7 @@ async def search_impl(
     path: str | None = None,
     page_size: int = 10,
     offset: int = 0,
+    progress_reporter: ProgressReporter | None = None,
 ) -> SearchResponse:
     """Unified search dispatching to regex or semantic based on type.
 
@@ -514,7 +524,7 @@ async def search_impl(
         except ValueError:
             raise ValueError("No default embedding provider configured.")
 
-        # Perform semantic search
+        await _emit(progress_reporter, 1, 2, "Embedding query…")
         results, pagination = await services.search_service.search_semantic(
             query=query,
             page_size=page_size,
@@ -524,7 +534,7 @@ async def search_impl(
             path_filter=path,
         )
     else:  # regex
-        # Perform regex search
+        await _emit(progress_reporter, 1, 2, "Searching index…")
         results, pagination = await services.search_service.search_regex_async(
             pattern=query,
             page_size=page_size,
@@ -532,6 +542,7 @@ async def search_impl(
             path_filter=path,
         )
 
+    await _emit(progress_reporter, 2, 2, "Formatting results…")
     # Convert file paths to native platform format
     native_results = _convert_paths_to_native(results)
 
@@ -567,6 +578,7 @@ async def deep_research_impl(
     progress: Any = None,
     path: str | None = None,
     config: Config | None = None,
+    progress_reporter: ProgressReporter | None = None,
 ) -> dict[str, Any]:
     """Core deep research implementation.
 
@@ -613,8 +625,7 @@ async def deep_research_impl(
     if config is None:
         config = Config.from_environment()
 
-    # Create code research service using factory (v1 or v2 based on config)
-    # This ensures followup suggestions automatically update if tool is renamed
+    await _emit(progress_reporter, 1, 2, "Setting up research service…")
     research_service = ResearchServiceFactory.create(
         config=config,
         db_services=services,
@@ -625,6 +636,7 @@ async def deep_research_impl(
         path_filter=path,
     )
 
+    await _emit(progress_reporter, 2, 2, "Running analysis (retrieval + LLM reranking)…")
     return await research_service.deep_research(query)
 
 
@@ -642,6 +654,7 @@ async def websearch_impl(
     query: str,
     limit: int = 30,
     path_filter: str | None = None,
+    progress_reporter: ProgressReporter | None = None,
 ) -> str:
     """Search the web, fetch results, and run deep research over them.
 
@@ -676,6 +689,7 @@ async def websearch_impl(
 
     limit = clamp_limit(limit)
 
+    await _emit(progress_reporter, 1, 3, "Searching web…")
     try:
         results = await asyncio.to_thread(search, query, limit, None)
     except urllib.error.URLError as e:
@@ -688,6 +702,7 @@ async def websearch_impl(
     tmpdir = Path(tempfile.mkdtemp(prefix="chunkhound_websearch_mcp_"))
     proc: asyncio.subprocess.Process | None = None
     try:
+        await _emit(progress_reporter, 2, 3, "Fetching pages…")
         await fetch_and_save(
             [url for _, url, _ in results],
             tmpdir,
@@ -696,6 +711,7 @@ async def websearch_impl(
             mapping=mapping,
         )
 
+        await _emit(progress_reporter, 3, 3, "Researching results…")
         cmd = build_quickresearch_argv_core(query, tmpdir, path_filter, config)
         # Scrub CHUNKHOUND_MCP_MODE so the child's RichOutputFormatter.error()
         # is not silenced — we rely on its stderr output to populate the
@@ -752,6 +768,7 @@ async def execute_tool(
     scan_progress: dict | None = None,
     llm_manager: Any = None,
     config: Config | None = None,
+    progress_reporter: ProgressReporter | None = None,
 ) -> dict[str, Any] | str:
     """Execute a tool from the registry with proper argument handling.
 
@@ -795,6 +812,8 @@ async def execute_tool(
         elif param_name == "progress":
             # Progress parameter for terminal UI (None for MCP mode)
             kwargs["progress"] = None
+        elif param_name == "progress_reporter":
+            kwargs["progress_reporter"] = progress_reporter
         elif param_name in arguments:
             # Tool-specific parameter from request
             kwargs[param_name] = arguments[param_name]

--- a/chunkhound/mcp_server/tools.py
+++ b/chunkhound/mcp_server/tools.py
@@ -8,7 +8,6 @@ The registry pattern ensures consistent tool metadata and behavior.
 
 import asyncio
 import inspect
-import json
 import os
 import re
 import shutil
@@ -67,6 +66,7 @@ ProgressReporter = Callable[[int, int | None, str], Awaitable[None]]
 async def _emit(
     reporter: ProgressReporter | None, progress: int, total: int | None, message: str
 ) -> None:
+    """Call reporter if set; no-op otherwise."""
     if reporter is not None:
         await reporter(progress, total, message)
 

--- a/chunkhound/mcp_server/tools.py
+++ b/chunkhound/mcp_server/tools.py
@@ -193,6 +193,7 @@ def _generate_json_schema_from_signature(func: Callable) -> dict[str, Any]:
             "llm_manager",
             "scan_progress",
             "progress",
+            "progress_reporter",
             "config",
         ):
             continue

--- a/tests/test_mcp_progress.py
+++ b/tests/test_mcp_progress.py
@@ -7,13 +7,17 @@ present, and stay silent when it is absent.
 from __future__ import annotations
 
 import asyncio
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from chunkhound.mcp_server.tools import _emit, execute_tool
-
+from chunkhound.mcp_server.common import MCPError, handle_tool_call
+from chunkhound.mcp_server.tools import (
+    _emit,
+    deep_research_impl,
+    execute_tool,
+    websearch_impl,
+)
 
 # ---------------------------------------------------------------------------
 # _emit helper
@@ -22,7 +26,8 @@ from chunkhound.mcp_server.tools import _emit, execute_tool
 
 @pytest.mark.asyncio
 async def test_emit_calls_reporter() -> None:
-    calls: list[tuple] = []
+    """_emit invokes the reporter with the supplied arguments."""
+    calls: list[tuple[int, int | None, str]] = []
 
     async def reporter(progress: int, total: int | None, message: str) -> None:
         calls.append((progress, total, message))
@@ -33,7 +38,7 @@ async def test_emit_calls_reporter() -> None:
 
 @pytest.mark.asyncio
 async def test_emit_no_op_when_none() -> None:
-    # Must not raise even with None reporter
+    """_emit is a no-op and does not raise when reporter is None."""
     await _emit(None, 1, 3, "Hello")
 
 
@@ -45,7 +50,7 @@ async def test_emit_no_op_when_none() -> None:
 @pytest.mark.asyncio
 async def test_search_regex_emits_progress() -> None:
     """Regex search emits 2 monotonically-increasing progress steps."""
-    calls: list[tuple] = []
+    calls: list[tuple[int, int | None, str]] = []
 
     async def reporter(progress: int, total: int | None, message: str) -> None:
         calls.append((progress, total, message))
@@ -65,7 +70,10 @@ async def test_search_regex_emits_progress() -> None:
 
     assert len(calls) == 2
     progresses = [c[0] for c in calls]
-    assert progresses == sorted(progresses), "progress values must be monotonically increasing"
+    assert progresses == sorted(progresses), (
+        "progress values must be monotonically increasing"
+    )
+    assert all(c[1] == 2 for c in calls)
     assert calls[0][2] == "Searching index…"
     assert calls[1][2] == "Formatting results…"
 
@@ -78,7 +86,6 @@ async def test_search_emits_no_progress_without_token() -> None:
         return_value=([], {"total": 0, "offset": 0, "has_more": False})
     )
 
-    # Should complete without error and without calling any reporter
     result = await execute_tool(
         tool_name="search",
         services=mock_services,
@@ -92,7 +99,7 @@ async def test_search_emits_no_progress_without_token() -> None:
 @pytest.mark.asyncio
 async def test_search_semantic_emits_progress() -> None:
     """Semantic search emits 2 progress steps including 'Embedding query…'."""
-    calls: list[tuple] = []
+    calls: list[tuple[int, int | None, str]] = []
 
     async def reporter(progress: int, total: int | None, message: str) -> None:
         calls.append((progress, total, message))
@@ -120,8 +127,213 @@ async def test_search_semantic_emits_progress() -> None:
 
     progresses = [c[0] for c in calls]
     assert progresses == sorted(progresses)
+    assert all(c[1] == 2 for c in calls)
     assert calls[0][2] == "Embedding query…"
     assert calls[-1][2] == "Formatting results…"
+
+
+# ---------------------------------------------------------------------------
+# websearch_impl progress emissions
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_proc(returncode: int = 0, stdout: bytes = b"ANSWER: test") -> MagicMock:
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, b""))
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock()
+    return proc
+
+
+@pytest.mark.asyncio
+async def test_websearch_emits_3_progress_steps() -> None:
+    """websearch emits (1,3), (2,3), (3,3) progress steps in order."""
+    calls: list[tuple[int, int | None, str]] = []
+
+    async def reporter(progress: int, total: int | None, message: str) -> None:
+        calls.append((progress, total, message))
+
+    mock_proc = _make_mock_proc()
+
+    with (
+        patch(
+            "chunkhound.utils.websearch_core.search",
+            return_value=[("title", "http://x.com", "snippet")],
+        ),
+        patch("chunkhound.utils.websearch_core.fetch_and_save", new=AsyncMock()),
+        patch(
+            "chunkhound.utils.websearch_core.clamp_limit", side_effect=lambda x: x
+        ),
+        patch(
+            "chunkhound.utils.websearch_core.build_quickresearch_argv_core",
+            return_value=["echo", "OK"],
+        ),
+        patch(
+            "chunkhound.utils.websearch_core.websearch_timeout", return_value=30.0
+        ),
+        patch(
+            "chunkhound.utils.websearch_postprocess.replace_paths_with_urls",
+            side_effect=lambda s, m: s,
+        ),
+        patch(
+            "asyncio.create_subprocess_exec", new=AsyncMock(return_value=mock_proc)
+        ),
+    ):
+        await websearch_impl(
+            embedding_manager=MagicMock(),
+            llm_manager=None,
+            config=MagicMock(),
+            query="test query",
+            limit=3,
+            progress_reporter=reporter,
+        )
+
+    assert len(calls) == 3
+    assert [c[0] for c in calls] == [1, 2, 3]
+    assert all(c[1] == 3 for c in calls)
+    assert calls[0][2] == "Searching web…"
+    assert calls[1][2] == "Fetching pages…"
+    assert calls[2][2] == "Researching results…"
+
+
+@pytest.mark.asyncio
+async def test_websearch_emits_no_progress_without_reporter() -> None:
+    """websearch completes without raising when progress_reporter is None."""
+    mock_proc = _make_mock_proc()
+
+    with (
+        patch(
+            "chunkhound.utils.websearch_core.search",
+            return_value=[("title", "http://x.com", "snippet")],
+        ),
+        patch("chunkhound.utils.websearch_core.fetch_and_save", new=AsyncMock()),
+        patch(
+            "chunkhound.utils.websearch_core.clamp_limit", side_effect=lambda x: x
+        ),
+        patch(
+            "chunkhound.utils.websearch_core.build_quickresearch_argv_core",
+            return_value=["echo", "OK"],
+        ),
+        patch(
+            "chunkhound.utils.websearch_core.websearch_timeout", return_value=30.0
+        ),
+        patch(
+            "chunkhound.utils.websearch_postprocess.replace_paths_with_urls",
+            side_effect=lambda s, m: s,
+        ),
+        patch(
+            "asyncio.create_subprocess_exec", new=AsyncMock(return_value=mock_proc)
+        ),
+    ):
+        result = await websearch_impl(
+            embedding_manager=MagicMock(),
+            llm_manager=None,
+            config=MagicMock(),
+            query="test query",
+            limit=3,
+            progress_reporter=None,
+        )
+
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_websearch_emits_step1_before_empty_results_error() -> None:
+    """Step 1 fires before the early-exit on empty search results."""
+    calls: list[tuple[int, int | None, str]] = []
+
+    async def reporter(progress: int, total: int | None, message: str) -> None:
+        calls.append((progress, total, message))
+
+    with (
+        patch("chunkhound.utils.websearch_core.search", return_value=[]),
+        patch(
+            "chunkhound.utils.websearch_core.clamp_limit", side_effect=lambda x: x
+        ),
+    ):
+        with pytest.raises(MCPError):
+            await websearch_impl(
+                embedding_manager=MagicMock(),
+                llm_manager=None,
+                config=MagicMock(),
+                query="no results query",
+                limit=3,
+                progress_reporter=reporter,
+            )
+
+    assert len(calls) == 1
+    assert calls[0] == (1, 3, "Searching web…")
+
+
+# ---------------------------------------------------------------------------
+# deep_research_impl progress emissions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_code_research_emits_progress() -> None:
+    """code_research emits 2 progress steps in order."""
+    calls: list[tuple[int, int | None, str]] = []
+
+    async def reporter(progress: int, total: int | None, message: str) -> None:
+        calls.append((progress, total, message))
+
+    mock_provider = MagicMock()
+    mock_provider.supports_reranking.return_value = True
+
+    mock_embedding_manager = MagicMock()
+    mock_embedding_manager.get_provider.return_value = mock_provider
+
+    mock_research_service = MagicMock()
+    mock_research_service.deep_research = AsyncMock(
+        return_value={"answer": "test", "sources": []}
+    )
+
+    with patch("chunkhound.mcp_server.tools.ResearchServiceFactory") as mock_factory:
+        mock_factory.create.return_value = mock_research_service
+        await deep_research_impl(
+            services=MagicMock(),
+            embedding_manager=mock_embedding_manager,
+            llm_manager=MagicMock(),
+            config=MagicMock(),
+            query="how does auth work",
+            progress_reporter=reporter,
+        )
+
+    assert len(calls) == 2
+    assert [c[0] for c in calls] == [1, 2]
+    assert all(c[1] == 2 for c in calls)
+    assert calls[0][2] == "Setting up research service…"
+    assert calls[1][2] == "Running analysis (retrieval + LLM reranking)…"
+
+
+@pytest.mark.asyncio
+async def test_code_research_emits_no_progress_without_reporter() -> None:
+    """code_research completes without raising when progress_reporter is None."""
+    mock_provider = MagicMock()
+    mock_provider.supports_reranking.return_value = True
+
+    mock_embedding_manager = MagicMock()
+    mock_embedding_manager.get_provider.return_value = mock_provider
+
+    mock_research_service = MagicMock()
+    mock_research_service.deep_research = AsyncMock(
+        return_value={"answer": "test", "sources": []}
+    )
+
+    with patch("chunkhound.mcp_server.tools.ResearchServiceFactory") as mock_factory:
+        mock_factory.create.return_value = mock_research_service
+        result = await deep_research_impl(
+            services=MagicMock(),
+            embedding_manager=mock_embedding_manager,
+            llm_manager=MagicMock(),
+            config=MagicMock(),
+            query="how does auth work",
+            progress_reporter=None,
+        )
+
+    assert result is not None
 
 
 # ---------------------------------------------------------------------------
@@ -132,9 +344,7 @@ async def test_search_semantic_emits_progress() -> None:
 @pytest.mark.asyncio
 async def test_handle_tool_call_passes_reporter() -> None:
     """handle_tool_call forwards progress_reporter to execute_tool."""
-    from chunkhound.mcp_server.common import handle_tool_call
-
-    calls: list[tuple] = []
+    calls: list[tuple[int, int | None, str]] = []
 
     async def reporter(progress: int, total: int | None, message: str) -> None:
         calls.append((progress, total, message))

--- a/tests/test_mcp_progress.py
+++ b/tests/test_mcp_progress.py
@@ -1,0 +1,163 @@
+"""Tests for MCP progress notifications (issue #309).
+
+Verifies that tools emit progress notifications when a progressToken is
+present, and stay silent when it is absent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from chunkhound.mcp_server.tools import _emit, execute_tool
+
+
+# ---------------------------------------------------------------------------
+# _emit helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emit_calls_reporter() -> None:
+    calls: list[tuple] = []
+
+    async def reporter(progress: int, total: int | None, message: str) -> None:
+        calls.append((progress, total, message))
+
+    await _emit(reporter, 1, 3, "Hello")
+    assert calls == [(1, 3, "Hello")]
+
+
+@pytest.mark.asyncio
+async def test_emit_no_op_when_none() -> None:
+    # Must not raise even with None reporter
+    await _emit(None, 1, 3, "Hello")
+
+
+# ---------------------------------------------------------------------------
+# search_impl progress emissions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_regex_emits_progress() -> None:
+    """Regex search emits 2 monotonically-increasing progress steps."""
+    calls: list[tuple] = []
+
+    async def reporter(progress: int, total: int | None, message: str) -> None:
+        calls.append((progress, total, message))
+
+    mock_services = MagicMock()
+    mock_services.search_service.search_regex_async = AsyncMock(
+        return_value=([], {"total": 0, "offset": 0, "has_more": False})
+    )
+
+    await execute_tool(
+        tool_name="search",
+        services=mock_services,
+        embedding_manager=None,
+        arguments={"type": "regex", "query": "def foo"},
+        progress_reporter=reporter,
+    )
+
+    assert len(calls) == 2
+    progresses = [c[0] for c in calls]
+    assert progresses == sorted(progresses), "progress values must be monotonically increasing"
+    assert calls[0][2] == "Searching index…"
+    assert calls[1][2] == "Formatting results…"
+
+
+@pytest.mark.asyncio
+async def test_search_emits_no_progress_without_token() -> None:
+    """No notifications emitted when progress_reporter is None."""
+    mock_services = MagicMock()
+    mock_services.search_service.search_regex_async = AsyncMock(
+        return_value=([], {"total": 0, "offset": 0, "has_more": False})
+    )
+
+    # Should complete without error and without calling any reporter
+    result = await execute_tool(
+        tool_name="search",
+        services=mock_services,
+        embedding_manager=None,
+        arguments={"type": "regex", "query": "def foo"},
+        progress_reporter=None,
+    )
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_search_semantic_emits_progress() -> None:
+    """Semantic search emits 2 progress steps including 'Embedding query…'."""
+    calls: list[tuple] = []
+
+    async def reporter(progress: int, total: int | None, message: str) -> None:
+        calls.append((progress, total, message))
+
+    mock_provider = MagicMock()
+    mock_provider.name = "openai"
+    mock_provider.model = "text-embedding-3-small"
+
+    mock_embedding_manager = MagicMock()
+    mock_embedding_manager.list_providers.return_value = ["openai"]
+    mock_embedding_manager.get_provider.return_value = mock_provider
+
+    mock_services = MagicMock()
+    mock_services.search_service.search_semantic = AsyncMock(
+        return_value=([], {"total": 0, "offset": 0, "has_more": False})
+    )
+
+    await execute_tool(
+        tool_name="search",
+        services=mock_services,
+        embedding_manager=mock_embedding_manager,
+        arguments={"type": "semantic", "query": "authentication logic"},
+        progress_reporter=reporter,
+    )
+
+    progresses = [c[0] for c in calls]
+    assert progresses == sorted(progresses)
+    assert calls[0][2] == "Embedding query…"
+    assert calls[-1][2] == "Formatting results…"
+
+
+# ---------------------------------------------------------------------------
+# handle_tool_call wires progress_reporter through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_tool_call_passes_reporter() -> None:
+    """handle_tool_call forwards progress_reporter to execute_tool."""
+    from chunkhound.mcp_server.common import handle_tool_call
+
+    calls: list[tuple] = []
+
+    async def reporter(progress: int, total: int | None, message: str) -> None:
+        calls.append((progress, total, message))
+
+    init_event = asyncio.Event()
+    init_event.set()
+
+    mock_services = MagicMock()
+    mock_services.search_service.search_regex_async = AsyncMock(
+        return_value=([], {"total": 0, "offset": 0, "has_more": False})
+    )
+
+    with patch("mcp.types") as mock_types:
+        mock_types.TextContent = MagicMock(side_effect=lambda **kw: kw)
+        await handle_tool_call(
+            tool_name="search",
+            arguments={"type": "regex", "query": "hello"},
+            services=mock_services,
+            embedding_manager=None,
+            initialization_complete=init_event,
+            progress_reporter=reporter,
+        )
+
+    assert len(calls) >= 2, "Expected at least 2 progress notifications"
+    progresses = [c[0] for c in calls]
+    assert progresses == sorted(progresses)


### PR DESCRIPTION
## Summary

- Instruments `search`, `code_research`, and `websearch` tools to emit `notifications/progress` messages when the client supplies a `progressToken`, giving Claude Desktop and Cursor live feedback during long-running calls
- Adds a `ProgressReporter` type alias and null-safe `_emit` helper; wires the reporter from `server.request_context` through `handle_tool_call` → `execute_tool` → each tool implementation
- Bumps the fallback stdio protocol version string from `2024-11-05` → `2025-06-18` (normal SDK path already negotiates dynamically)

## Progress steps emitted per tool

| Tool | Steps |
|---|---|
| `search` (regex) | `"Searching index…"` → `"Formatting results…"` |
| `search` (semantic) | `"Embedding query…"` → `"Formatting results…"` |
| `code_research` | `"Setting up research service…"` → `"Running analysis (retrieval + LLM reranking)…"` |
| `websearch` | `"Searching web…"` → `"Fetching pages…"` → `"Researching results…"` |
| `daemon_status` | _(skipped — near-instant)_ |

Notifications are a no-op when the client omits `progressToken`.

## Test plan

- [ ] `tests/test_mcp_progress.py` — 6 new tests: `_emit` helper, regex/semantic search emissions, no-op without token, end-to-end wiring through `handle_tool_call`
- [ ] `uv run pytest tests/test_smoke.py -v -n auto` — all pre-existing smoke tests pass

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)