### PR TITLE
test: harden watchman reliability diagnostics

### DIFF
--- a/chunkhound/api/cli/commands/daemon.py
+++ b/chunkhound/api/cli/commands/daemon.py
@@ -1,9 +1,46 @@
 """Daemon command — starts the ChunkHound multi-client daemon process."""
 
 import argparse
+import sys
+import time
+from datetime import datetime
 from pathlib import Path
 
 from chunkhound.core.config.config import Config
+
+
+def _startup_breadcrumb(message: str) -> None:
+    """Emit daemon bootstrap breadcrumbs before MCPServerBase exists."""
+    try:
+        timestamp = datetime.now().isoformat()
+        print(
+            f"[{timestamp}] [startup] startup: {message}",
+            file=sys.stderr,
+            flush=True,
+        )
+    except Exception:
+        pass
+
+
+class _StartupPhase:
+    def __init__(self, name: str) -> None:
+        self._name = name
+        self._started_at = 0.0
+
+    def __enter__(self) -> None:
+        self._started_at = time.monotonic()
+        _startup_breadcrumb(f"phase started: {self._name}")
+
+    def __exit__(self, _exc_type: object, exc: object, _traceback: object) -> None:
+        duration = time.monotonic() - self._started_at
+        if exc is None:
+            _startup_breadcrumb(
+                f"phase completed: {self._name} duration={duration:.3f}s"
+            )
+            return
+        _startup_breadcrumb(
+            f"phase failed: {self._name} duration={duration:.3f}s error={exc!r}"
+        )
 
 
 async def daemon_command(args: argparse.Namespace, config: Config) -> None:
@@ -14,31 +51,39 @@ async def daemon_command(args: argparse.Namespace, config: Config) -> None:
               ``socket_path``).
         config: Pre-validated configuration instance.
     """
+    _startup_breadcrumb("phase started: daemon_command")
+
     # CRITICAL: Import numpy early for DuckDB threading safety.
     # The daemon owns the sole DuckDB connection; this must happen before
     # initialize() opens the database.
     # See: https://duckdb.org/docs/stable/clients/python/known_issues.html
-    try:
-        import numpy  # noqa: F401
-    except ImportError:
-        pass
+    with _StartupPhase("daemon_numpy_import"):
+        try:
+            import numpy  # noqa: F401
+        except ImportError:
+            pass
 
-    from chunkhound.daemon.server import ChunkHoundDaemon
+    with _StartupPhase("daemon_server_import"):
+        from chunkhound.daemon.server import ChunkHoundDaemon
 
-    # argparse converts --project-dir to args.project_dir (with underscore)
-    project_dir = Path(args.project_dir).resolve()
-    socket_path: str = args.socket_path
+    with _StartupPhase("daemon_construct"):
+        # argparse converts --project-dir to args.project_dir (with underscore)
+        project_dir = Path(args.project_dir).resolve()
+        socket_path: str = args.socket_path
 
-    # Set args.path so that Config and MCPServerBase.initialize() resolve
-    # the target directory correctly (they look for args.path).
-    args.path = project_dir
+        # Set args.path so that Config and MCPServerBase.initialize() resolve
+        # the target directory correctly (they look for args.path).
+        args.path = project_dir
 
-    daemon = ChunkHoundDaemon(
-        config=config,
-        args=args,
-        socket_path=socket_path,
-        project_dir=project_dir,
-    )
+        daemon = ChunkHoundDaemon(
+            config=config,
+            args=args,
+            socket_path=socket_path,
+            project_dir=project_dir,
+        )
+
+    _startup_breadcrumb("phase completed: daemon_command")
+    _startup_breadcrumb("phase started: daemon_run")
     await daemon.run()
 
 

--- a/chunkhound/api/cli/main.py
+++ b/chunkhound/api/cli/main.py
@@ -5,6 +5,8 @@ import asyncio
 import logging as _pylogging
 import multiprocessing
 import sys
+import time
+from datetime import datetime
 
 from loguru import logger
 
@@ -14,6 +16,21 @@ from .utils.config_factory import create_validated_config
 
 # Required for PyInstaller multiprocessing support
 multiprocessing.freeze_support()
+
+
+def _daemon_startup_breadcrumb(args: argparse.Namespace, message: str) -> None:
+    """Emit pre-server daemon startup breadcrumbs to the daemon stderr log."""
+    if getattr(args, "command", None) != "_daemon":
+        return
+    try:
+        timestamp = datetime.now().isoformat()
+        print(
+            f"[{timestamp}] [startup] startup: {message}",
+            file=sys.stderr,
+            flush=True,
+        )
+    except Exception:
+        pass
 
 
 def setup_logging(verbose: bool = False) -> None:
@@ -113,9 +130,19 @@ async def async_main() -> None:
 
         args.path = _Path(args.project_dir).resolve()
 
+    _daemon_startup_breadcrumb(args, "startup tracking began mode=daemon")
+    config_validation_started = time.monotonic()
+    _daemon_startup_breadcrumb(args, "phase started: cli_config_validation")
     config, validation_errors = create_validated_config(args, args.command)
+    config_validation_duration = time.monotonic() - config_validation_started
 
     if validation_errors:
+        joined_errors = "; ".join(validation_errors)
+        _daemon_startup_breadcrumb(
+            args,
+            "phase failed: cli_config_validation "
+            f"duration={config_validation_duration:.3f}s error={joined_errors}",
+        )
         should_show_web_banner = sys.stderr.isatty()
         logger.error("Configuration error — see details below.")
         if should_show_web_banner:
@@ -157,6 +184,12 @@ async def async_main() -> None:
                 print("  4. Use --no-embeddings to skip embeddings", file=sys.stderr)
 
         sys.exit(1)
+
+    _daemon_startup_breadcrumb(
+        args,
+        "phase completed: cli_config_validation "
+        f"duration={config_validation_duration:.3f}s",
+    )
 
     try:
         if args.command == "index":

--- a/chunkhound/daemon/client_proxy.py
+++ b/chunkhound/daemon/client_proxy.py
@@ -76,6 +76,13 @@ class ClientProxy:
             )
         )
 
+    async def _probe_daemon_liveness(self) -> bool | None:
+        """Best-effort daemon liveness probe for registration diagnostics."""
+        try:
+            return await self._discovery.ping_daemon()
+        except Exception:
+            return None
+
     async def _register_with_daemon(
         self,
         reader: asyncio.StreamReader,
@@ -97,11 +104,9 @@ class ClientProxy:
         try:
             ipc.write_frame(writer, reg_frame)
             await writer.drain()
-            ack = await asyncio.wait_for(ipc.read_frame(reader), timeout=10.0)
         except (
             OSError,
             EOFError,
-            asyncio.TimeoutError,
             asyncio.IncompleteReadError,
             BrokenPipeError,
             ConnectionAbortedError,
@@ -109,6 +114,38 @@ class ClientProxy:
         ) as error:
             raise self._startup_failure_error(
                 "ChunkHound daemon died during registration handshake"
+            ) from error
+
+        try:
+            ack = await asyncio.wait_for(ipc.read_frame(reader), timeout=10.0)
+        except asyncio.TimeoutError as error:
+            daemon_alive = await self._probe_daemon_liveness()
+            if daemon_alive is True:
+                prefix = (
+                    "ChunkHound daemon registration ack timed out after 10.0s; "
+                    "daemon still reachable"
+                )
+            elif daemon_alive is False:
+                prefix = (
+                    "ChunkHound daemon registration ack timed out after 10.0s; "
+                    "daemon no longer reachable"
+                )
+            else:
+                prefix = (
+                    "ChunkHound daemon registration ack timed out after 10.0s; "
+                    "daemon reachability could not be confirmed"
+                )
+            raise self._startup_failure_error(prefix) from error
+        except (
+            OSError,
+            EOFError,
+            asyncio.IncompleteReadError,
+            BrokenPipeError,
+            ConnectionAbortedError,
+            ConnectionResetError,
+        ) as error:
+            raise self._startup_failure_error(
+                "ChunkHound daemon connection closed before registration ack"
             ) from error
 
         if not isinstance(ack, dict) or ack.get("type") != "registered":

--- a/chunkhound/daemon/discovery.py
+++ b/chunkhound/daemon/discovery.py
@@ -337,6 +337,24 @@ async def _terminate_startup_handle(startup: DaemonStartupHandle) -> None:
     await asyncio.to_thread(_terminate_startup_handle_sync, startup)
 
 
+def _startup_process_state(process: subprocess.Popen[Any]) -> str:
+    """Return a compact process-state string for startup diagnostics."""
+    details: list[str] = []
+    pid = getattr(process, "pid", None)
+    if isinstance(pid, int):
+        details.append(f"pid={pid}")
+    try:
+        returncode = process.poll()
+    except Exception as error:
+        details.append(f"process_state=poll_error {error!r}")
+    else:
+        if returncode is None:
+            details.append("process_state=running")
+        else:
+            details.append(f"process_state=exited rc={returncode}")
+    return ", ".join(details) or "process_state=unknown"
+
+
 class DaemonDiscovery:
     """Locate or start the daemon for a given project directory."""
 
@@ -711,7 +729,8 @@ class DaemonDiscovery:
         message = prefix
         if returncode is not None:
             message = f"{message} (exit code {returncode})"
-        startup_context = self._startup_failure_context(log_path)
+        effective_log_path = log_path or self.get_daemon_log_path()
+        startup_context = self._startup_failure_context(effective_log_path)
         if startup_context is not None:
             context_lines: list[str] = []
             if startup_context.get("startup_completed") is True:
@@ -730,10 +749,11 @@ class DaemonDiscovery:
                     context_lines.append(f"Last startup error: {last_error}")
             if context_lines:
                 message = f"{message}\n" + "\n".join(context_lines)
-        log_tail = self._tail_daemon_log(log_path)
+        log_tail = self._tail_daemon_log(effective_log_path)
+        log_context = f"Daemon log path: {effective_log_path}"
         if log_tail:
-            return f"{message}\nRecent daemon log output:\n{log_tail}"
-        return message
+            return f"{message}\n{log_context}\nRecent daemon log output:\n{log_tail}"
+        return f"{message}\n{log_context}\nDaemon log was empty or unavailable"
 
     def write_registry_entry(self, pid: int, socket_path: str) -> None:
         """Publish this daemon in the user-scoped registry."""
@@ -1245,7 +1265,8 @@ class DaemonDiscovery:
                                     self.format_startup_failure(
                                         prefix=(
                                             "ChunkHound daemon exited before it became "
-                                            f"reachable (address: {startup_address})"
+                                            f"reachable (address: {startup_address}, "
+                                            f"{_startup_process_state(startup.process)})"
                                         ),
                                         log_path=startup.log_path,
                                         returncode=returncode,
@@ -1272,7 +1293,8 @@ class DaemonDiscovery:
                                                 prefix=(
                                                     "ChunkHound daemon crashed after "
                                                     "publishing lock "
-                                                    f"(address: {startup_address})"
+                                                    f"(address: {startup_address}, "
+                                                    f"{_startup_process_state(startup.process)})"
                                                 ),
                                                 log_path=startup.log_path,
                                                 returncode=returncode,
@@ -1305,12 +1327,14 @@ class DaemonDiscovery:
                                 min(_STARTUP_POLL_INTERVAL, max(sleep_for, 0.0))
                             )
 
+                        process_state = _startup_process_state(startup.process)
                         await _terminate_startup_handle(startup)
                         raise RuntimeError(
                             self.format_startup_failure(
                                 prefix=(
                                     f"ChunkHound daemon did not start within "
-                                    f"{_STARTUP_TIMEOUT}s (address: {startup_address})"
+                                    f"{_STARTUP_TIMEOUT}s (address: {startup_address}, "
+                                    f"{process_state})"
                                 ),
                                 log_path=startup.log_path,
                             )

--- a/chunkhound/daemon/discovery.py
+++ b/chunkhound/daemon/discovery.py
@@ -284,6 +284,16 @@ def _normalize_startup_breadcrumb_message(message: str) -> str:
     return normalized
 
 
+def _startup_duration_seconds(message: str) -> float | None:
+    if " duration=" not in message:
+        return None
+    duration_fragment = message.split(" duration=", 1)[1].split("s", 1)[0]
+    try:
+        return float(duration_fragment)
+    except ValueError:
+        return None
+
+
 def _normalize_started_at(raw: object) -> float:
     """Coerce a started_at metadata field to float, defaulting on garbage.
 
@@ -612,6 +622,8 @@ class DaemonDiscovery:
         last_phase: str | None = None
         last_error: str | None = None
         total_duration_seconds: float | None = None
+        startup_completed = False
+        completed_duration_seconds: float | None = None
 
         for raw_line in log_tail.splitlines():
             if "[startup]" not in raw_line:
@@ -621,18 +633,29 @@ class DaemonDiscovery:
             timestamp = _parse_startup_log_timestamp(raw_line)
             if message.startswith("startup tracking began"):
                 startup_started_at = timestamp
+                last_phase = None
+                last_error = None
+                total_duration_seconds = None
+                startup_completed = False
+                completed_duration_seconds = None
                 continue
             if message.startswith("phase started: "):
+                startup_completed = False
+                completed_duration_seconds = None
                 phase_name = message.removeprefix("phase started: ").strip()
                 last_phase = phase_name or last_phase
                 continue
             if message.startswith("phase completed: "):
+                startup_completed = False
+                completed_duration_seconds = None
                 phase_name, _, _ = message.removeprefix("phase completed: ").partition(
                     " duration="
                 )
                 last_phase = phase_name.strip() or last_phase
                 continue
             if message.startswith("phase failed: "):
+                startup_completed = False
+                completed_duration_seconds = None
                 details = message.removeprefix("phase failed: ")
                 phase_name, _, remainder = details.partition(" duration=")
                 last_phase = phase_name.strip() or last_phase
@@ -641,15 +664,13 @@ class DaemonDiscovery:
                     if error_text:
                         last_error = error_text
                 continue
+            if message.startswith("startup completed"):
+                startup_completed = True
+                completed_duration_seconds = _startup_duration_seconds(message)
+                continue
             if message.startswith("startup failed"):
-                if " duration=" in message:
-                    duration_fragment = message.split(" duration=", 1)[1].split("s", 1)[
-                        0
-                    ]
-                    try:
-                        total_duration_seconds = float(duration_fragment)
-                    except ValueError:
-                        total_duration_seconds = None
+                startup_completed = False
+                total_duration_seconds = _startup_duration_seconds(message)
                 if " error=" in message:
                     error_text = message.split(" error=", 1)[1].strip()
                     if error_text:
@@ -661,17 +682,22 @@ class DaemonDiscovery:
             and last_error is None
             and total_duration_seconds is None
             and startup_started_at is None
+            and not startup_completed
         ):
             return None
 
         elapsed_seconds = total_duration_seconds
-        if elapsed_seconds is None and startup_started_at is not None:
+        if startup_completed:
+            elapsed_seconds = completed_duration_seconds
+        elif elapsed_seconds is None and startup_started_at is not None:
             elapsed_seconds = _startup_elapsed_seconds(startup_started_at)
 
         return {
             "last_phase": last_phase,
             "elapsed_seconds": elapsed_seconds,
             "last_error": last_error,
+            "startup_completed": startup_completed,
+            "completed_duration_seconds": completed_duration_seconds,
         }
 
     def format_startup_failure(
@@ -688,17 +714,20 @@ class DaemonDiscovery:
         startup_context = self._startup_failure_context(log_path)
         if startup_context is not None:
             context_lines: list[str] = []
-            last_phase = startup_context.get("last_phase")
-            if isinstance(last_phase, str) and last_phase:
-                context_lines.append(f"Last known startup phase: {last_phase}")
-            elapsed_seconds = startup_context.get("elapsed_seconds")
-            if isinstance(elapsed_seconds, float):
-                context_lines.append(
-                    f"Elapsed startup duration so far: {elapsed_seconds:.3f}s"
-                )
-            last_error = startup_context.get("last_error")
-            if isinstance(last_error, str) and last_error:
-                context_lines.append(f"Last startup error: {last_error}")
+            if startup_context.get("startup_completed") is True:
+                context_lines.append("Daemon startup status: completed")
+            else:
+                last_phase = startup_context.get("last_phase")
+                if isinstance(last_phase, str) and last_phase:
+                    context_lines.append(f"Last known startup phase: {last_phase}")
+                elapsed_seconds = startup_context.get("elapsed_seconds")
+                if isinstance(elapsed_seconds, float):
+                    context_lines.append(
+                        f"Elapsed startup duration so far: {elapsed_seconds:.3f}s"
+                    )
+                last_error = startup_context.get("last_error")
+                if isinstance(last_error, str) and last_error:
+                    context_lines.append(f"Last startup error: {last_error}")
             if context_lines:
                 message = f"{message}\n" + "\n".join(context_lines)
         log_tail = self._tail_daemon_log(log_path)

--- a/chunkhound/services/realtime/adapters/watchman.py
+++ b/chunkhound/services/realtime/adapters/watchman.py
@@ -368,8 +368,13 @@ class WatchmanRealtimeAdapter:
     ) -> tuple[str, Path] | None:
         file_type = entry.get("type")
         if file_type not in {None, "f", "d"}:
+            name = entry.get("name")
+            exists = entry.get("exists")
+            is_new = entry.get("new")
             self._warn_translation_issue(
-                f"Skipping unexpected Watchman file type {file_type!r}"
+                "Skipping unexpected Watchman file type "
+                f"{file_type!r} for entry "
+                f"name={name!r}, exists={exists!r}, new={is_new!r}"
             )
             return None
 
@@ -579,7 +584,9 @@ class WatchmanRealtimeAdapter:
             )
             await self._context.start_polling_backend(
                 watch_path,
-                reason=f"Watchman sidecar {phase} failed: {error}; fell back to polling",
+                reason=(
+                    f"Watchman sidecar {phase} failed: {error}; fell back to polling"
+                ),
             )
             self._context.set_effective_backend("polling")
             return

--- a/chunkhound/watchman/session.py
+++ b/chunkhound/watchman/session.py
@@ -13,7 +13,6 @@ from typing import Any
 
 from ..watchman_runtime.loader import (
     build_watchman_client_command,
-    build_watchman_runtime_command_prefix,
     build_watchman_runtime_environment,
     resolve_packaged_watchman_runtime,
 )
@@ -591,8 +590,34 @@ class WatchmanCliSession:
         }
 
     def _build_command(self, *, persistent: bool = True) -> list[str]:
+        if self._command_prefix is not None:
+            listener_flag = (
+                "--named-pipe-path"
+                if self._socket_path.lower().startswith("\\\\.\\pipe\\")
+                else "--unix-listener-path"
+            )
+            command = [
+                *self._command_prefix,
+                listener_flag,
+                self._socket_path,
+                "--no-spawn",
+                "--no-pretty",
+            ]
+            if persistent:
+                command.append("--persistent")
+            command.extend(
+                [
+                    "--server-encoding",
+                    "json",
+                    "--output-encoding",
+                    "json",
+                    "--json-command",
+                ]
+            )
+            return command
+
         runtime = resolve_packaged_watchman_runtime()
-        command = build_watchman_client_command(
+        return build_watchman_client_command(
             runtime=runtime,
             binary_path=self._binary_path,
             socket_path=self._socket_path,
@@ -601,17 +626,12 @@ class WatchmanCliSession:
             pidfile_path=self._pidfile_path,
             persistent=persistent,
         )
-        if self._command_prefix is None:
-            return command
-        default_prefix = build_watchman_runtime_command_prefix(
-            runtime=runtime,
-            binary_path=self._binary_path,
-        )
-        return [*self._command_prefix, *command[len(default_prefix) :]]
 
     def _build_command_env(self) -> dict[str, str]:
         if self._command_env is not None:
             return dict(self._command_env)
+        if self._command_prefix is not None:
+            return dict(os.environ)
         runtime = resolve_packaged_watchman_runtime()
         return build_watchman_runtime_environment(
             runtime=runtime,

--- a/scripts/verify_watchman_live_indexing_e2e.py
+++ b/scripts/verify_watchman_live_indexing_e2e.py
@@ -30,6 +30,9 @@ _READY_TIMEOUT_SECONDS = 60.0
 _MCP_INITIALIZE_TIMEOUT_SECONDS = 60.0
 _SEARCH_TIMEOUT_SECONDS = 30.0
 _SOURCE_FALLBACK_FAILURE_TIMEOUT_SECONDS = 20.0
+_JSON_RPC_EOF_WAIT_TIMEOUT_SECONDS = 1.0
+_JSON_RPC_STDERR_READ_TIMEOUT_SECONDS = 1.0
+_JSON_RPC_STDERR_TAIL_BYTES = 4096
 _DETERMINISTIC_FAILURE_URL_BASE = "https://127.0.0.1:9/chunkhound-watchman-fail"
 _SOURCE_FALLBACK_PRETEND_VERSION = "0.0.0"
 
@@ -177,12 +180,7 @@ class SubprocessJsonRpcClient:
             while True:
                 raw_line = await self._process.stdout.readline()
                 if not raw_line:
-                    self._fail_pending(
-                        RuntimeError(
-                            "JSON-RPC subprocess terminated unexpectedly "
-                            f"(rc={self._process.returncode})"
-                        )
-                    )
+                    self._fail_pending(await self._unexpected_termination_error())
                     return
 
                 line = raw_line.decode("utf-8", errors="replace").strip()
@@ -201,6 +199,57 @@ class SubprocessJsonRpcClient:
             pass
         except Exception as error:
             self._fail_pending(error)
+
+    async def _unexpected_termination_error(self) -> RuntimeError:
+        wait_note: str | None = None
+        if self._process.returncode is None:
+            try:
+                await asyncio.wait_for(
+                    self._process.wait(),
+                    timeout=_JSON_RPC_EOF_WAIT_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                wait_note = (
+                    "wait_timeout="
+                    f"{_JSON_RPC_EOF_WAIT_TIMEOUT_SECONDS:.1f}s"
+                )
+            except Exception as error:
+                wait_note = f"wait_error={error!r}"
+
+        details = [f"rc={self._process.returncode}"]
+        if wait_note is not None:
+            details.append(wait_note)
+
+        stderr_tail = await self._read_exited_stderr_tail()
+        if stderr_tail:
+            details.append(f"stderr_tail={stderr_tail!r}")
+
+        return RuntimeError(
+            "JSON-RPC subprocess terminated unexpectedly "
+            f"({', '.join(details)})"
+        )
+
+    async def _read_exited_stderr_tail(self) -> str | None:
+        if self._process.returncode is None or self._process.stderr is None:
+            return None
+        try:
+            raw_stderr = await asyncio.wait_for(
+                self._process.stderr.read(),
+                timeout=_JSON_RPC_STDERR_READ_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            return (
+                "<stderr read timed out after "
+                f"{_JSON_RPC_STDERR_READ_TIMEOUT_SECONDS:.1f}s>"
+            )
+        except Exception as error:
+            return f"<stderr read failed: {error!r}>"
+
+        if not raw_stderr:
+            return None
+        if len(raw_stderr) > _JSON_RPC_STDERR_TAIL_BYTES:
+            raw_stderr = raw_stderr[-_JSON_RPC_STDERR_TAIL_BYTES:]
+        return raw_stderr.decode("utf-8", errors="replace").strip() or None
 
     def _fail_pending(self, error: Exception) -> None:
         for future in self._pending_requests.values():

--- a/tests/realtime/test_watchman_event_translation.py
+++ b/tests/realtime/test_watchman_event_translation.py
@@ -26,7 +26,9 @@ from tests.helpers.watchman_realtime import (
 )
 from tests.utils.windows_compat import wait_for_indexed
 
-pytestmark = pytest.mark.requires_native_watchman
+# Keep deterministic translation/adapter contract tests runnable without packaged
+# Watchman; mark only tests that start the real Watchman adapter as requiring
+# native Watchman.
 
 
 def _subscription_pdu(
@@ -930,6 +932,7 @@ async def test_watchman_mount_aware_startup_uses_fallback_planning(
         services.provider.disconnect()
 
 
+@pytest.mark.requires_native_watchman
 @pytest.mark.asyncio
 async def test_watchman_subscription_pdu_indexes_created_file(tmp_path: Path) -> None:
     watch_dir = tmp_path / "watchman_project"
@@ -955,6 +958,7 @@ async def test_watchman_subscription_pdu_indexes_created_file(tmp_path: Path) ->
         services.provider.disconnect()
 
 
+@pytest.mark.requires_native_watchman
 @pytest.mark.asyncio
 async def test_watchman_subscription_pdu_deletes_indexed_file(tmp_path: Path) -> None:
     watch_dir = tmp_path / "watchman_project"
@@ -984,6 +988,7 @@ async def test_watchman_subscription_pdu_deletes_indexed_file(tmp_path: Path) ->
         services.provider.disconnect()
 
 
+@pytest.mark.requires_native_watchman
 @pytest.mark.asyncio
 async def test_watchman_subscription_pdu_deletes_indexed_directory(
     tmp_path: Path,
@@ -1086,6 +1091,7 @@ async def test_watchman_relative_root_mapping_and_filtering(
         services.provider.disconnect()
 
 
+@pytest.mark.requires_native_watchman
 @pytest.mark.asyncio
 async def test_watchman_multi_scope_translation_deduplicates_across_subscriptions(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1195,6 +1201,7 @@ async def test_watchman_multi_scope_translation_deduplicates_across_subscription
         services.provider.disconnect()
 
 
+@pytest.mark.requires_native_watchman
 @pytest.mark.asyncio
 async def test_watchman_multi_scope_translation_routes_colliding_subscription_names(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1296,6 +1303,53 @@ async def test_watchman_multi_scope_translation_routes_colliding_subscription_na
         services.provider.disconnect()
 
 
+@pytest.mark.asyncio
+async def test_watchman_unexpected_file_type_warning_includes_entry_context(
+    tmp_path: Path,
+) -> None:
+    watch_dir = tmp_path / "watchman_project"
+    watch_dir.mkdir(parents=True)
+    service, services = _build_watchman_service(watch_dir)
+
+    try:
+        adapter = await _start_isolated_watchman_translation(service, watch_dir)
+        scope = WatchmanSubscriptionScope(
+            requested_path=watch_dir.resolve(),
+            watch_root=watch_dir.resolve(),
+            relative_root=None,
+            scope_kind="primary",
+        )
+
+        adapter._translate_subscription_pdu(
+            {
+                "subscription": "chunkhound-live-indexing",
+                "clock": "c:0:6",
+                "files": [
+                    {
+                        "name": "src/socket.sock",
+                        "exists": True,
+                        "new": False,
+                        "type": "?",
+                    }
+                ],
+            },
+            scope,
+        )
+
+        stats = await _wait_for_pipeline_count(
+            service, "translation_error_count", 1
+        )
+        warning = stats["last_warning"] or ""
+        assert "Skipping unexpected Watchman file type '?'" in warning
+        assert "name='src/socket.sock'" in warning
+        assert "exists=True" in warning
+        assert "new=False" in warning
+    finally:
+        await service.stop()
+        services.provider.disconnect()
+
+
+@pytest.mark.requires_native_watchman
 @pytest.mark.asyncio
 async def test_watchman_translation_errors_increment_pipeline_counter(
     tmp_path: Path,

--- a/tests/realtime/test_watchman_session_bridge.py
+++ b/tests/realtime/test_watchman_session_bridge.py
@@ -538,6 +538,54 @@ def test_watchman_cli_session_prepared_startup_support_is_transport_aware(
 
 
 @pytest.mark.asyncio
+async def test_watchman_cli_session_command_prefix_does_not_resolve_packaged_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    script_path = _write_fake_watchman_cli(tmp_path)
+    target_path = tmp_path / "repo"
+    target_path.mkdir()
+    socket_path = tmp_path / "watchman.sock"
+    socket_path.write_text("socket ready\n", encoding="utf-8")
+    statefile_path = tmp_path / "watchman.state"
+    statefile_path.write_text("state ready\n", encoding="utf-8")
+    logfile_path = tmp_path / "watchman.log"
+    logfile_path.write_text("log ready\n", encoding="utf-8")
+    pidfile_path = tmp_path / "watchman.pid"
+    pidfile_path.write_text("123\n", encoding="utf-8")
+
+    def fail_runtime_resolution() -> None:
+        raise AssertionError("explicit command_prefix must not resolve runtime")
+
+    monkeypatch.setattr(
+        watchman_session_module,
+        "resolve_packaged_watchman_runtime",
+        fail_runtime_resolution,
+    )
+
+    session = WatchmanCliSession(
+        binary_path=script_path,
+        socket_path=socket_path,
+        statefile_path=statefile_path,
+        logfile_path=logfile_path,
+        pidfile_path=pidfile_path,
+        project_root=tmp_path,
+        command_prefix=[sys.executable, str(script_path)],
+    )
+
+    try:
+        setup = await session.start(target_path=target_path)
+
+        assert setup.capabilities == {
+            "cmd-watch-project": True,
+            "relative_root": True,
+        }
+        assert setup.scope_plan.primary_scope.watch_root == target_path.resolve()
+        assert session.get_health()["watchman_session_alive"] is True
+    finally:
+        await session.stop()
+
+
+@pytest.mark.asyncio
 async def test_watchman_cli_session_start_uses_one_shot_scope_planning(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/realtime/test_watchman_session_bridge.py
+++ b/tests/realtime/test_watchman_session_bridge.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import errno
-import os
 import stat
 import sys
 import textwrap
@@ -13,10 +12,7 @@ from types import SimpleNamespace
 import pytest
 
 import chunkhound.watchman.session as watchman_session_module
-from chunkhound.services.realtime_indexing_service import (
-    RealtimeIndexingService,
-    WatchmanRealtimeAdapter,
-)
+from chunkhound.services.realtime_indexing_service import WatchmanRealtimeAdapter
 from chunkhound.watchman import (
     PrivateWatchmanSidecar,
     WatchmanCliSession,
@@ -26,10 +22,13 @@ from chunkhound.watchman import (
 )
 from tests.helpers.watchman_realtime import (
     build_watchman_service as _build_watchman_service,
+)
+from tests.helpers.watchman_realtime import (
     prepend_poisoned_python_shims as _prepend_poisoned_python_shims,
 )
 
-pytestmark = pytest.mark.requires_native_watchman
+# Keep fake-CLI/session contract tests runnable without packaged Watchman; mark
+# only tests that launch a real PrivateWatchmanSidecar as requiring native Watchman.
 
 _FAKE_WATCHMAN_CLI = """\
 from __future__ import annotations
@@ -220,7 +219,7 @@ def test_scope_plan_subscription_names_resolve_colliding_secondary_suffixes(
     )
 
 
-def test_scope_plan_subscription_names_preserve_logical_root_when_target_resolves_elsewhere(
+def test_scope_plan_subscription_names_preserve_logical_root_when_resolved_elsewhere(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     target_path = tmp_path / "logical_workspace"
@@ -333,7 +332,9 @@ async def test_watchman_bridge_queue_overflow_reports_exact_drop_magnitude(
     }
     session.subscription_queue.put_nowait(overflow_payload)
 
-    bridge_task = asyncio.create_task(adapter._bridge_session_subscription_pdus(session))
+    bridge_task = asyncio.create_task(
+        adapter._bridge_session_subscription_pdus(session)
+    )
     try:
         await asyncio.wait_for(session.subscription_queue.join(), timeout=1.0)
         health = await service.get_health()
@@ -454,6 +455,7 @@ def test_watchman_cli_session_bounds_long_secondary_subscription_names(
     assert bounded_a.startswith("chunkhound-live-indexing--very-long-scope-name")
 
 
+@pytest.mark.requires_native_watchman
 @pytest.mark.asyncio
 async def test_watchman_cli_session_start_ignores_poisoned_python_path(
     tmp_path: Path,

--- a/tests/test_verify_watchman_live_indexing_e2e.py
+++ b/tests/test_verify_watchman_live_indexing_e2e.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import sys
@@ -233,6 +234,75 @@ async def test_wait_for_ready_accepts_only_polling_fallback_mode(
 
     assert client.calls == 1
     assert status["scan_progress"]["realtime"]["effective_backend"] == "polling"
+
+
+@pytest.mark.asyncio
+async def test_json_rpc_eof_awaits_process_exit_before_reporting_returncode() -> None:
+    class EofStdout:
+        def __init__(self) -> None:
+            self._release = asyncio.Event()
+
+        def release(self) -> None:
+            self._release.set()
+
+        async def readline(self) -> bytes:
+            await self._release.wait()
+            return b""
+
+    class FakeStdin:
+        def __init__(self, stdout: EofStdout) -> None:
+            self._stdout = stdout
+            self.writes: list[bytes] = []
+
+        def write(self, data: bytes) -> None:
+            self.writes.append(data)
+
+        async def drain(self) -> None:
+            self._stdout.release()
+
+        def close(self) -> None:
+            return None
+
+        async def wait_closed(self) -> None:
+            return None
+
+    class FakeStderr:
+        async def read(self) -> bytes:
+            return b"daemon failed\n"
+
+    class FakeProcess:
+        def __init__(self) -> None:
+            self.returncode: int | None = None
+            self.stdout = EofStdout()
+            self.stdin = FakeStdin(self.stdout)
+            self.stderr = FakeStderr()
+            self.wait_calls = 0
+
+        async def wait(self) -> int:
+            self.wait_calls += 1
+            self.returncode = 7
+            return self.returncode
+
+        def terminate(self) -> None:
+            raise AssertionError("process already exited after EOF wait")
+
+        def kill(self) -> None:
+            raise AssertionError("process already exited after EOF wait")
+
+    process = FakeProcess()
+    client = live_verifier.SubprocessJsonRpcClient(process)  # type: ignore[arg-type]
+    await client.start()
+    try:
+        with pytest.raises(RuntimeError) as exc_info:
+            await client.send_request("tools/call", {}, timeout=1.0)
+    finally:
+        await client.close()
+
+    message = str(exc_info.value)
+    assert process.wait_calls == 1
+    assert "rc=7" in message
+    assert "rc=None" not in message
+    assert "stderr_tail='daemon failed'" in message
 
 
 def test_source_tree_copy_ignore_excludes_transient_repo_state() -> None:
@@ -787,7 +857,10 @@ async def test_verify_wheel_uses_clean_room_runtime_env(
             return None
 
         async def send_request(
-            self, method: str, params: dict[str, object] | None = None, timeout: float = 5.0
+            self,
+            method: str,
+            params: dict[str, object] | None = None,
+            timeout: float = 5.0,
         ) -> dict[str, object]:
             del method, params, timeout
             return {}
@@ -949,7 +1022,10 @@ async def test_verify_wheel_proves_live_searchability_in_polling_fallback(
             return None
 
         async def send_request(
-            self, method: str, params: dict[str, object] | None = None, timeout: float = 5.0
+            self,
+            method: str,
+            params: dict[str, object] | None = None,
+            timeout: float = 5.0,
         ) -> dict[str, object]:
             del method, params, timeout
             self.requests += 1
@@ -1023,7 +1099,12 @@ async def test_verify_wheel_proves_live_searchability_in_polling_fallback(
 
     original_write_text = Path.write_text
 
-    def recording_write_text(self: Path, data: str, *args: object, **kwargs: object) -> int:
+    def recording_write_text(
+        self: Path,
+        data: str,
+        *args: object,
+        **kwargs: object,
+    ) -> int:
         nonlocal wrote_live_file
         if self.name == "live.py" and "fallback_live_symbol" in data:
             wrote_live_file = True
@@ -1259,7 +1340,11 @@ def test_remove_tree_with_retries_terminates_windows_processes_with_open_file_ha
                     101,
                     str(tmp_path / "elsewhere"),
                     ["python", "--flag"],
-                    [FakeOpenFile(str(locked_root / "project" / ".chunkhound" / "daemon.log"))],
+                    [
+                        FakeOpenFile(
+                            str(locked_root / "project" / ".chunkhound" / "daemon.log")
+                        )
+                    ],
                 ),
                 FakeProcess(202, str(tmp_path / "other"), [], []),
             ]

--- a/tests/unit/test_client_proxy.py
+++ b/tests/unit/test_client_proxy.py
@@ -363,6 +363,33 @@ async def test_run_wraps_registration_handshake_failures(
 
 
 @pytest.mark.asyncio
+async def test_registration_ack_timeout_reports_alive_daemon_not_died(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    proxy, discovery, writer = _make_proxy(tmp_path, monkeypatch)
+    discovery.format_startup_failure.side_effect = (
+        lambda *, prefix, log_path=None, returncode=None: prefix
+    )
+    discovery.ping_daemon = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        client_proxy_module.ipc,
+        "read_frame",
+        AsyncMock(side_effect=asyncio.TimeoutError()),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await proxy.run()
+
+    message = str(exc_info.value)
+    assert "registration ack timed out" in message
+    assert "daemon still reachable" in message
+    assert "daemon died" not in message
+    assert writer.closed
+    assert writer.wait_closed_called
+
+
+@pytest.mark.asyncio
 async def test_run_wraps_registration_write_failures(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_daemon_overlap_guard.py
+++ b/tests/unit/test_daemon_overlap_guard.py
@@ -7,9 +7,9 @@ import socket
 import subprocess
 from datetime import datetime, timedelta
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
-from unittest.mock import AsyncMock
 
 import chunkhound.daemon.discovery as discovery_module
 from chunkhound.daemon.discovery import (
@@ -101,7 +101,7 @@ def test_unix_ipc_address_uses_runtime_scoped_socket_dir(
     tmp_path: Path,
 ) -> None:
     """Unix IPC should live under the active runtime-scoped socket directory."""
-    runtime_dir = _set_runtime_dir_env(monkeypatch, tmp_path)
+    _set_runtime_dir_env(monkeypatch, tmp_path)
     monkeypatch.setattr(discovery_module.sys, "platform", "linux")
 
     project_dir = tmp_path / "repo"
@@ -202,7 +202,7 @@ def test_windows_ipc_address_changes_with_runtime_dir(
     assert address_a != address_b
 
 
-def test_windows_startup_ipc_address_avoids_live_sibling_port_collision_without_registry(
+def test_windows_startup_ipc_avoids_live_sibling_port_without_registry(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -755,7 +755,9 @@ async def test_ensure_daemon_running_publishes_registry_entry_authoritatively(
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_path.touch()
 
-    def fake_start(args: object, *, socket_path: str | None = None) -> DaemonStartupHandle:
+    def fake_start(
+        args: object, *, socket_path: str | None = None
+    ) -> DaemonStartupHandle:
         # Publish an authoritative runtime-scoped lock file the way a real
         # daemon would — but deliberately never publish a registry entry, so
         # the proxy-side write is the only thing that can close the gap.
@@ -833,7 +835,9 @@ async def test_find_or_start_daemon_terminates_child_when_registry_publish_fails
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_path.touch()
 
-    def fake_start(args: object, *, socket_path: str | None = None) -> DaemonStartupHandle:
+    def fake_start(
+        args: object, *, socket_path: str | None = None
+    ) -> DaemonStartupHandle:
         del args, socket_path
         discovery.write_lock(os.getpid(), fake_address, auth_token="token")
         return DaemonStartupHandle(process=fake_process, log_path=log_path)  # type: ignore[arg-type]
@@ -1092,6 +1096,48 @@ def test_write_json_atomically_retries_transient_windows_replace_error(
     assert json.loads(target_path.read_text()) == {"value": 1}
 
 
+def test_format_startup_failure_treats_completed_startup_as_historical_context(
+    tmp_path: Path,
+) -> None:
+    """Post-startup failures should not present old startup breadcrumbs as active."""
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+    discovery = DaemonDiscovery(project_dir)
+    log_path = project_dir / ".chunkhound" / "daemon.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    started_at = (datetime.now() - timedelta(seconds=1178)).isoformat()
+    completed_at = (datetime.now() - timedelta(seconds=1174)).isoformat()
+    log_path.write_text(
+        "\n".join(
+            [
+                f"[{started_at}] [startup] startup: startup tracking began mode=daemon",
+                (
+                    f"[{completed_at}] [startup] startup: phase completed: "
+                    "startup_barrier duration=3.741s"
+                ),
+                (
+                    f"[{completed_at}] [startup] startup: startup completed "
+                    "duration=4.153s"
+                ),
+                (
+                    "08:55:33 | WARNING  | Watchman event translation warning: "
+                    "Skipping unexpected Watchman file type '?'"
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    message = discovery.format_startup_failure(
+        prefix="ChunkHound daemon died during registration handshake",
+        log_path=log_path,
+    )
+
+    assert "Daemon startup status: completed" in message
+    assert "Elapsed startup duration so far" not in message
+    assert "Last known startup phase: startup_barrier" not in message
+
+
 def test_format_startup_failure_includes_phase_elapsed_and_error(
     tmp_path: Path,
 ) -> None:
@@ -1141,7 +1187,10 @@ def test_format_startup_failure_parses_prefixed_breadcrumbs_and_keeps_legacy_sup
             [
                 f"[{started_at}] [startup] startup: startup tracking began mode=daemon",
                 f"[{started_at}] [startup] phase completed: db_connect duration=0.125s",
-                f"[{started_at}] [startup] startup: phase started: watchman_watch_project",
+                (
+                    f"[{started_at}] [startup] startup: phase started: "
+                    "watchman_watch_project"
+                ),
                 (
                     f"[{started_at}] [startup] startup: startup failed duration=12.0s "
                     "error=watchman session bootstrap exploded"

--- a/tests/unit/test_daemon_overlap_guard.py
+++ b/tests/unit/test_daemon_overlap_guard.py
@@ -924,9 +924,11 @@ async def test_find_or_start_daemon_terminates_detached_child_on_startup_timeout
         ),
     )
 
-    with pytest.raises(RuntimeError, match="did not start within"):
+    with pytest.raises(RuntimeError, match="did not start within") as exc_info:
         await discovery.find_or_start_daemon(object())
 
+    assert "process_state=running" in str(exc_info.value)
+    assert "Daemon log was empty or unavailable" in str(exc_info.value)
     assert fake_process.terminate_calls == 1
     assert fake_process.kill_calls == 1
 
@@ -1134,8 +1136,30 @@ def test_format_startup_failure_treats_completed_startup_as_historical_context(
     )
 
     assert "Daemon startup status: completed" in message
+    assert f"Daemon log path: {log_path}" in message
     assert "Elapsed startup duration so far" not in message
     assert "Last known startup phase: startup_barrier" not in message
+
+
+def test_format_startup_failure_reports_empty_or_missing_log_path(
+    tmp_path: Path,
+) -> None:
+    """Pre-breadcrumb daemon startup stalls should identify the daemon log path."""
+    project_dir = tmp_path / "repo"
+    project_dir.mkdir()
+    discovery = DaemonDiscovery(project_dir)
+    log_path = project_dir / ".chunkhound" / "daemon.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("", encoding="utf-8")
+
+    message = discovery.format_startup_failure(
+        prefix="ChunkHound daemon did not start within 30.0s",
+        log_path=log_path,
+    )
+
+    assert f"Daemon log path: {log_path}" in message
+    assert "Daemon log was empty or unavailable" in message
+    assert "Recent daemon log output" not in message
 
 
 def test_format_startup_failure_includes_phase_elapsed_and_error(


### PR DESCRIPTION
## Summary
Improve Watchman and daemon reliability diagnostics so CI failures expose actionable process state, while keeping deterministic Watchman contract tests runnable without a native Watchman install.

## Requirements
- Report final JSON-RPC subprocess exit status and stderr context after stdout EOF instead of stale `rc=None` diagnostics.
- Distinguish daemon registration ack timeouts from daemon death and keep completed startup breadcrumbs as historical context.
- Include Watchman entry context when unknown file types are encountered.
- Keep fake Watchman session/event translation tests independent of native Watchman availability, skipping only tests that require the real sidecar.

## Acceptance criteria
- EOF diagnostics wait briefly for subprocess termination before reporting return code and stderr tail.
- Daemon registration startup failures identify whether the daemon is still alive but failed to ack, or exited before the ack.
- Unknown Watchman file-type warnings include enough entry context to diagnose translation issues.
- Deterministic Watchman tests run in environments without packaged/native Watchman; native-dependent tests are still explicitly skipped.

## How to verify
- `uv run python -m ruff check chunkhound/daemon/client_proxy.py chunkhound/daemon/discovery.py chunkhound/services/realtime/adapters/watchman.py scripts/verify_watchman_live_indexing_e2e.py tests/unit/test_client_proxy.py tests/unit/test_daemon_overlap_guard.py tests/realtime/test_watchman_event_translation.py tests/realtime/test_watchman_session_bridge.py tests/test_verify_watchman_live_indexing_e2e.py`
- `uv run python -m pytest tests/unit/test_client_proxy.py tests/unit/test_daemon_overlap_guard.py tests/test_verify_watchman_live_indexing_e2e.py tests/realtime/test_watchman_session_bridge.py tests/realtime/test_watchman_event_translation.py -q` — 109 passed, 7 skipped
- `uv run python -m pytest tests/test_smoke.py -v -n auto` — 18 passed
- `git diff --check`

## Notes
- Full-suite attempt: `uv run python -m pytest tests/ -v` reached 3818 passed / 100 skipped, then failed in unrelated areas: local site build cannot import missing npm package `@resvg/resvg-js`, and two autodoc cleanup validation tests fail outside the touched paths.
