### PR TITLE
Fix: websearch ignores user indexing filters

### DIFF
--- a/chunkhound/api/cli/commands/quickresearch.py
+++ b/chunkhound/api/cli/commands/quickresearch.py
@@ -24,6 +24,14 @@ async def quickresearch_command(args: argparse.Namespace, config: Config) -> Non
         formatter.error(f"Path does not exist or is not a directory: {args.path}")
         sys.exit(1)
 
+    # _quickresearch is only invoked by `chunkhound websearch` and the websearch
+    # MCP tool, which point it at a tempdir of fetched pages. User-supplied
+    # include/exclude (from .chunkhound.json, --config, env vars, or global
+    # config) would zero out files in that tempdir. Reset to library defaults.
+    # System tempdirs typically have no .gitignore/.chignore, so the remaining
+    # ignore knobs (workspace_gitignore_*, chignore_file) are de-facto inert.
+    config.indexing.reset_user_include_exclude()
+
     embedding_manager, llm_manager = setup_embedding_llm(formatter, config)
 
     # Single create_services call owns the only :memory: connection.

--- a/chunkhound/core/config/indexing_config.py
+++ b/chunkhound/core/config/indexing_config.py
@@ -569,6 +569,24 @@ class IndexingConfig(BaseModel):
                 out.append(pat)
         return out
 
+    def reset_user_include_exclude(self) -> None:
+        """Reset include/exclude state to library defaults (mutates in place).
+
+        Resets: `include`, `exclude`, `exclude_sentinel`, `exclude_mode`,
+        `exclude_user_supplied`. Other ignore knobs (`chignore_file`,
+        `workspace_gitignore_*`, `gitignore_backend`) are untouched.
+
+        Use when filters loaded from `.chunkhound.json`, `--config`, env vars,
+        or global config must not apply to a runtime-supplied path (e.g., a
+        tempdir of fetched pages in `_quickresearch`).
+        """
+        defaults = IndexingConfig()
+        self.include = list(defaults.include)
+        self.exclude = list(defaults.exclude)
+        self.exclude_sentinel = None
+        self.exclude_mode = None
+        self.exclude_user_supplied = False
+
     @classmethod
     def extract_cli_overrides(cls, args: Any) -> dict[str, Any]:
         """Extract indexing config from CLI arguments."""

--- a/tests/unit/test_quickresearch_ignores_indexing_filters.py
+++ b/tests/unit/test_quickresearch_ignores_indexing_filters.py
@@ -1,0 +1,84 @@
+"""Contract test: `_quickresearch` ignores user include/exclude filters.
+
+The `_quickresearch` CLI subcommand is invoked only by `chunkhound websearch`
+and the websearch MCP tool to index a tempdir of fetched pages. User-supplied
+`indexing.include` / `indexing.exclude` (from `.chunkhound.json`, `--config`,
+or `CHUNKHOUND_INDEXING__*` env vars) would silently zero out those files.
+
+This test pins the externally-observable invariant: by the time
+`DirectoryIndexingService` is constructed inside `quickresearch_command`, the
+five filter-related `IndexingConfig` fields are reset to library defaults.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from chunkhound.api.cli.commands import quickresearch as qr_mod
+from chunkhound.core.config.config import Config
+from chunkhound.core.config.indexing_config import IndexingConfig
+
+
+@pytest.mark.asyncio
+async def test_quickresearch_ignores_user_include_exclude_filters(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Build a config carrying every filter knob the indexing pipeline reads.
+    config = Config()
+    config.indexing.include = ["**/*.py"]
+    config.indexing.exclude = ["**/foo/**"]
+    config.indexing.exclude_sentinel = ".gitignore"
+    config.indexing.exclude_mode = "config_only"
+    config.indexing.exclude_user_supplied = True
+
+    captured: dict[str, IndexingConfig] = {}
+
+    def fake_setup(formatter: Any, cfg: Any) -> tuple[Any, Any]:
+        return (object(), object())
+
+    def fake_create_services(db: Any, cfg: Any, embedding_manager: Any) -> Any:
+        return argparse.Namespace(indexing_coordinator=object())
+
+    class FakeIndexingService:
+        def __init__(
+            self,
+            *,
+            indexing_coordinator: Any,
+            config: Any,
+            progress_callback: Any,
+        ) -> None:
+            # Snapshot the indexing config at construction time — this is the
+            # moment the pipeline starts consulting include/exclude.
+            captured["indexing"] = config.indexing
+
+        async def process_directory(self, path: Any) -> None:
+            return None
+
+    async def fake_run_research(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(qr_mod, "setup_embedding_llm", fake_setup)
+    monkeypatch.setattr(qr_mod, "create_services", fake_create_services)
+    monkeypatch.setattr(qr_mod, "DirectoryIndexingService", FakeIndexingService)
+    monkeypatch.setattr(qr_mod, "run_research", fake_run_research)
+
+    args = argparse.Namespace(
+        query="q",
+        path=tmp_path,
+        path_filter=None,
+        verbose=False,
+    )
+
+    await qr_mod.quickresearch_command(args, config)
+
+    snapshot = captured["indexing"]
+    defaults = IndexingConfig()
+    assert snapshot.include == defaults.include
+    assert snapshot.exclude == defaults.exclude
+    assert snapshot.exclude_sentinel is None
+    assert snapshot.exclude_mode is None
+    assert snapshot.exclude_user_supplied is False


### PR DESCRIPTION
**Note**: This PR was generated by an AI agent. If you'd like to talk with other humans, drop by our [Discord](https://discord.gg/BAepHEXXnX)!

---

## Fix: websearch ignores user indexing filters

`chunkhound websearch` (and the websearch MCP tool) drop fetched pages into a tempdir and then re-enter the CLI as the hidden `_quickresearch` subcommand to index them in memory. The problem: `_quickresearch` loaded the *user's* `Config`, so any `indexing.include` / `indexing.exclude` configured in `.chunkhound.json`, `--config`, `CHUNKHOUND_INDEXING__*` env vars, or the new global config file would also apply to that tempdir. If the user had something like `include: ["**/*.py"]`, every fetched page got silently filtered out and the websearch returned nothing — no error, just empty.

The fix adds `IndexingConfig.reset_user_include_exclude()`, which resets the five filter-related fields (`include`, `exclude`, `exclude_sentinel`, `exclude_mode`, `exclude_user_supplied`) to library defaults, and calls it at the top of `quickresearch_command` before services are built. Other ignore knobs (`chignore_file`, `workspace_gitignore_*`, `gitignore_backend`) are intentionally left alone — system tempdirs don't carry `.gitignore` / `.chignore`, so those are de-facto inert anyway and keeping them avoids surprising downstream behavior. A contract test pins the invariant at the boundary that matters: by the time `DirectoryIndexingService` is constructed, the five fields are back to defaults.

No breaking changes — `_quickresearch` is an internal subcommand (hidden from `--help`) and the new method is additive. End-user value: websearch actually returns results regardless of project-level indexing config.
[AGENT_REVIEW.md](https://github.com/user-attachments/files/29175245/AGENT_REVIEW.md)
