### PR TITLE
feat(config): add support for global configuration file

### DIFF
--- a/chunkhound/api/cli/commands/run.py
+++ b/chunkhound/api/cli/commands/run.py
@@ -135,6 +135,8 @@ async def run_command(args: argparse.Namespace, config: Config) -> None:
     local_config_path = project_dir / ".chunkhound.json"
     if local_config_path.exists():
         formatter.info(f"Found local config: {local_config_path}")
+    if getattr(config, "global_config_file", None):
+        formatter.info(f"Found global config: {config.global_config_file}")
 
     # Use database path from config
     db_path = Path(config.database.path)

--- a/chunkhound/core/config/config.py
+++ b/chunkhound/core/config/config.py
@@ -192,7 +192,7 @@ class Config(BaseModel):
         if target_dir and target_dir.exists():
             local_config_path = target_dir / ".chunkhound.json"
             if local_config_path.exists() and local_config_path != config_file:
-                config_data["local_config_file"] = local_config_path
+                config_data["local_config_file"] = local_config_path.resolve()
                 try:
                     with open(local_config_path) as f:
                         local_config = json.load(f)
@@ -357,6 +357,19 @@ class Config(BaseModel):
             # Ensure target_dir is resolved to canonical path (handles symlinks)
             # Use object.__setattr__ to avoid Pydantic validation recursion
             object.__setattr__(self, "target_dir", self.target_dir.resolve())
+
+        # Ensure the tracked config file paths are also resolved to canonical form.
+        # This handles Windows short names (8.3 like RUNNER~1), symlinks, and
+        # any differences in how temp dirs / constructed Paths are represented
+        # before vs after .resolve().
+        for field_name in ("local_config_file", "global_config_file", "config_file"):
+            val = getattr(self, field_name, None)
+            if val is not None:
+                try:
+                    object.__setattr__(self, field_name, val.resolve())
+                except Exception:
+                    # Best effort; leave as-is if resolve is not possible.
+                    pass
 
         # Ensure database path is set
         if not self.database.path:

--- a/chunkhound/core/config/config.py
+++ b/chunkhound/core/config/config.py
@@ -4,8 +4,14 @@ This module provides a unified configuration system with clear precedence:
 1. CLI arguments (highest priority)
 2. Explicit config file (via --config path or CHUNKHOUND_CONFIG_FILE)
 3. Local .chunkhound.json in target directory
-4. Environment variables
-5. Default values (lowest priority)
+4. Global defaults (CHUNKHOUND_GLOBAL_CONFIG_FILE or auto-discovered under
+   ~/.config/chunkhound/ or ~/.chunkhound/)
+5. Environment variables
+6. Default values (lowest priority)
+
+Global config support means you can maintain common settings (API keys,
+indexing rules, etc.) in one place instead of copying .chunkhound.json
+to every project directory. Project-local files override the global layer.
 """
 
 import json
@@ -24,7 +30,17 @@ from .research_config import ResearchConfig
 
 
 class Config(BaseModel):
-    """Centralized configuration for ChunkHound."""
+    """Centralized configuration for ChunkHound.
+
+    Precedence (highest first):
+    1. CLI arguments
+    2. Explicit config file (--config or CHUNKHOUND_CONFIG_FILE)
+    3. Local .chunkhound.json in target directory
+    4. Global defaults (CHUNKHOUND_GLOBAL_CONFIG_FILE or
+       ~/.config/chunkhound/*.json etc.)
+    5. Environment variables (CHUNKHOUND_*)
+    6. Defaults
+    """
 
     model_config = ConfigDict(validate_assignment=True)
 
@@ -42,8 +58,29 @@ class Config(BaseModel):
     embeddings_disabled: bool = Field(default=False, exclude=True)
     # Private field to store the auto-discovered local .chunkhound.json path
     local_config_file: Path | None = Field(default=None, exclude=True)
+    # Private field to store the global defaults config path
+    # (from home or CHUNKHOUND_GLOBAL_CONFIG_FILE)
+    global_config_file: Path | None = Field(default=None, exclude=True)
     # Private field to store the explicit --config path (absolute) when provided
     config_file: Path | None = Field(default=None, exclude=True)
+
+    @staticmethod
+    def _get_global_config_candidates() -> list[Path]:
+        """Return preferred locations for global/user defaults config files.
+
+        These provide defaults that apply across projects without needing
+        a .chunkhound.json in every directory. Project-local .chunkhound.json
+        (and explicit --config) override values from global configs.
+        """
+        home = Path.home()
+        return [
+            home / ".config" / "chunkhound" / "chunkhound.json",
+            home / ".config" / "chunkhound" / ".chunkhound.json",
+            home / ".chunkhound" / "chunkhound.json",
+            home / ".chunkhound" / ".chunkhound.json",
+            home / "chunkhound.json",
+            home / ".chunkhound.json",
+        ]
 
     def __init__(self, args: Any | None = None, **kwargs: Any) -> None:
         """Universal configuration initialization that handles all contexts.
@@ -52,8 +89,14 @@ class Config(BaseModel):
         1. CLI arguments (highest priority)
         2. Explicit config file (via --config path or CHUNKHOUND_CONFIG_FILE)
         3. Local .chunkhound.json in target directory
-        4. Environment variables
-        5. Default values (lowest priority)
+        4. Global defaults config (CHUNKHOUND_GLOBAL_CONFIG_FILE or discovered in
+           ~/.config/chunkhound/ or ~/.chunkhound/)
+        5. Environment variables
+        6. Default values (lowest priority)
+
+        Global config enables one set of defaults (e.g. embedding provider + key,
+        common excludes) without copying .chunkhound.json into every project.
+        Local project config and explicit/CLI always override globals.
 
         Args:
             args: Optional argparse.Namespace from command line parsing
@@ -112,7 +155,40 @@ class Config(BaseModel):
         env_vars = self._load_env_vars()
         self._deep_merge(config_data, env_vars)
 
-        # 3. Check for local .chunkhound.json in target directory (overrides env vars)
+        # 2.5 Load global defaults config (env var or auto-discovered).
+        # Merged before local so project-local .chunkhound.json overrides globals.
+        # Lets users keep common settings (keys, excludes) in one place instead
+        # of copying .chunkhound.json into every project.
+        global_config_file = None
+        env_global = os.getenv("CHUNKHOUND_GLOBAL_CONFIG_FILE")
+        if env_global:
+            global_config_file = Path(env_global)
+            if not global_config_file.exists():
+                raise ValueError(
+                    f"Global config file not found: {global_config_file}. "
+                    "Check the path or remove CHUNKHOUND_GLOBAL_CONFIG_FILE."
+                )
+            config_data["global_config_file"] = global_config_file.resolve()
+        else:
+            for candidate in self._get_global_config_candidates():
+                if candidate.exists() and candidate.is_file():
+                    global_config_file = candidate
+                    config_data["global_config_file"] = global_config_file.resolve()
+                    break
+
+        if global_config_file:
+            try:
+                with open(global_config_file) as f:
+                    global_config = json.load(f)
+                    self._deep_merge(config_data, global_config)
+                    self._mark_exclude_user_supplied(config_data)
+            except json.JSONDecodeError as e:
+                raise ValueError(
+                    f"Invalid JSON in global config file {global_config_file}: {e}. "
+                    "Please check the file format and try again."
+                )
+
+        # 3. Check for local .chunkhound.json (overrides env vars and globals)
         if target_dir and target_dir.exists():
             local_config_path = target_dir / ".chunkhound.json"
             if local_config_path.exists() and local_config_path != config_file:

--- a/site/src/pages/docs/configuration.md
+++ b/site/src/pages/docs/configuration.md
@@ -14,6 +14,86 @@ ChunkHound is configured through a JSON file, environment variables, and CLI fla
 
 Create `.chunkhound.json` in your project root. Here is a full example showing all sections:
 
+### Global Defaults (cross-project configuration)
+
+To avoid copying the same settings into every project, place a global config in one of these locations (checked in order):
+
+- `~/.config/chunkhound/chunkhound.json`
+- `~/.config/chunkhound/.chunkhound.json`
+- `~/.chunkhound/chunkhound.json`
+- `~/.chunkhound/.chunkhound.json`
+- `~/chunkhound.json`
+- `~/.chunkhound.json`
+
+You can also point to an arbitrary file with the `CHUNKHOUND_GLOBAL_CONFIG_FILE` environment variable.
+
+Example global config (`~/.config/chunkhound/chunkhound.json`):
+
+```json
+{
+  "embedding": {
+    "provider": "voyageai",
+    "model": "voyage-3.5"
+  },
+  "llm": {
+    "provider": "anthropic"
+  },
+  "indexing": {
+    "exclude": ["**/node_modules/**", "**/.git/**", "**/dist/**"]
+  }
+}
+```
+
+Then in a specific project you only need a minimal `.chunkhound.json` for project-specific overrides (or nothing at all if the globals are sufficient):
+
+```json
+{
+  "embedding": {
+    "api_key": "sk-..."   // only the key differs per machine
+  }
+}
+```
+
+Global values are deep-merged; project files win for any keys they specify.
+
+Merging behavior:
+
+- **Nested objects** (`embedding`, `llm`, `research`, `database`, etc.): deep merge. You only need to specify the keys you want to change in a higher-priority file (local, explicit config, or CLI). Siblings from global (or lower layers) are preserved. This lets a project override just an `api_key`, switch `llm.model`, or change `research.algorithm` without losing other global settings.
+
+- **Lists** (`indexing.exclude`, `indexing.include`): the list supplied by the higher-priority source completely replaces any list from a lower layer (including global). ChunkHound's built-in safe defaults are still layered on top of your list in the *effective* excludes (see `get_effective_config_excludes()`), and `.gitignore` interaction is controlled by `exclude_mode`.
+
+Example — project overrides only the secret while inheriting provider + model from global (or switches providers entirely):
+
+```json
+{
+  "embedding": {
+    "api_key": "sk-..."
+  }
+}
+```
+
+or to use a completely different provider for this project:
+
+```json
+{
+  "embedding": {
+    "provider": "openai",
+    "model": "text-embedding-3-large",
+    "api_key": "sk-..."
+  }
+}
+```
+
+Example — project uses its own exclude list (replaces global's list at the raw config level):
+
+```json
+{
+  "indexing": {
+    "exclude": ["**/my-vendor/**", "**/generated/**"]
+  }
+}
+```
+
 ```json
 {
   "database": {
@@ -48,8 +128,11 @@ Settings are resolved in this order (highest priority first):
 1. **CLI arguments** -- flags passed directly on the command line
 2. **Config file** -- loaded via `--config` or `CHUNKHOUND_CONFIG_FILE`
 3. **Local `.chunkhound.json`** -- auto-detected in the target directory
-4. **Environment variables** -- `CHUNKHOUND_*` prefixed variables
-5. **Defaults** -- built-in fallback values
+4. **Global defaults** -- `CHUNKHOUND_GLOBAL_CONFIG_FILE` or auto-discovered in `~/.config/chunkhound/` (or `~/.chunkhound/`)
+5. **Environment variables** -- `CHUNKHOUND_*` prefixed variables
+6. **Defaults** -- built-in fallback values
+
+Global defaults let you maintain shared settings (e.g. embedding provider + API key, common exclude patterns, LLM roles) in a single file so you do not need to copy `.chunkhound.json` into every project. Any project-local `.chunkhound.json` (or explicit config/CLI) overrides values from the global layer. Nested objects (embedding, llm, research, database, ...) are deep-merged: specify only the keys you want to change and siblings from global survive. Lists such as `indexing.exclude` / `include` from a higher layer fully replace lower ones (built-in defaults are still applied on top; see Global Defaults above for details and examples).
 
 ## Embedding Providers
 

--- a/tests/test_config_integration.py
+++ b/tests/test_config_integration.py
@@ -19,7 +19,12 @@ from chunkhound.core.config.embedding_config import EmbeddingConfig
 from chunkhound.core.config.llm_config import LLMConfig
 from chunkhound.utils.windows_constants import IS_WINDOWS, WINDOWS_FILE_HANDLE_DELAY
 from chunkhound.registry import configure_registry, get_registry
-from tests.utils.windows_compat import database_cleanup_context, cleanup_database_resources, windows_safe_tempdir
+from tests.utils.windows_compat import (
+    cleanup_database_resources,
+    database_cleanup_context,
+    paths_equal,
+    windows_safe_tempdir,
+)
 
 
 def _cleanup_registry_and_connections():
@@ -549,8 +554,8 @@ def test_global_config_provides_defaults_and_is_overridden_by_local(monkeypatch,
         monkeypatch.setenv("CHUNKHOUND_GLOBAL_CONFIG_FILE", str(global_cfg))
 
         c = Config(target_dir=td)
-        assert c.global_config_file == global_cfg.resolve()
-        assert c.local_config_file == local_cfg.resolve()
+        assert paths_equal(c.global_config_file, global_cfg)
+        assert paths_equal(c.local_config_file, local_cfg)
         assert c.embedding is not None
         assert c.embedding.api_key.get_secret_value() == "lkey"  # local overrides
         assert c.embedding.model == "gmodel"  # from global
@@ -652,5 +657,5 @@ def test_global_local_deep_merge_partial_overrides_and_list_replacement(
         )
 
         # global_config_file / local_config_file still recorded
-        assert c.global_config_file == global_cfg.resolve()
-        assert c.local_config_file == local_cfg.resolve()
+        assert paths_equal(c.global_config_file, global_cfg)
+        assert paths_equal(c.local_config_file, local_cfg)

--- a/tests/test_config_integration.py
+++ b/tests/test_config_integration.py
@@ -358,7 +358,7 @@ def test_azure_api_version_accepts_valid_formats() -> None:
 def test_local_config_overrides_env_vars(monkeypatch, clean_environment):
     """Local .chunkhound.json must override environment variables.
 
-    Config precedence (high to low): CLI > local config > env vars > config file > defaults.
+    Config precedence (high to low): CLI > explicit --config > local > global > env > defaults.
     This is a regression test for the reorder in config.py where local config
     was moved after env vars so it wins.
     """
@@ -390,7 +390,7 @@ def test_local_config_overrides_env_vars(monkeypatch, clean_environment):
 def test_cli_overrides_local_config(clean_environment):
     """CLI arguments must override local .chunkhound.json.
 
-    Config precedence (high to low): CLI > local config > env vars > config file > defaults.
+    Config precedence (high to low): CLI > explicit --config > local > global > env > defaults.
     Complementary to test_local_config_overrides_env_vars.
     """
     from types import SimpleNamespace
@@ -525,3 +525,132 @@ def test_map_command_uses_config_parent_for_workspace_root(clean_environment):
         assert config.llm is not None
         assert config.llm.provider == "grok"
         assert config.database.path == workspace_root.resolve() / ".chunkhound" / "db"
+
+
+def test_global_config_provides_defaults_and_is_overridden_by_local(monkeypatch, clean_environment):
+    """Global config (via CHUNKHOUND_GLOBAL_CONFIG_FILE) supplies cross-project defaults.
+
+    Local .chunkhound.json and explicit config override globals (deep merge).
+    """
+    with windows_safe_tempdir() as td:
+        td = Path(td)
+        global_cfg = td / "global.json"
+        global_cfg.write_text(
+            json.dumps(
+                {
+                    "embedding": {"provider": "openai", "api_key": "gkey", "model": "gmodel"},
+                    "indexing": {"batch_size": 42},
+                }
+            )
+        )
+        local_cfg = td / ".chunkhound.json"
+        local_cfg.write_text(json.dumps({"embedding": {"api_key": "lkey"}}))
+
+        monkeypatch.setenv("CHUNKHOUND_GLOBAL_CONFIG_FILE", str(global_cfg))
+
+        c = Config(target_dir=td)
+        assert c.global_config_file == global_cfg.resolve()
+        assert c.local_config_file == local_cfg.resolve()
+        assert c.embedding is not None
+        assert c.embedding.api_key.get_secret_value() == "lkey"  # local overrides
+        assert c.embedding.model == "gmodel"  # from global
+        assert c.indexing.batch_size == 42  # global not overridden by local
+
+
+def test_global_local_deep_merge_partial_overrides_and_list_replacement(
+    monkeypatch, clean_environment
+):
+    """Global + local demonstrate deep merge for objects and list replacement.
+
+    Covers the user-facing contract for global config merging:
+    - Partial overrides inside embedding/llm/research (specific keys only;
+      siblings from global survive).
+    - Full provider/model switch possible by supplying a sub-dict.
+    - Project exclude list replaces global's (raw level).
+    - Built-in defaults still appear in effective excludes.
+    - Untouched global values survive.
+    """
+
+    with windows_safe_tempdir() as td:
+        td = Path(td)
+        global_cfg = td / "global.json"
+        global_cfg.write_text(
+            json.dumps(
+                {
+                    "embedding": {
+                        "provider": "voyageai",
+                        "model": "voyage-3.5",
+                        "api_key": "g-voyage-key",
+                    },
+                    "llm": {
+                        "provider": "anthropic",
+                        "model": "claude-3-5-sonnet-20241022",
+                        "api_key": "g-anthropic-key",
+                    },
+                    "research": {
+                        "algorithm": "v2",
+                        "query_expansion_enabled": True,
+                        "num_expanded_queries": 3,
+                    },
+                    "indexing": {
+                        "batch_size": 77,
+                        "exclude": ["**/global-exclude-pattern/**"],
+                    },
+                }
+            )
+        )
+        local_cfg = td / ".chunkhound.json"
+        local_cfg.write_text(
+            json.dumps(
+                {
+                    # Partial: only the secret (provider + model from global survive)
+                    "embedding": {"api_key": "project-voyage-key"},
+                    # Different model for this project (provider from global survives)
+                    "llm": {"model": "claude-3-opus-20240229"},
+                    # Research tuning override (other research fields from global survive)
+                    "research": {"algorithm": "v3"},
+                    # Project-specific excludes fully replace global's list
+                    "indexing": {
+                        "exclude": ["**/my-project-vendor/**", "**/generated/**"]
+                    },
+                }
+            )
+        )
+
+        monkeypatch.setenv("CHUNKHOUND_GLOBAL_CONFIG_FILE", str(global_cfg))
+
+        c = Config(target_dir=td)
+
+        # embedding: partial override works, global siblings preserved
+        assert c.embedding is not None
+        assert c.embedding.provider == "voyageai"  # from global
+        assert c.embedding.model == "voyage-3.5"  # from global
+        assert c.embedding.api_key.get_secret_value() == "project-voyage-key"  # local
+
+        # llm: partial model override
+        assert c.llm is not None
+        assert c.llm.provider == "anthropic"  # from global
+        assert c.llm.model == "claude-3-opus-20240229"  # local override
+
+        # research: partial algorithm override, other fields from global
+        assert c.research.algorithm == "v3"  # local
+        assert c.research.query_expansion_enabled is True  # global
+        assert c.research.num_expanded_queries == 3  # global
+
+        # indexing scalar from global survives when local only touches exclude
+        assert c.indexing.batch_size == 77  # global
+
+        # exclude list: local fully replaces global's
+        assert c.indexing.exclude == ["**/my-project-vendor/**", "**/generated/**"]
+        # but effective excludes still include built-in defaults
+        effective = c.indexing.get_effective_config_excludes()
+        assert any("my-project-vendor" in p for p in effective)
+        assert any("node_modules" in p for p in effective)  # built-in default present
+        # global's list is gone from the raw exclude (replaced)
+        assert not any(
+            "global-exclude-pattern" in p for p in c.indexing.exclude
+        )
+
+        # global_config_file / local_config_file still recorded
+        assert c.global_config_file == global_cfg.resolve()
+        assert c.local_config_file == local_cfg.resolve()


### PR DESCRIPTION
Introduce a global config file that supplies cross-project defaults. Users can define common settings once (embedding provider and key, LLM configuration, research options, etc.) instead of maintaining them in every project's `.chunkhound.json`.

Global config is loaded from `CHUNKHOUND_GLOBAL_CONFIG_FILE` or auto-discovered from standard user locations and participates in the existing configuration precedence and merge order.

- Added global config discovery and loading in `Config`.
- Added "Found global config" logging in the run command (matching local config behavior).
- Updated documentation with global config locations and usage.
- Added test coverage for global config integration.

The feature follows the project's established config loading and precedence rules.