### PR TITLE
OpenCode CLI: process-group cleanup & orphan prevention

### DIFF
--- a/chunkhound/providers/llm/opencode_cli_provider.py
+++ b/chunkhound/providers/llm/opencode_cli_provider.py
@@ -423,7 +423,8 @@ class OpenCodeCLIProvider(BaseCLIProvider):
         """Terminate an opencode subprocess and its descendants."""
         if sys.platform == "win32":
             try:
-                subprocess.run(
+                await asyncio.to_thread(
+                    subprocess.run,
                     ["taskkill", "/T", "/PID", str(process.pid), "/F"],
                     check=False,
                     timeout=10,
@@ -439,7 +440,7 @@ class OpenCodeCLIProvider(BaseCLIProvider):
         process_group_id = pgid if pgid is not None else process.pid
         try:
             os.killpg(process_group_id, signal.SIGTERM)
-        except ProcessLookupError:
+        except (ProcessLookupError, PermissionError):
             pass
 
         try:
@@ -449,7 +450,7 @@ class OpenCodeCLIProvider(BaseCLIProvider):
 
         try:
             os.killpg(process_group_id, signal.SIGKILL)
-        except ProcessLookupError:
+        except (ProcessLookupError, PermissionError):
             pass
 
         try:
@@ -473,7 +474,7 @@ class OpenCodeCLIProvider(BaseCLIProvider):
         """
         cmd = self._build_cmd(model, use_json)
         process = None
-        process_pgid: int | None = None
+        captured_process_pid: int | None = None
         cleanup_required = False
         try:
             if sys.platform == "win32":
@@ -501,7 +502,7 @@ class OpenCodeCLIProvider(BaseCLIProvider):
                 )
             cleanup_required = True
             if sys.platform != "win32":
-                process_pgid = process.pid
+                captured_process_pid = process.pid
 
             stdout, stderr = await asyncio.wait_for(
                 process.communicate(input=message.encode("utf-8")),
@@ -600,7 +601,7 @@ class OpenCodeCLIProvider(BaseCLIProvider):
 
         finally:
             if cleanup_required and process is not None:
-                await self._kill_process_tree(process, pgid=process_pgid)
+                await self._kill_process_tree(process, pgid=captured_process_pid)
 
     async def _try_phase(
         self,

--- a/chunkhound/providers/llm/opencode_cli_provider.py
+++ b/chunkhound/providers/llm/opencode_cli_provider.py
@@ -476,15 +476,29 @@ class OpenCodeCLIProvider(BaseCLIProvider):
         process_pgid: int | None = None
         cleanup_required = False
         try:
-            process = await asyncio.create_subprocess_exec(
-                *cmd,
-                stdin=asyncio.subprocess.PIPE,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=os.environ.copy(),
-                cwd=tempfile.gettempdir(),
-                start_new_session=True,
-            )
+            if sys.platform == "win32":
+                create_new_process_group = getattr(
+                    subprocess, "CREATE_NEW_PROCESS_GROUP", 0
+                )
+                process = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    env=os.environ.copy(),
+                    cwd=tempfile.gettempdir(),
+                    creationflags=create_new_process_group,
+                )
+            else:
+                process = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    env=os.environ.copy(),
+                    cwd=tempfile.gettempdir(),
+                    start_new_session=True,
+                )
             cleanup_required = True
             if sys.platform != "win32":
                 process_pgid = process.pid

--- a/chunkhound/providers/llm/opencode_cli_provider.py
+++ b/chunkhound/providers/llm/opencode_cli_provider.py
@@ -14,7 +14,9 @@ Note: This provider is configured for vanilla LLM behavior:
 import asyncio
 import json
 import os
+import signal
 import subprocess
+import sys
 import tempfile
 from dataclasses import dataclass
 from typing import Literal
@@ -415,6 +417,46 @@ class OpenCodeCLIProvider(BaseCLIProvider):
 
         return _JSONParseResult(action="success", text="".join(text_parts).strip())
 
+    async def _kill_process_tree(
+        self, process: asyncio.subprocess.Process, *, pgid: int | None = None
+    ) -> None:
+        """Terminate an opencode subprocess and its descendants."""
+        if sys.platform == "win32":
+            try:
+                subprocess.run(
+                    ["taskkill", "/T", "/PID", str(process.pid), "/F"],
+                    check=False,
+                    timeout=10,
+                )
+            except (FileNotFoundError, subprocess.SubprocessError, OSError):
+                logger.debug("Windows taskkill failed during OpenCode cleanup")
+            try:
+                await asyncio.wait_for(process.wait(), timeout=5)
+            except (asyncio.TimeoutError, ProcessLookupError):
+                pass
+            return
+
+        process_group_id = pgid if pgid is not None else process.pid
+        try:
+            os.killpg(process_group_id, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+
+        try:
+            await asyncio.wait_for(process.wait(), timeout=5)
+        except (asyncio.TimeoutError, ProcessLookupError):
+            pass
+
+        try:
+            os.killpg(process_group_id, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+        try:
+            await asyncio.wait_for(process.wait(), timeout=5)
+        except (asyncio.TimeoutError, ProcessLookupError):
+            pass
+
     async def _run_single_attempt(
         self,
         message: str,
@@ -431,6 +473,8 @@ class OpenCodeCLIProvider(BaseCLIProvider):
         """
         cmd = self._build_cmd(model, use_json)
         process = None
+        process_pgid: int | None = None
+        cleanup_required = False
         try:
             process = await asyncio.create_subprocess_exec(
                 *cmd,
@@ -439,7 +483,11 @@ class OpenCodeCLIProvider(BaseCLIProvider):
                 stderr=asyncio.subprocess.PIPE,
                 env=os.environ.copy(),
                 cwd=tempfile.gettempdir(),
+                start_new_session=True,
             )
+            cleanup_required = True
+            if sys.platform != "win32":
+                process_pgid = process.pid
 
             stdout, stderr = await asyncio.wait_for(
                 process.communicate(input=message.encode("utf-8")),
@@ -456,6 +504,7 @@ class OpenCodeCLIProvider(BaseCLIProvider):
                 raise RuntimeError(
                     "Subprocess communicate() completed but returncode is None"
                 )
+            cleanup_required = False
 
             if use_json:
                 json_result = self._parse_json_output(
@@ -519,13 +568,6 @@ class OpenCodeCLIProvider(BaseCLIProvider):
             return _PhaseResult(action="success", output=output, attempts_used=1)
 
         except asyncio.TimeoutError:
-            if process and process.returncode is None:
-                try:
-                    process.kill()
-                except ProcessLookupError:
-                    pass
-                await process.wait()
-
             cmd_ctx = self._describe_command_context(model=model, use_json=use_json)
             error = RuntimeError(
                 f"OpenCode CLI command timed out after {request_timeout}s "
@@ -537,17 +579,14 @@ class OpenCodeCLIProvider(BaseCLIProvider):
             if isinstance(e, RuntimeError):
                 raise
 
-            if process and process.returncode is None:
-                try:
-                    process.kill()
-                except ProcessLookupError:
-                    pass
-                await process.wait()
-
             cmd_ctx = self._describe_command_context(model=model, use_json=use_json)
             error = RuntimeError(f"OpenCode CLI command failed: {e} ({cmd_ctx})")
             error.__cause__ = e
             return _PhaseResult(action="failure", error=error, attempts_used=1)
+
+        finally:
+            if cleanup_required and process is not None:
+                await self._kill_process_tree(process, pgid=process_pgid)
 
     async def _try_phase(
         self,

--- a/tests/integration/test_opencode_cli_orphan_cleanup.py
+++ b/tests/integration/test_opencode_cli_orphan_cleanup.py
@@ -1,0 +1,103 @@
+"""Integration proof that cancelled OpenCode CLI calls do not leave child orphans."""
+
+import asyncio
+import os
+import sys
+import textwrap
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import psutil
+import pytest
+
+from chunkhound.providers.llm.opencode_cli_provider import OpenCodeCLIProvider
+
+pytestmark = pytest.mark.integration
+
+
+async def _wait_for_pid_file(path: Path, timeout: float = 5.0) -> int:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            text = path.read_text(encoding="utf-8").strip()
+            if text:
+                return int(text)
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"child pid file was not written: {path}")
+
+
+async def _wait_until_pid_gone(pid: int, timeout: float = 8.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not psutil.pid_exists(pid):
+            return
+        await asyncio.sleep(0.1)
+    raise AssertionError(f"child process {pid} survived cancellation cleanup")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix process-group proof")
+@pytest.mark.asyncio
+async def test_opencode_orphan_child_terminated_after_cancellation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Fake opencode spawns a long-running child; cancellation kills the group."""
+    child_pid_file = tmp_path / "child.pid"
+    fake_opencode = tmp_path / "opencode"
+    fake_opencode.write_text(
+        textwrap.dedent(
+            f"""
+            #!{sys.executable}
+            import os
+            import subprocess
+            import sys
+            import time
+
+            child = subprocess.Popen([
+                sys.executable,
+                "-c",
+                "import time; time.sleep(60)",
+            ])
+            pid_file = os.environ["OPENCODE_CHILD_PID_FILE"]
+            with open(pid_file, "w", encoding="utf-8") as handle:
+                handle.write(str(child.pid))
+                handle.flush()
+            time.sleep(60)
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    fake_opencode.chmod(0o755)
+
+    monkeypatch.setenv("PATH", f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}")
+    monkeypatch.setenv("OPENCODE_CHILD_PID_FILE", str(child_pid_file))
+
+    with patch.object(OpenCodeCLIProvider, "_opencode_available", return_value=True):
+        provider = OpenCodeCLIProvider(
+            model="test-provider/test-model",
+            timeout=30,
+            max_retries=1,
+        )
+
+    task = asyncio.create_task(
+        provider._run_single_attempt(
+            "prompt",
+            30,
+            model="test-provider/test-model",
+            use_json=False,
+        )
+    )
+    child_pid = await _wait_for_pid_file(child_pid_file)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    try:
+        await _wait_until_pid_gone(child_pid)
+    finally:
+        if psutil.pid_exists(child_pid):
+            try:
+                psutil.Process(child_pid).kill()
+            except psutil.NoSuchProcess:
+                pass

--- a/tests/unit/llm/test_opencode_cli_provider.py
+++ b/tests/unit/llm/test_opencode_cli_provider.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import signal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -267,10 +268,207 @@ class TestOpenCodeCLIProvider:
             assert mock_subprocess.call_count == provider._max_retries
 
     @pytest.mark.asyncio
+    async def test_run_single_attempt_timeout_uses_killpg(self, provider):
+        """Timeout cleanup kills the captured process group, not just the parent."""
+        with (
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+            patch("os.killpg") as mock_killpg,
+        ):
+            mock_process = AsyncMock()
+            mock_process.pid = 4321
+            mock_process.communicate.side_effect = asyncio.TimeoutError()
+            mock_process.wait = AsyncMock()
+            mock_process.kill = MagicMock()
+            mock_process.returncode = None
+            mock_subprocess.return_value = mock_process
+
+            result = await provider._run_single_attempt(
+                "Test prompt",
+                1,
+                model="test-provider/test-model",
+                use_json=False,
+            )
+
+            assert result.action == "timeout"
+            assert mock_subprocess.call_args.kwargs["start_new_session"] is True
+            killpg_calls = [
+                (args[0], args[1]) for args, _kwargs in mock_killpg.call_args_list
+            ]
+            assert (4321, signal.SIGTERM) in killpg_calls
+            assert (4321, signal.SIGKILL) in killpg_calls
+            mock_process.kill.assert_not_called()
+            mock_process.wait.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_run_single_attempt_group_escalation_uses_captured_pgid(
+        self, provider
+    ):
+        """Cleanup uses the PGID captured at spawn rather than a later PID lookup."""
+        with (
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+            patch("os.killpg") as mock_killpg,
+            patch("os.getpgid", side_effect=AssertionError("late PGID lookup")),
+        ):
+            mock_process = AsyncMock()
+            mock_process.pid = 4321
+
+            async def timeout_after_pid_change(*_args, **_kwargs):
+                mock_process.pid = 9999
+                raise asyncio.TimeoutError()
+
+            mock_process.communicate.side_effect = timeout_after_pid_change
+            mock_process.wait = AsyncMock()
+            mock_process.kill = MagicMock()
+            mock_process.returncode = None
+            mock_subprocess.return_value = mock_process
+
+            result = await provider._run_single_attempt(
+                "Test prompt",
+                1,
+                model="test-provider/test-model",
+                use_json=False,
+            )
+
+            assert result.action == "timeout"
+            killpg_calls = [
+                (args[0], args[1]) for args, _kwargs in mock_killpg.call_args_list
+            ]
+            assert (4321, signal.SIGTERM) in killpg_calls
+            assert (4321, signal.SIGKILL) in killpg_calls
+            assert all(pgid == 4321 for pgid, _sig in killpg_calls)
+
+    @pytest.mark.asyncio
+    async def test_run_single_attempt_parent_exit_still_killpg_captured_pgid(
+        self, provider
+    ):
+        """SIGKILL is still attempted for descendants after the parent exits."""
+        with (
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+            patch("os.killpg") as mock_killpg,
+        ):
+            mock_process = AsyncMock()
+            mock_process.pid = 4321
+            mock_process.communicate.side_effect = asyncio.TimeoutError()
+
+            async def wait_and_mark_parent_exit():
+                mock_process.returncode = 0
+                return 0
+
+            mock_process.wait = AsyncMock(side_effect=wait_and_mark_parent_exit)
+            mock_process.kill = MagicMock()
+            mock_process.returncode = None
+            mock_subprocess.return_value = mock_process
+
+            result = await provider._run_single_attempt(
+                "Test prompt",
+                1,
+                model="test-provider/test-model",
+                use_json=False,
+            )
+
+            assert result.action == "timeout"
+            killpg_calls = [
+                (args[0], args[1]) for args, _kwargs in mock_killpg.call_args_list
+            ]
+            assert (4321, signal.SIGTERM) in killpg_calls
+            assert (4321, signal.SIGKILL) in killpg_calls
+
+    @pytest.mark.asyncio
+    async def test_run_single_attempt_cancelled_cleans_up(self, provider):
+        """Cancelled tasks propagate only after process-group cleanup runs."""
+        with (
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+            patch("os.killpg") as mock_killpg,
+        ):
+            mock_process = AsyncMock()
+            mock_process.pid = 4321
+            mock_process.communicate.side_effect = asyncio.CancelledError()
+            mock_process.wait = AsyncMock()
+            mock_process.kill = MagicMock()
+            mock_process.returncode = None
+            mock_subprocess.return_value = mock_process
+
+            with pytest.raises(asyncio.CancelledError):
+                await provider._run_single_attempt(
+                    "Test prompt",
+                    30,
+                    model="test-provider/test-model",
+                    use_json=False,
+                )
+
+            mock_killpg.assert_any_call(4321, signal.SIGTERM)
+            mock_killpg.assert_any_call(4321, signal.SIGKILL)
+            mock_process.kill.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_single_attempt_exception_cleans_up(self, provider):
+        """Unexpected subprocess-body exceptions trigger process-tree cleanup."""
+        with (
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+            patch("os.killpg") as mock_killpg,
+        ):
+            mock_process = AsyncMock()
+            mock_process.pid = 4321
+            mock_process.communicate.side_effect = OSError("boom")
+            mock_process.wait = AsyncMock()
+            mock_process.kill = MagicMock()
+            mock_process.returncode = None
+            mock_subprocess.return_value = mock_process
+
+            result = await provider._run_single_attempt(
+                "Test prompt",
+                30,
+                model="test-provider/test-model",
+                use_json=False,
+            )
+
+            assert result.action == "failure"
+            assert "boom" in str(result.error)
+            mock_killpg.assert_any_call(4321, signal.SIGTERM)
+            mock_killpg.assert_any_call(4321, signal.SIGKILL)
+            mock_process.kill.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_single_attempt_windows_uses_taskkill(self, provider):
+        """Windows cleanup routes to taskkill /T instead of Unix killpg."""
+        with (
+            patch("sys.platform", "win32"),
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+            patch("subprocess.run") as mock_run,
+            patch("os.killpg") as mock_killpg,
+        ):
+            mock_process = AsyncMock()
+            mock_process.pid = 2468
+            mock_process.communicate.side_effect = asyncio.TimeoutError()
+            mock_process.wait = AsyncMock()
+            mock_process.kill = MagicMock()
+            mock_process.returncode = None
+            mock_subprocess.return_value = mock_process
+
+            result = await provider._run_single_attempt(
+                "Test prompt",
+                1,
+                model="test-provider/test-model",
+                use_json=False,
+            )
+
+            assert result.action == "timeout"
+            mock_run.assert_called_once_with(
+                ["taskkill", "/T", "/PID", "2468", "/F"],
+                check=False,
+                timeout=10,
+            )
+            mock_killpg.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_run_cli_command_timeout(self, provider):
         """Test CLI command timeout."""
-        with patch("asyncio.create_subprocess_exec") as mock_subprocess:
+        with (
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+            patch("os.killpg") as mock_killpg,
+        ):
             mock_process = AsyncMock()
+            mock_process.pid = 4321
             mock_process.communicate.side_effect = asyncio.TimeoutError()
             mock_process.wait = AsyncMock()
             mock_process.kill = MagicMock()
@@ -283,7 +481,9 @@ class TestOpenCodeCLIProvider:
             msg = str(exc.value)
             assert "model=test-provider/test-model" in msg
             assert "Test prompt" not in msg
-            mock_process.kill.assert_called()
+            mock_killpg.assert_any_call(4321, signal.SIGTERM)
+            mock_killpg.assert_any_call(4321, signal.SIGKILL)
+            mock_process.kill.assert_not_called()
             mock_process.wait.assert_awaited()
 
     @pytest.mark.asyncio
@@ -291,36 +491,46 @@ class TestOpenCodeCLIProvider:
         self, provider
     ):
         """Stale process cleanup must not mask the timeout error."""
-        with patch("asyncio.create_subprocess_exec") as mock_subprocess:
+        with (
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+            patch("os.killpg", side_effect=ProcessLookupError()),
+        ):
             mock_process = AsyncMock()
+            mock_process.pid = 4321
             mock_process.communicate.side_effect = asyncio.TimeoutError()
             mock_process.wait = AsyncMock()
             mock_process.returncode = None
-            mock_process.kill = MagicMock(side_effect=ProcessLookupError())
+            mock_process.kill = MagicMock()
             mock_subprocess.return_value = mock_process
 
             with pytest.raises(RuntimeError, match="timed out"):
                 await provider._run_cli_command("Test prompt")
 
             mock_process.wait.assert_awaited()
+            mock_process.kill.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_run_cli_command_generic_failure_ignores_stale_process_lookup_error(
         self, provider
     ):
         """Unexpected failures must survive stale process cleanup."""
-        with patch("asyncio.create_subprocess_exec") as mock_subprocess:
+        with (
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+            patch("os.killpg", side_effect=ProcessLookupError()),
+        ):
             mock_process = AsyncMock()
+            mock_process.pid = 4321
             mock_process.communicate.side_effect = ValueError("boom")
             mock_process.wait = AsyncMock()
             mock_process.returncode = None
-            mock_process.kill = MagicMock(side_effect=ProcessLookupError())
+            mock_process.kill = MagicMock()
             mock_subprocess.return_value = mock_process
 
             with pytest.raises(RuntimeError, match="OpenCode CLI command failed: boom"):
                 await provider._run_cli_command("Test prompt")
 
-            assert mock_process.wait.await_count == provider._max_retries
+            assert mock_process.wait.await_count == provider._max_retries * 2
+            mock_process.kill.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_run_cli_command_failure_redacts_prompt_from_error(self, provider):
@@ -1001,8 +1211,12 @@ class TestOpenCodeCLIProvider:
                 max_retries=1,
             )
 
-        with patch("asyncio.create_subprocess_exec") as mock_subprocess:
+        with (
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+            patch("os.killpg"),
+        ):
             mock_process_timeout = AsyncMock()
+            mock_process_timeout.pid = 4321
             mock_process_timeout.communicate.side_effect = asyncio.TimeoutError()
             mock_process_timeout.wait = AsyncMock()
             mock_process_timeout.kill = MagicMock()
@@ -1066,8 +1280,12 @@ class TestOpenCodeCLIProvider:
                 max_retries=1,
             )
 
-        with patch("asyncio.create_subprocess_exec") as mock_subprocess:
+        with (
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+            patch("os.killpg"),
+        ):
             mock_process_timeout = AsyncMock()
+            mock_process_timeout.pid = 4321
             mock_process_timeout.communicate.side_effect = asyncio.TimeoutError()
             mock_process_timeout.wait = AsyncMock()
             mock_process_timeout.kill = MagicMock()
@@ -1098,8 +1316,12 @@ class TestOpenCodeCLIProvider:
                 max_retries=1,
             )
 
-        with patch("asyncio.create_subprocess_exec") as mock_subprocess:
+        with (
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+            patch("os.killpg"),
+        ):
             mock_process_timeout = AsyncMock()
+            mock_process_timeout.pid = 4321
             mock_process_timeout.communicate.side_effect = asyncio.TimeoutError()
             mock_process_timeout.wait = AsyncMock()
             mock_process_timeout.kill = MagicMock()
@@ -1137,14 +1359,19 @@ class TestOpenCodeCLIProvider:
                 max_retries=1,
             )
 
-        with patch("asyncio.create_subprocess_exec") as mock_subprocess:
+        with (
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+            patch("os.killpg"),
+        ):
             mock_process_timeout = AsyncMock()
+            mock_process_timeout.pid = 4321
             mock_process_timeout.communicate.side_effect = asyncio.TimeoutError()
             mock_process_timeout.wait = AsyncMock()
             mock_process_timeout.kill = MagicMock()
             mock_process_timeout.returncode = None
 
             mock_process_fallback = AsyncMock()
+            mock_process_fallback.pid = 8765
             mock_process_fallback.communicate.side_effect = asyncio.TimeoutError()
             mock_process_fallback.wait = AsyncMock()
             mock_process_fallback.kill = MagicMock()

--- a/tests/unit/llm/test_opencode_cli_provider.py
+++ b/tests/unit/llm/test_opencode_cli_provider.py
@@ -271,8 +271,9 @@ class TestOpenCodeCLIProvider:
     async def test_run_single_attempt_timeout_uses_killpg(self, provider):
         """Timeout cleanup kills the captured process group, not just the parent."""
         with (
+            patch("sys.platform", "linux"),
             patch("asyncio.create_subprocess_exec") as mock_subprocess,
-            patch("os.killpg") as mock_killpg,
+            patch("os.killpg", create=True) as mock_killpg,
         ):
             mock_process = AsyncMock()
             mock_process.pid = 4321
@@ -305,8 +306,9 @@ class TestOpenCodeCLIProvider:
     ):
         """Cleanup uses the PGID captured at spawn rather than a later PID lookup."""
         with (
+            patch("sys.platform", "linux"),
             patch("asyncio.create_subprocess_exec") as mock_subprocess,
-            patch("os.killpg") as mock_killpg,
+            patch("os.killpg", create=True) as mock_killpg,
             patch("os.getpgid", side_effect=AssertionError("late PGID lookup")),
         ):
             mock_process = AsyncMock()
@@ -343,8 +345,9 @@ class TestOpenCodeCLIProvider:
     ):
         """SIGKILL is still attempted for descendants after the parent exits."""
         with (
+            patch("sys.platform", "linux"),
             patch("asyncio.create_subprocess_exec") as mock_subprocess,
-            patch("os.killpg") as mock_killpg,
+            patch("os.killpg", create=True) as mock_killpg,
         ):
             mock_process = AsyncMock()
             mock_process.pid = 4321
@@ -377,8 +380,9 @@ class TestOpenCodeCLIProvider:
     async def test_run_single_attempt_cancelled_cleans_up(self, provider):
         """Cancelled tasks propagate only after process-group cleanup runs."""
         with (
+            patch("sys.platform", "linux"),
             patch("asyncio.create_subprocess_exec") as mock_subprocess,
-            patch("os.killpg") as mock_killpg,
+            patch("os.killpg", create=True) as mock_killpg,
         ):
             mock_process = AsyncMock()
             mock_process.pid = 4321
@@ -404,8 +408,9 @@ class TestOpenCodeCLIProvider:
     async def test_run_single_attempt_exception_cleans_up(self, provider):
         """Unexpected subprocess-body exceptions trigger process-tree cleanup."""
         with (
+            patch("sys.platform", "linux"),
             patch("asyncio.create_subprocess_exec") as mock_subprocess,
-            patch("os.killpg") as mock_killpg,
+            patch("os.killpg", create=True) as mock_killpg,
         ):
             mock_process = AsyncMock()
             mock_process.pid = 4321
@@ -435,7 +440,8 @@ class TestOpenCodeCLIProvider:
             patch("sys.platform", "win32"),
             patch("asyncio.create_subprocess_exec") as mock_subprocess,
             patch("subprocess.run") as mock_run,
-            patch("os.killpg") as mock_killpg,
+            patch("subprocess.CREATE_NEW_PROCESS_GROUP", 0x00000200, create=True),
+            patch("os.killpg", create=True) as mock_killpg,
         ):
             mock_process = AsyncMock()
             mock_process.pid = 2468
@@ -453,6 +459,8 @@ class TestOpenCodeCLIProvider:
             )
 
             assert result.action == "timeout"
+            assert "start_new_session" not in mock_subprocess.call_args.kwargs
+            assert mock_subprocess.call_args.kwargs["creationflags"] == 0x00000200
             mock_run.assert_called_once_with(
                 ["taskkill", "/T", "/PID", "2468", "/F"],
                 check=False,
@@ -464,8 +472,9 @@ class TestOpenCodeCLIProvider:
     async def test_run_cli_command_timeout(self, provider):
         """Test CLI command timeout."""
         with (
+            patch("sys.platform", "linux"),
             patch("asyncio.create_subprocess_exec") as mock_subprocess,
-            patch("os.killpg") as mock_killpg,
+            patch("os.killpg", create=True) as mock_killpg,
         ):
             mock_process = AsyncMock()
             mock_process.pid = 4321
@@ -492,8 +501,9 @@ class TestOpenCodeCLIProvider:
     ):
         """Stale process cleanup must not mask the timeout error."""
         with (
+            patch("sys.platform", "linux"),
             patch("asyncio.create_subprocess_exec") as mock_subprocess,
-            patch("os.killpg", side_effect=ProcessLookupError()),
+            patch("os.killpg", side_effect=ProcessLookupError(), create=True),
         ):
             mock_process = AsyncMock()
             mock_process.pid = 4321
@@ -515,8 +525,9 @@ class TestOpenCodeCLIProvider:
     ):
         """Unexpected failures must survive stale process cleanup."""
         with (
+            patch("sys.platform", "linux"),
             patch("asyncio.create_subprocess_exec") as mock_subprocess,
-            patch("os.killpg", side_effect=ProcessLookupError()),
+            patch("os.killpg", side_effect=ProcessLookupError(), create=True),
         ):
             mock_process = AsyncMock()
             mock_process.pid = 4321
@@ -1212,8 +1223,9 @@ class TestOpenCodeCLIProvider:
             )
 
         with (
+            patch("sys.platform", "linux"),
             patch("asyncio.create_subprocess_exec") as mock_subprocess,
-            patch("os.killpg"),
+            patch("os.killpg", create=True),
         ):
             mock_process_timeout = AsyncMock()
             mock_process_timeout.pid = 4321
@@ -1281,8 +1293,9 @@ class TestOpenCodeCLIProvider:
             )
 
         with (
+            patch("sys.platform", "linux"),
             patch("asyncio.create_subprocess_exec") as mock_subprocess,
-            patch("os.killpg"),
+            patch("os.killpg", create=True),
         ):
             mock_process_timeout = AsyncMock()
             mock_process_timeout.pid = 4321
@@ -1317,8 +1330,9 @@ class TestOpenCodeCLIProvider:
             )
 
         with (
+            patch("sys.platform", "linux"),
             patch("asyncio.create_subprocess_exec") as mock_subprocess,
-            patch("os.killpg"),
+            patch("os.killpg", create=True),
         ):
             mock_process_timeout = AsyncMock()
             mock_process_timeout.pid = 4321
@@ -1360,8 +1374,9 @@ class TestOpenCodeCLIProvider:
             )
 
         with (
+            patch("sys.platform", "linux"),
             patch("asyncio.create_subprocess_exec") as mock_subprocess,
-            patch("os.killpg"),
+            patch("os.killpg", create=True),
         ):
             mock_process_timeout = AsyncMock()
             mock_process_timeout.pid = 4321

--- a/tests/unit/llm/test_opencode_cli_provider.py
+++ b/tests/unit/llm/test_opencode_cli_provider.py
@@ -21,6 +21,12 @@ def test_default_timeout():
 class TestOpenCodeCLIProvider:
     """Test cases for OpenCode CLI provider."""
 
+    @pytest.fixture(autouse=True)
+    def posix_signal_constants(self):
+        """Make POSIX-only signal constants available for mocked Unix tests."""
+        with patch("signal.SIGKILL", 9, create=True):
+            yield
+
     @pytest.fixture
     def provider(self):
         """Create a provider with a dummy model."""
@@ -309,7 +315,11 @@ class TestOpenCodeCLIProvider:
             patch("sys.platform", "linux"),
             patch("asyncio.create_subprocess_exec") as mock_subprocess,
             patch("os.killpg", create=True) as mock_killpg,
-            patch("os.getpgid", side_effect=AssertionError("late PGID lookup")),
+            patch(
+                "os.getpgid",
+                side_effect=AssertionError("late PGID lookup"),
+                create=True,
+            ),
         ):
             mock_process = AsyncMock()
             mock_process.pid = 4321

--- a/tests/unit/llm/test_opencode_cli_provider.py
+++ b/tests/unit/llm/test_opencode_cli_provider.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import signal
+import subprocess
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -445,11 +446,11 @@ class TestOpenCodeCLIProvider:
 
     @pytest.mark.asyncio
     async def test_run_single_attempt_windows_uses_taskkill(self, provider):
-        """Windows cleanup routes to taskkill /T instead of Unix killpg."""
+        """Windows cleanup routes to taskkill /T without blocking the event loop."""
         with (
             patch("sys.platform", "win32"),
             patch("asyncio.create_subprocess_exec") as mock_subprocess,
-            patch("subprocess.run") as mock_run,
+            patch("asyncio.to_thread", new_callable=AsyncMock) as mock_to_thread,
             patch("subprocess.CREATE_NEW_PROCESS_GROUP", 0x00000200, create=True),
             patch("os.killpg", create=True) as mock_killpg,
         ):
@@ -471,7 +472,8 @@ class TestOpenCodeCLIProvider:
             assert result.action == "timeout"
             assert "start_new_session" not in mock_subprocess.call_args.kwargs
             assert mock_subprocess.call_args.kwargs["creationflags"] == 0x00000200
-            mock_run.assert_called_once_with(
+            mock_to_thread.assert_awaited_once_with(
+                subprocess.run,
                 ["taskkill", "/T", "/PID", "2468", "/F"],
                 check=False,
                 timeout=10,
@@ -530,6 +532,30 @@ class TestOpenCodeCLIProvider:
             mock_process.kill.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_run_cli_command_timeout_ignores_killpg_permission_error(
+        self, provider
+    ):
+        """Permission-denied process groups must not mask timeout errors."""
+        with (
+            patch("sys.platform", "linux"),
+            patch("asyncio.create_subprocess_exec") as mock_subprocess,
+            patch("os.killpg", side_effect=PermissionError(), create=True),
+        ):
+            mock_process = AsyncMock()
+            mock_process.pid = 4321
+            mock_process.communicate.side_effect = asyncio.TimeoutError()
+            mock_process.wait = AsyncMock()
+            mock_process.returncode = None
+            mock_process.kill = MagicMock()
+            mock_subprocess.return_value = mock_process
+
+            with pytest.raises(RuntimeError, match="timed out"):
+                await provider._run_cli_command("Test prompt")
+
+            mock_process.wait.assert_awaited()
+            mock_process.kill.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_run_cli_command_generic_failure_ignores_stale_process_lookup_error(
         self, provider
     ):
@@ -550,7 +576,7 @@ class TestOpenCodeCLIProvider:
             with pytest.raises(RuntimeError, match="OpenCode CLI command failed: boom"):
                 await provider._run_cli_command("Test prompt")
 
-            assert mock_process.wait.await_count == provider._max_retries * 2
+            mock_process.wait.assert_awaited()
             mock_process.kill.assert_not_called()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
OpenCode-backed ChunkHound requests now clean up the entire OpenCode process tree when a request times out, is cancelled, or fails unexpectedly, preventing long-lived orphan subprocesses from accumulating across sessions.

## Requirements
- Operators using OpenCode as an LLM backend should not be left with surviving `opencode` descendants after a cancelled or timed-out request.
- Cleanup should cover direct OpenCode subprocesses and descendants such as search helpers or MCP servers.
- Cancellation should still propagate to callers after cleanup completes.
- Cleanup behavior should work across Unix-like systems and route to a Windows tree-kill mechanism on Windows.

## Acceptance criteria
- On request timeout, ChunkHound uses a process-tree kill rather than killing only the immediate OpenCode process.
- On task cancellation, cleanup still runs before cancellation is re-raised.
- On unexpected subprocess-path exceptions, the same cleanup path runs before returning failure.
- On Unix-like systems, cleanup gives the OpenCode process group a graceful termination window, then escalates to a hard process-group kill even if the immediate parent already exited.
- OpenCode subprocesses are launched in their own session so group-wide cleanup can target the full tree.
- On Windows, cleanup routes through `taskkill /T /PID <pid> /F`.
- A cancellation scenario with a fake OpenCode executable that spawns a long-running child leaves no surviving child process after cleanup.

## Contract changes
- OpenCode CLI provider cancellation, timeout, and abnormal-failure behavior now promises process-tree cleanup instead of parent-only subprocess cleanup.
- No public CLI flags, config keys, API shapes, or file formats are changed.

## Out of scope
- Applying the same process-tree cleanup pattern to Codex CLI or Claude Code CLI providers.
- Timeout or retry-budget tuning.
- Changing OpenCode retry phase behavior.
- Preventing OpenCode itself from spawning helper processes.
- Daemon-level orphan detection or periodic zombie reaping.

## How to verify
Run the focused OpenCode provider checks:

```bash
uv run python -m pytest tests/unit/llm/test_opencode_cli_provider.py -v
uv run python -m pytest tests/integration/test_opencode_cli_orphan_cleanup.py -v
uv run ruff check chunkhound/providers/llm/opencode_cli_provider.py tests/unit/llm/test_opencode_cli_provider.py tests/integration/test_opencode_cli_orphan_cleanup.py
```

Optional smoke check:

```bash
uv run python -m pytest tests/test_smoke.py -v -n auto
```

## Epic reference
- Epic: llm-provider-integration
- Story: 02 — OpenCode CLI: process-group cleanup & orphan prevention
- Step file: agent_coordination/epics/llm-provider-integration/story-02-opencode-cli-process-group-cleanup.md
