### PR TITLE
feat(llm): add Claude Opus 4.8 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Claude Opus 4.8 support**: the Anthropic provider now gives Opus 4.8 full Opus 4.7 capability parity: adaptive-only extended thinking (an explicit `manual` request auto-resolves to adaptive), effort levels `low`/`medium`/`high`/`xhigh`/`max`, and the task-budgets beta. The pinned `claude-opus` offline fallback was bumped to `claude-opus-4-8`. Fixes a `400 "thinking.type.enabled is not supported for this model"` error when targeting `claude-opus-4-8` with thinking enabled.
+
 ## [5.1.0] - 2026-05-20
 
 ### Breaking Changes

--- a/chunkhound/core/config/claude_model_resolution.py
+++ b/chunkhound/core/config/claude_model_resolution.py
@@ -39,7 +39,7 @@ CLAUDE_OPUS_SENTINEL = "claude-opus"
 
 CLAUDE_HAIKU_FALLBACK = "claude-haiku-4-5-20251001"
 CLAUDE_SONNET_FALLBACK = "claude-sonnet-4-6"
-CLAUDE_OPUS_FALLBACK = "claude-opus-4-7"
+CLAUDE_OPUS_FALLBACK = "claude-opus-4-8"
 
 # ── Sentinel config lookup table ─────────────────────────────────────────
 

--- a/chunkhound/core/config/llm_config.py
+++ b/chunkhound/core/config/llm_config.py
@@ -283,9 +283,9 @@ class LLMConfig(BaseSettings):
         default=None,
         description=(
             "Control token usage vs thoroughness tradeoff. Supported on "
-            "Opus 4.5, Opus 4.6, Opus 4.7, Sonnet 4.6, and Mythos. "
+            "Opus 4.5, Opus 4.6, Opus 4.7, Opus 4.8, Sonnet 4.6, and Mythos. "
             "low/medium/high on all supported models; max on 4.6+; "
-            "xhigh is Opus 4.7 only. high is the API default; Sonnet 4.6 "
+            "xhigh on Opus 4.7/4.8. high is the API default; Sonnet 4.6 "
             "recommends medium."
         ),
     )

--- a/chunkhound/providers/llm/anthropic_llm_provider.py
+++ b/chunkhound/providers/llm/anthropic_llm_provider.py
@@ -53,27 +53,31 @@ _EFFORT_FAMILY_PREFIXES: tuple[str, ...] = (
     "claude-opus-4-5",
     "claude-opus-4-6",
     "claude-opus-4-7",
+    "claude-opus-4-8",
     "claude-sonnet-4-6",
     "claude-mythos-preview",
 )
 _MAX_EFFORT_PREFIXES: tuple[str, ...] = (
     "claude-opus-4-6",
     "claude-opus-4-7",
+    "claude-opus-4-8",
     "claude-sonnet-4-6",
     "claude-mythos-preview",
 )
-_XHIGH_EFFORT_PREFIXES: tuple[str, ...] = ("claude-opus-4-7",)
+_XHIGH_EFFORT_PREFIXES: tuple[str, ...] = ("claude-opus-4-7", "claude-opus-4-8")
 _ADAPTIVE_THINKING_PREFIXES: tuple[str, ...] = (
     "claude-opus-4-6",
     "claude-opus-4-7",
+    "claude-opus-4-8",
     "claude-sonnet-4-6",
     "claude-mythos-preview",
 )
 _ADAPTIVE_ONLY_PREFIXES: tuple[str, ...] = (
     "claude-opus-4-7",
+    "claude-opus-4-8",
     "claude-mythos-preview",
 )
-_TASK_BUDGET_PREFIXES: tuple[str, ...] = ("claude-opus-4-7",)
+_TASK_BUDGET_PREFIXES: tuple[str, ...] = ("claude-opus-4-7", "claude-opus-4-8")
 
 
 def _matches_family(model: str, prefixes: tuple[str, ...]) -> bool:
@@ -122,18 +126,18 @@ class AnthropicLLMProvider(LLMProvider):
     """Anthropic LLM provider using Claude models.
 
     Supports adaptive/manual extended thinking, tool use, effort control, and
-    automatic context management across Opus 4.5/4.6/4.7 and Sonnet 4.5/4.6.
+    automatic context management across Opus 4.5/4.6/4.7/4.8 and Sonnet 4.5/4.6.
 
     Thinking modes:
-        - Adaptive (Opus 4.7, Opus 4.6, Sonnet 4.6, Mythos): Claude decides
-          when to think. Interleaved thinking is auto-enabled. Opus 4.7 rejects
-          manual mode.
+        - Adaptive (Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Mythos): Claude
+          decides when to think. Interleaved thinking is auto-enabled. Opus
+          4.7/4.8 reject manual mode.
         - Manual (Opus 4.5 and older): fixed thinking_budget_tokens.
         - Off: omit thinking.
 
     Effort parameter:
-        - Supported on Opus 4.5, Opus 4.6, Opus 4.7, Sonnet 4.6, Mythos.
-        - Levels: low, medium, high (default), max (4.6+), xhigh (Opus 4.7 only).
+        - Supported on Opus 4.5, Opus 4.6, Opus 4.7, Opus 4.8, Sonnet 4.6, Mythos.
+        - Levels: low, medium, high (default), max (4.6+), xhigh (Opus 4.7/4.8).
         - Affects all tokens: text, tool calls, and thinking.
 
     Interleaved thinking:
@@ -179,6 +183,8 @@ class AnthropicLLMProvider(LLMProvider):
                 because Haiku is Anthropic's cheapest capable Claude model.
                 Pass an explicit synthesis model for maximum quality.
                 Supported families:
+                - claude-opus-4-8: adaptive thinking only. Effort levels
+                  low/medium/high/xhigh/max. xhigh recommended for coding.
                 - claude-opus-4-7: adaptive thinking only. Effort levels
                   low/medium/high/xhigh/max. xhigh recommended for coding.
                 - claude-opus-4-6: adaptive thinking. Effort low/medium/high/max.
@@ -198,7 +204,7 @@ class AnthropicLLMProvider(LLMProvider):
             interleaved_thinking: Enable thinking between tool calls in manual
                 mode. Auto-enabled for adaptive mode regardless of this flag.
             effort: Token usage level - "low", "medium", "high", "xhigh"
-                (Opus 4.7 only), or "max" (4.6+ only).
+                (Opus 4.7/4.8), or "max" (4.6+ only).
             context_management_enabled: Enable automatic context management
             clear_thinking_keep_turns: Number of thinking turns to preserve (None=all)
             clear_tool_uses_trigger_tokens: Token threshold to trigger tool clearing
@@ -206,8 +212,8 @@ class AnthropicLLMProvider(LLMProvider):
             thinking_mode: Explicit thinking mode: "adaptive", "manual", "off",
                 or "auto" / None for automatic selection based on model.
             thinking_display: "summarized" (default on 4.6) or "omitted"
-                (default on Opus 4.7 / Mythos). Controls whether thinking text
-                is returned in the response.
+                (default on Opus 4.7/4.8 / Mythos). Controls whether thinking
+                text is returned in the response.
             prompt_caching: When True, sends cache_control={"type": "ephemeral"}
                 so the Messages API can cache prompt prefixes. Disabled by
                 default because ChunkHound requests rarely reuse prefixes enough
@@ -216,7 +222,7 @@ class AnthropicLLMProvider(LLMProvider):
                 writes but is useful when the same prefix is reused less
                 often than every 5 minutes.
             task_budget_tokens: Total token budget across a full agentic loop
-                (beta, Opus 4.7 only). Advisory cap visible to the
+                (beta, Opus 4.7/4.8). Advisory cap visible to the
                 model; min 20000. Leave None for open-ended quality work.
         """
         if not ANTHROPIC_AVAILABLE:
@@ -581,7 +587,7 @@ class AnthropicLLMProvider(LLMProvider):
 
         Effort is applied only when the model supports it. task_budget is
         applied only when task_budget_tokens was accepted in __init__ (which
-        requires an Opus 4.7-family model).
+        requires an Opus 4.7/4.8-family model).
 
         Args:
             json_schema: Optional JSON schema for structured outputs.

--- a/site/src/pages/docs/configuration.md
+++ b/site/src/pages/docs/configuration.md
@@ -176,12 +176,23 @@ When an OpenAI-compatible LLM provider points at a custom `base_url`, ChunkHound
 
 ### Anthropic-specific Options
 
+These apply when the active provider (or a role provider) is `anthropic`. Each option also has a matching `CHUNKHOUND_LLM_ANTHROPIC_<OPTION>` environment variable (single underscore, uppercased).
+
 | Option | Type | Default | Description |
 |---|---|---|---|
-| `anthropic_thinking_enabled` | `boolean` | `false` | Enable extended thinking |
-| `anthropic_thinking_budget_tokens` | `number` | `10000` | Token budget for thinking (min 1024) |
-| `anthropic_interleaved_thinking` | `boolean` | `false` | Interleaved thinking for tool use (Claude 4+) |
-| `anthropic_effort` | `string` | `null` | Effort parameter: `low`, `medium`, `high`, `xhigh`, `max` (higher levels are model-gated; see provider docs) |
+| `anthropic_thinking_enabled` | `boolean` | `false` | Enable extended thinking. |
+| `anthropic_thinking_mode` | `string` | `null` | `auto` (default when unset), `off`, `manual`, or `adaptive`. `auto` selects adaptive on Opus 4.6+/Sonnet 4.6 and manual on older models. |
+| `anthropic_thinking_budget_tokens` | `number` | `10000` | Manual-mode thinking budget (min 1024). Ignored in adaptive mode (Opus 4.6+). |
+| `anthropic_thinking_display` | `string` | `null` | Adaptive-mode thinking text: `summarized` or `omitted`. Opus 4.7/4.8 omit by default. |
+| `anthropic_interleaved_thinking` | `boolean` | `false` | Manual-mode interleaved thinking between tool calls. Auto-enabled in adaptive mode. |
+| `anthropic_effort` | `string` | `null` | Token-usage effort: `low`, `medium`, `high`, `xhigh`, `max`. `xhigh` is Opus 4.7/4.8 only; `max` is Opus 4.6+. Unsupported levels are dropped with a warning. |
+| `anthropic_task_budget_tokens` | `number` | `null` | Advisory agentic-loop token budget (beta). Opus 4.7/4.8 only; minimum 20000. |
+| `anthropic_prompt_caching` | `boolean` | `false` | Send `cache_control` so the Messages API can cache prompt prefixes. |
+| `anthropic_cache_ttl` | `string` | `null` | Prompt-cache TTL such as `1h`. `null` uses the API default of 5 minutes. |
+| `anthropic_context_management_enabled` | `boolean` | `false` | Automatic clearing of tool results and thinking blocks (beta). |
+| `anthropic_clear_thinking_keep_turns` | `number` | `null` | Thinking turns to keep when context management clears them. `null` keeps all. |
+| `anthropic_clear_tool_uses_trigger_tokens` | `number` | `null` | Input-token threshold that triggers tool-result clearing. |
+| `anthropic_clear_tool_uses_keep` | `number` | `null` | Number of recent tool-use pairs to keep after clearing. |
 
 ## Research Configuration
 

--- a/site/src/pages/docs/configuration.md
+++ b/site/src/pages/docs/configuration.md
@@ -181,7 +181,7 @@ When an OpenAI-compatible LLM provider points at a custom `base_url`, ChunkHound
 | `anthropic_thinking_enabled` | `boolean` | `false` | Enable extended thinking |
 | `anthropic_thinking_budget_tokens` | `number` | `10000` | Token budget for thinking (min 1024) |
 | `anthropic_interleaved_thinking` | `boolean` | `false` | Interleaved thinking for tool use (Claude 4+) |
-| `anthropic_effort` | `string` | `null` | Effort parameter: `low`, `medium`, `high` |
+| `anthropic_effort` | `string` | `null` | Effort parameter: `low`, `medium`, `high`, `xhigh`, `max` (higher levels are model-gated; see provider docs) |
 
 ## Research Configuration
 

--- a/tests/manual/README.md
+++ b/tests/manual/README.md
@@ -67,9 +67,9 @@ TEST SUMMARY
 
 - ChunkHound intentionally defaults both Anthropic utility and synthesis roles to the `claude-haiku` sentinel. Haiku is capable enough for synthesis, is Anthropic's cheapest available Claude model, and Anthropic does not currently offer a true low-cost utility tier.
 - Extended thinking has two modes:
-  - Adaptive (Claude Opus 4.7, Opus 4.6, Sonnet 4.6, Mythos). No budget_tokens needed. Auto-enables interleaved thinking.
+  - Adaptive (Claude Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Mythos). No budget_tokens needed. Auto-enables interleaved thinking.
   - Manual (Opus 4.5 and older Claude 4 models). Requires thinking.budget_tokens of at least 1024.
-- Opus 4.7 accepts only adaptive thinking; manual is rejected with a 400 error.
-- The effort parameter (low/medium/high/xhigh/max) is supported on Opus 4.5/4.6/4.7, Sonnet 4.6, and Mythos. xhigh is Opus 4.7 only; max is 4.6 and later.
+- Opus 4.7 and 4.8 accept only adaptive thinking; manual is rejected with a 400 error.
+- The effort parameter (low/medium/high/xhigh/max) is supported on Opus 4.5/4.6/4.7/4.8, Sonnet 4.6, and Mythos. xhigh is Opus 4.7/4.8; max is 4.6 and later.
 - Thinking blocks are processed but not included in text output by default.
 - Token usage includes full thinking tokens (not just summary) for billing.

--- a/tests/test_anthropic_provider.py
+++ b/tests/test_anthropic_provider.py
@@ -1277,6 +1277,13 @@ class TestLLMConfigEnvLoading:
 class TestLLMConfigDefaults:
     """Pin default model selection."""
 
+    @pytest.fixture(autouse=True)
+    def _isolate_env(self, clean_environment):
+        # Default resolution must not depend on the developer's ambient
+        # CHUNKHOUND_* / provider-key env. clean_environment (conftest) strips
+        # it so this class behaves identically locally and in CI.
+        yield
+
     def test_anthropic_prompt_caching_default_disabled(self):
         from chunkhound.core.config.llm_config import LLMConfig
 

--- a/tests/test_anthropic_provider.py
+++ b/tests/test_anthropic_provider.py
@@ -1836,6 +1836,65 @@ class TestRequestShape:
         assert "betas" not in kwargs
 
     @pytest.mark.asyncio
+    async def test_opus_48_emits_adaptive_thinking_and_xhigh_effort(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        provider = AnthropicLLMProvider(
+            api_key="test-key",
+            model="claude-opus-4-8",
+            thinking_enabled=True,
+            effort="xhigh",
+        )
+        provider._client.messages = MagicMock()
+        provider._client.messages.create = AsyncMock(
+            return_value=self._text_response(),
+        )
+        provider._client.beta = MagicMock()
+        provider._client.beta.messages = MagicMock()
+        provider._client.beta.messages.create = AsyncMock(
+            return_value=self._text_response(),
+        )
+
+        await provider.complete("hello")
+
+        # Plain adaptive request: no beta features, so the standard endpoint.
+        assert provider._client.beta.messages.create.call_args is None
+        kwargs = provider._client.messages.create.call_args.kwargs
+        assert kwargs["model"] == "claude-opus-4-8"
+        # Opus 4.8 is adaptive-only; auto thinking must go out as adaptive.
+        assert kwargs["thinking"] == {"type": "adaptive"}
+        # xhigh is a 4.7/4.8-only effort level and must reach output_config.
+        assert kwargs["output_config"] == {"effort": "xhigh"}
+
+    @pytest.mark.asyncio
+    async def test_opus_48_manual_thinking_falls_back_to_adaptive(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        provider = AnthropicLLMProvider(
+            api_key="test-key",
+            model="claude-opus-4-8",
+            thinking_enabled=True,
+            thinking_mode="manual",
+            thinking_budget_tokens=8000,
+        )
+        provider._client.messages = MagicMock()
+        provider._client.messages.create = AsyncMock(
+            return_value=self._text_response(),
+        )
+        provider._client.beta = MagicMock()
+        provider._client.beta.messages = MagicMock()
+        provider._client.beta.messages.create = AsyncMock(
+            return_value=self._text_response(),
+        )
+
+        await provider.complete("hello")
+
+        # Opus 4.8 rejects thinking.type=enabled, so a manual/budgeted request
+        # must go out as adaptive (no budget_tokens), not the enabled shape.
+        kwargs = provider._client.messages.create.call_args.kwargs
+        assert kwargs["thinking"] == {"type": "adaptive"}
+
+    @pytest.mark.asyncio
     async def test_complete_with_tools_routes_strict_tools_to_beta(self):
         from unittest.mock import AsyncMock, MagicMock
 


### PR DESCRIPTION
## Summary

Adds Claude Opus 4.8 to the Anthropic provider, following #261 which added the 4.6/4.7 generation. Opus 4.8 is adaptive-only like Opus 4.7, so without this change `claude-opus-4-8` fell through to the manual-thinking default and the API rejected thinking-enabled requests with `400 "thinking.type.enabled is not supported for this model"`.

## What changed

**Capability detection**
- Added `claude-opus-4-8` to every capability family: `_ADAPTIVE_THINKING_PREFIXES`, `_ADAPTIVE_ONLY_PREFIXES`, `_EFFORT_FAMILY_PREFIXES`, `_MAX_EFFORT_PREFIXES`, `_XHIGH_EFFORT_PREFIXES`, and `_TASK_BUDGET_PREFIXES`. This gives 4.8 full Opus 4.7 parity: adaptive-only thinking, effort through `xhigh`/`max`, and task budgets.
- Prefix matching already covers the stable alias and dated variants (`claude-opus-4-8-20260601`).

**Defaults**
- Pinned `claude-opus` offline fallback moved to `claude-opus-4-8` (from `claude-opus-4-7`). Discovery still prefers the newest available model; this only changes the offline fallback.

**Docs**
- Documented the full set of Anthropic LLM options in `configuration.md`; the table previously listed only four.

**Tests**
- New request-shape tests assert a 4.8 request emits `thinking.type=adaptive` and honors `xhigh`, and that a manual or budgeted 4.8 request falls back to adaptive instead of the rejected `enabled` shape.
- `TestLLMConfigDefaults` now opts into the existing `clean_environment` fixture so default-resolution assertions no longer depend on ambient `CHUNKHOUND_LLM_*` env. Scoped to that class so CI-only vars stay intact.

## Breaking changes

- Default `claude-opus` offline fallback changed from `claude-opus-4-7` to `claude-opus-4-8`. Affects only setups where API model discovery is disabled or unavailable; explicit model names and discovery are unaffected.
