### PR TITLE
docs: clarify Ollama LLM provider config

### DIFF
--- a/site/src/pages/docs/configuration.md
+++ b/site/src/pages/docs/configuration.md
@@ -414,6 +414,10 @@ No `rerank_url` is needed — it is auto-derived from `base_url`.
 
 LLM config:
 
+> **Migration note:** Do not set `llm.provider` to `"ollama"`.
+> ChunkHound treats Ollama as an OpenAI-compatible endpoint, so use
+> `provider: "openai"` with the Ollama `base_url` and an explicit `model`.
+
 ```json
 {
   "llm": {


### PR DESCRIPTION
**Note**: This PR was generated by an AI agent. If you'd like to
talk with other humans, drop by our [Discord](https://discord.gg/BAepHEXXnX)!

---

Closes #252.

This clarifies the Ollama LLM configuration docs after #252. Ollama is supported as an OpenAI-compatible endpoint, so users should keep `llm.provider` set to `"openai"` and point `base_url` at the Ollama `/v1` endpoint instead of setting `llm.provider` to `"ollama"`.

The change is intentionally limited to the Configuration page's Ollama LLM example, where users are most likely to copy the setting.

**Verification**

- `git diff --check`
- `npm ci --prefix site`
- `npm run build --prefix site`

Local notes:

- `uv run pytest tests/test_smoke.py -v -n auto` was attempted. After dependency warmup, 16/18 passed; the two failing cases timed out waiting for MCP stdio `initialize` locally (`test_mcp_stdio_protocol_handshake`, `test_mcp_websearch_stdio_mocked`). No Python code changed in this PR.
- `uv run ruff check chunkhound` was attempted and reported existing lint failures across the current tree. This PR does not touch Python files.

---

Agent review context is included inline rather than as a separate attachment because this PR changes one docs paragraph.

Scope:

- Docs-only change in `site/src/pages/docs/configuration.md`.
- Adds a migration note immediately before the Ollama LLM JSON example.
- Documents that `llm.provider: "ollama"` is not the supported spelling; Ollama LLMs should use `provider: "openai"` plus `base_url` and explicit `model`.
