### PR TITLE
Make depth exploration token budget configurable

### DIFF
--- a/chunkhound/core/config/research_config.py
+++ b/chunkhound/core/config/research_config.py
@@ -25,8 +25,8 @@ _DEFAULT_MAX_CHUNKS_PER_FILE_REPR = 5
 _DEFAULT_MAX_TOKENS_PER_FILE_REPR = 2000
 _DEFAULT_QUERY_EXPANSION_ENABLED = True
 _DEFAULT_NUM_EXPANDED_QUERIES = 2
-# Preserve the previous query-expansion utility budget as the default.
-_DEFAULT_EXPLORATION_QUERY_GENERATION_MAX_COMPLETION_TOKENS = 10_000
+# Use the query-expansion utility budget as the depth exploration default.
+_DEFAULT_DEPTH_EXPLORATION_MAX_COMPLETION_TOKENS = 10_000
 
 
 class ResearchConfig(BaseSettings):
@@ -43,7 +43,7 @@ class ResearchConfig(BaseSettings):
         CHUNKHOUND_RESEARCH_ALGORITHM=v2
         CHUNKHOUND_RESEARCH_QUERY_EXPANSION_ENABLED=true
         CHUNKHOUND_RESEARCH_NUM_EXPANDED_QUERIES=2
-        CHUNKHOUND_RESEARCH_EXPLORATION_QUERY_GENERATION_MAX_COMPLETION_TOKENS=10000
+        CHUNKHOUND_RESEARCH_DEPTH_EXPLORATION_MAX_COMPLETION_TOKENS=10000
         CHUNKHOUND_RESEARCH_EXHAUSTIVE_MODE=false
     """
 
@@ -178,8 +178,8 @@ class ResearchConfig(BaseSettings):
         description="Number of aspect-based queries to generate per file",
     )
 
-    exploration_query_generation_max_completion_tokens: int = Field(
-        default=_DEFAULT_EXPLORATION_QUERY_GENERATION_MAX_COMPLETION_TOKENS,
+    depth_exploration_max_completion_tokens: int = Field(
+        default=_DEFAULT_DEPTH_EXPLORATION_MAX_COMPLETION_TOKENS,
         ge=1,
         le=50_000,
         description=(
@@ -430,9 +430,9 @@ class ResearchConfig(BaseSettings):
             config["exploration_queries_per_file"] = int(exp_queries)
 
         if exp_query_tokens := os.getenv(
-            "CHUNKHOUND_RESEARCH_EXPLORATION_QUERY_GENERATION_MAX_COMPLETION_TOKENS"
+            "CHUNKHOUND_RESEARCH_DEPTH_EXPLORATION_MAX_COMPLETION_TOKENS"
         ):
-            config["exploration_query_generation_max_completion_tokens"] = int(
+            config["depth_exploration_max_completion_tokens"] = int(
                 exp_query_tokens
             )
 

--- a/chunkhound/core/config/research_config.py
+++ b/chunkhound/core/config/research_config.py
@@ -25,6 +25,8 @@ _DEFAULT_MAX_CHUNKS_PER_FILE_REPR = 5
 _DEFAULT_MAX_TOKENS_PER_FILE_REPR = 2000
 _DEFAULT_QUERY_EXPANSION_ENABLED = True
 _DEFAULT_NUM_EXPANDED_QUERIES = 2
+# Preserve the previous query-expansion utility budget as the default.
+_DEFAULT_EXPLORATION_QUERY_GENERATION_MAX_COMPLETION_TOKENS = 10_000
 
 
 class ResearchConfig(BaseSettings):
@@ -41,6 +43,7 @@ class ResearchConfig(BaseSettings):
         CHUNKHOUND_RESEARCH_ALGORITHM=v2
         CHUNKHOUND_RESEARCH_QUERY_EXPANSION_ENABLED=true
         CHUNKHOUND_RESEARCH_NUM_EXPANDED_QUERIES=2
+        CHUNKHOUND_RESEARCH_EXPLORATION_QUERY_GENERATION_MAX_COMPLETION_TOKENS=10000
         CHUNKHOUND_RESEARCH_EXHAUSTIVE_MODE=false
     """
 
@@ -173,6 +176,16 @@ class ResearchConfig(BaseSettings):
         ge=1,
         le=3,
         description="Number of aspect-based queries to generate per file",
+    )
+
+    exploration_query_generation_max_completion_tokens: int = Field(
+        default=_DEFAULT_EXPLORATION_QUERY_GENERATION_MAX_COMPLETION_TOKENS,
+        ge=1,
+        le=50_000,
+        description=(
+            "Maximum completion token budget for depth exploration query generation "
+            "(includes reasoning tokens for thinking models)"
+        ),
     )
 
     # Phase 2: Gap Detection Parameters
@@ -415,6 +428,13 @@ class ResearchConfig(BaseSettings):
 
         if exp_queries := os.getenv("CHUNKHOUND_RESEARCH_EXPLORATION_QUERIES_PER_FILE"):
             config["exploration_queries_per_file"] = int(exp_queries)
+
+        if exp_query_tokens := os.getenv(
+            "CHUNKHOUND_RESEARCH_EXPLORATION_QUERY_GENERATION_MAX_COMPLETION_TOKENS"
+        ):
+            config["exploration_query_generation_max_completion_tokens"] = int(
+                exp_query_tokens
+            )
 
         if min_gaps := os.getenv("CHUNKHOUND_RESEARCH_MIN_GAPS"):
             config["min_gaps"] = int(min_gaps)

--- a/chunkhound/services/research/shared/depth_exploration.py
+++ b/chunkhound/services/research/shared/depth_exploration.py
@@ -45,6 +45,7 @@ from chunkhound.services.research.shared.import_resolution_helper import (
 )
 from chunkhound.services.research.shared.models import (
     IMPORT_DEFAULT_SCORE,
+    QUERY_EXPANSION_TOKENS,
     ResearchContext,
 )
 from chunkhound.services.research.shared.unified_search import UnifiedSearch
@@ -394,7 +395,7 @@ Output JSON with queries array."""
             result = await llm.complete_structured(
                 prompt=prompt,
                 json_schema=schema,
-                max_completion_tokens=512,
+                max_completion_tokens=QUERY_EXPANSION_TOKENS,
             )
 
             queries: list[str] = result.get("queries", [])

--- a/chunkhound/services/research/shared/depth_exploration.py
+++ b/chunkhound/services/research/shared/depth_exploration.py
@@ -395,7 +395,7 @@ Output JSON with queries array."""
                 prompt=prompt,
                 json_schema=schema,
                 max_completion_tokens=(
-                    self._config.exploration_query_generation_max_completion_tokens
+                    self._config.depth_exploration_max_completion_tokens
                 ),
             )
 

--- a/chunkhound/services/research/shared/depth_exploration.py
+++ b/chunkhound/services/research/shared/depth_exploration.py
@@ -45,7 +45,6 @@ from chunkhound.services.research.shared.import_resolution_helper import (
 )
 from chunkhound.services.research.shared.models import (
     IMPORT_DEFAULT_SCORE,
-    QUERY_EXPANSION_TOKENS,
     ResearchContext,
 )
 from chunkhound.services.research.shared.unified_search import UnifiedSearch
@@ -395,7 +394,9 @@ Output JSON with queries array."""
             result = await llm.complete_structured(
                 prompt=prompt,
                 json_schema=schema,
-                max_completion_tokens=QUERY_EXPANSION_TOKENS,
+                max_completion_tokens=(
+                    self._config.exploration_query_generation_max_completion_tokens
+                ),
             )
 
             queries: list[str] = result.get("queries", [])

--- a/site/src/pages/docs/configuration.md
+++ b/site/src/pages/docs/configuration.md
@@ -219,6 +219,7 @@ Controls the `code_research` MCP tool and `chunkhound research` command.
 | `multi_hop_result_limit` | `number` | `500` | `CHUNKHOUND_RESEARCH_MULTI_HOP_RESULT_LIMIT` | Max accumulated chunks |
 | `target_tokens` | `number` | `20000` | `CHUNKHOUND_RESEARCH_TARGET_TOKENS` | Output token budget for synthesis |
 | `query_expansion_enabled` | `bool` | `true` | `CHUNKHOUND_RESEARCH_QUERY_EXPANSION_ENABLED` | LLM-based query expansion |
+| `exploration_query_generation_max_completion_tokens` | `number` | `10000` | `CHUNKHOUND_RESEARCH_EXPLORATION_QUERY_GENERATION_MAX_COMPLETION_TOKENS` | Completion/reasoning token budget for depth exploration query generation |
 | `relevance_threshold` | `number` | `0.5` | `CHUNKHOUND_RESEARCH_RELEVANCE_THRESHOLD` | Min rerank score for inclusion |
 
 ```json
@@ -228,6 +229,7 @@ Controls the `code_research` MCP tool and `chunkhound research` command.
     "exhaustive_mode": false,
     "target_tokens": 20000,
     "query_expansion_enabled": true,
+    "exploration_query_generation_max_completion_tokens": 10000,
     "relevance_threshold": 0.5
   }
 }

--- a/site/src/pages/docs/configuration.md
+++ b/site/src/pages/docs/configuration.md
@@ -219,7 +219,7 @@ Controls the `code_research` MCP tool and `chunkhound research` command.
 | `multi_hop_result_limit` | `number` | `500` | `CHUNKHOUND_RESEARCH_MULTI_HOP_RESULT_LIMIT` | Max accumulated chunks |
 | `target_tokens` | `number` | `20000` | `CHUNKHOUND_RESEARCH_TARGET_TOKENS` | Output token budget for synthesis |
 | `query_expansion_enabled` | `bool` | `true` | `CHUNKHOUND_RESEARCH_QUERY_EXPANSION_ENABLED` | LLM-based query expansion |
-| `exploration_query_generation_max_completion_tokens` | `number` | `10000` | `CHUNKHOUND_RESEARCH_EXPLORATION_QUERY_GENERATION_MAX_COMPLETION_TOKENS` | Completion/reasoning token budget for depth exploration query generation |
+| `depth_exploration_max_completion_tokens` | `number` | `10000` | `CHUNKHOUND_RESEARCH_DEPTH_EXPLORATION_MAX_COMPLETION_TOKENS` | Completion/reasoning token budget for depth exploration query generation |
 | `relevance_threshold` | `number` | `0.5` | `CHUNKHOUND_RESEARCH_RELEVANCE_THRESHOLD` | Min rerank score for inclusion |
 
 ```json
@@ -229,7 +229,7 @@ Controls the `code_research` MCP tool and `chunkhound research` command.
     "exhaustive_mode": false,
     "target_tokens": 20000,
     "query_expansion_enabled": true,
-    "exploration_query_generation_max_completion_tokens": 10000,
+    "depth_exploration_max_completion_tokens": 10000,
     "relevance_threshold": 0.5
   }
 }

--- a/tests/unit/research/shared/test_depth_exploration.py
+++ b/tests/unit/research/shared/test_depth_exploration.py
@@ -464,6 +464,37 @@ class TestGenerateExplorationQueries:
         ]
 
     @pytest.mark.asyncio
+    async def test_uses_configured_query_generation_token_budget(
+        self, depth_service, fake_llm_provider
+    ):
+        """Should pass configured completion budget to query-generation LLM call."""
+        depth_service._config.exploration_query_generation_max_completion_tokens = (
+            12_345
+        )
+        fragments = [
+            {"chunk_id": "c1", "content": "def main(): pass", "file_path": "test.py"}
+        ]
+        captured: dict[str, int] = {}
+        original_complete = fake_llm_provider.complete_structured
+
+        async def capturing_complete(*args, **kwargs):
+            captured["max_completion_tokens"] = kwargs["max_completion_tokens"]
+            return {"queries": ["How does initialization work?"]}
+
+        fake_llm_provider.complete_structured = capturing_complete
+
+        try:
+            await depth_service._generate_exploration_queries(
+                root_query="How does the system work?",
+                fragments=fragments,
+                file_path="test.py",
+            )
+        finally:
+            fake_llm_provider.complete_structured = original_complete
+
+        assert captured["max_completion_tokens"] == 12_345
+
+    @pytest.mark.asyncio
     async def test_returns_empty_on_llm_failure(self, depth_service, fake_llm_provider):
         """Should return empty list on LLM failure."""
         # Make LLM raise exception

--- a/tests/unit/research/shared/test_depth_exploration.py
+++ b/tests/unit/research/shared/test_depth_exploration.py
@@ -468,7 +468,7 @@ class TestGenerateExplorationQueries:
         self, depth_service, fake_llm_provider
     ):
         """Should pass configured completion budget to query-generation LLM call."""
-        depth_service._config.exploration_query_generation_max_completion_tokens = (
+        depth_service._config.depth_exploration_max_completion_tokens = (
             12_345
         )
         fragments = [

--- a/tests/unit/test_research_config.py
+++ b/tests/unit/test_research_config.py
@@ -1,0 +1,23 @@
+"""Unit tests for research configuration parsing."""
+
+import pytest
+
+from chunkhound.core.config.research_config import ResearchConfig
+
+
+def test_load_from_env_parses_exploration_query_generation_token_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "CHUNKHOUND_RESEARCH_EXPLORATION_QUERY_GENERATION_MAX_COMPLETION_TOKENS",
+        "12345",
+    )
+
+    config = ResearchConfig.load_from_env()
+
+    assert config["exploration_query_generation_max_completion_tokens"] == 12345
+
+
+def test_exploration_query_generation_token_budget_is_positive() -> None:
+    with pytest.raises(ValueError):
+        ResearchConfig(exploration_query_generation_max_completion_tokens=0)

--- a/tests/unit/test_research_config.py
+++ b/tests/unit/test_research_config.py
@@ -5,19 +5,19 @@ import pytest
 from chunkhound.core.config.research_config import ResearchConfig
 
 
-def test_load_from_env_parses_exploration_query_generation_token_budget(
+def test_load_from_env_parses_depth_exploration_token_budget(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv(
-        "CHUNKHOUND_RESEARCH_EXPLORATION_QUERY_GENERATION_MAX_COMPLETION_TOKENS",
+        "CHUNKHOUND_RESEARCH_DEPTH_EXPLORATION_MAX_COMPLETION_TOKENS",
         "12345",
     )
 
     config = ResearchConfig.load_from_env()
 
-    assert config["exploration_query_generation_max_completion_tokens"] == 12345
+    assert config["depth_exploration_max_completion_tokens"] == 12345
 
 
-def test_exploration_query_generation_token_budget_is_positive() -> None:
+def test_depth_exploration_token_budget_is_positive() -> None:
     with pytest.raises(ValueError):
-        ResearchConfig(exploration_query_generation_max_completion_tokens=0)
+        ResearchConfig(depth_exploration_max_completion_tokens=0)


### PR DESCRIPTION
## Summary
Depth exploration query generation now has enough completion headroom to avoid silent truncation, while exposing a research configuration knob so users can tune the budget for their model and cost/latency needs.

## Requirements
- Prevent depth exploration query generation from being capped at the old 512-token completion limit.
- Keep the default budget aligned with the existing query-expansion utility budget.
- Let users configure the depth exploration completion/reasoning-token budget without code changes.

## Acceptance criteria
- Depth exploration query-generation calls use a configurable completion budget instead of a hardcoded 512-token cap.
- The default budget is 10,000 completion tokens.
- Environment configuration can override the budget.
- Invalid non-positive budgets are rejected.
- Documentation lists the new research configuration option.

## Contract changes
- Adds research config key `depth_exploration_max_completion_tokens` with default `10000`.
- Adds environment variable `CHUNKHOUND_RESEARCH_DEPTH_EXPLORATION_MAX_COMPLETION_TOKENS`.
- The setting controls the completion/reasoning-token budget for depth exploration query generation only.

## How to verify
- `uv run pytest tests/unit/test_research_config.py tests/unit/research/shared/test_depth_exploration.py -q`
- `uv run pytest tests/test_smoke.py -v -n auto`
- `uv run pytest tests/ -q`
