### PR TITLE
feat(parsers): add Ruby language support

### DIFF
--- a/chunkhound/core/types/common.py
+++ b/chunkhound/core/types/common.py
@@ -182,6 +182,7 @@ class Language(Enum):
     SWIFT = "swift"
     DART = "dart"
     ELIXIR = "elixir"
+    RUBY = "ruby"
     LUA = "lua"
     TWINCAT = "twincat"
 
@@ -224,6 +225,8 @@ class Language(Enum):
             "gnumakefile": cls.MAKEFILE,
             "dockerfile": cls.TEXT,
             "jenkinsfile": cls.TEXT,
+            "gemfile": cls.RUBY,
+            "rakefile": cls.RUBY,
         }
 
         if basename in filename_map:
@@ -308,6 +311,9 @@ class Language(Enum):
             ".swiftinterface": cls.SWIFT,
             ".ex": cls.ELIXIR,
             ".exs": cls.ELIXIR,
+            ".rb": cls.RUBY,
+            ".rake": cls.RUBY,
+            ".gemspec": cls.RUBY,
             ".lua": cls.LUA,
             ".scss": cls.SCSS if SCSS_AVAILABLE else cls.TEXT,
             ".html": cls.HTML,
@@ -377,6 +383,7 @@ class Language(Enum):
             Language.SWIFT,
             Language.DART,
             Language.ELIXIR,
+            Language.RUBY,
             Language.LUA,
             Language.TWINCAT,
         }
@@ -401,6 +408,7 @@ class Language(Enum):
             Language.SVELTE,
             Language.SWIFT,
             Language.DART,
+            Language.RUBY,
         }
 
     @property

--- a/chunkhound/parsers/mappings/__init__.py
+++ b/chunkhound/parsers/mappings/__init__.py
@@ -30,6 +30,7 @@ from .objc import ObjCMapping
 from .pdf import PDFMapping
 from .php import PHPMapping
 from .python import PythonMapping
+from .ruby import RubyMapping
 from .rust import RustMapping
 from .scss import ScssMapping
 from .sql import SqlMapping
@@ -72,6 +73,7 @@ __all__ = [
     "PDFMapping",
     "PHPMapping",
     "PythonMapping",
+    "RubyMapping",
     "RustMapping",
     "ScssMapping",
     "SqlMapping",

--- a/chunkhound/parsers/mappings/ruby.py
+++ b/chunkhound/parsers/mappings/ruby.py
@@ -40,13 +40,17 @@ class RubyMapping(BaseMapping):
 
     def get_function_query(self) -> str:
         """Get tree-sitter query pattern for Ruby method definitions."""
+        # name: (_) matches every method-name node shape - identifier
+        # (plain_method), setter (name=), and operator ([], <=>, +, ...) -
+        # mirroring upstream tree-sitter-ruby tags.scm. (identifier) alone
+        # silently drops setter and operator methods.
         return """
             (method
-                name: (identifier) @function_name
+                name: (_) @function_name
             ) @function_def
 
             (singleton_method
-                name: (identifier) @function_name
+                name: (_) @function_name
             ) @function_def
         """
 
@@ -107,12 +111,15 @@ class RubyMapping(BaseMapping):
                 name: (_) @name
             ) @definition
 
+            ; name: (_) matches identifier (plain_method), setter (name=),
+            ; and operator ([], <=>, +, ...) method names, matching upstream
+            ; tags.scm. (identifier) alone drops setter/operator methods.
             (method
-                name: (identifier) @name
+                name: (_) @name
             ) @definition
 
             (singleton_method
-                name: (identifier) @name
+                name: (_) @name
             ) @definition
 
             ; Constant assignment (left side is a constant node)

--- a/chunkhound/parsers/mappings/ruby.py
+++ b/chunkhound/parsers/mappings/ruby.py
@@ -1,0 +1,377 @@
+"""Ruby language mapping for unified parser architecture.
+
+This module provides Ruby-specific tree-sitter queries and extraction logic
+for mapping Ruby AST nodes to universal semantic concepts used by the unified
+parser.
+
+Ruby's tree-sitter grammar exposes real named nodes (``class``, ``module``,
+``method``, ``singleton_method``), so this mapping follows the named-node
+pattern used by ``python.py`` / ``java.py`` rather than the call-node pattern
+used by ``elixir.py``.
+"""
+
+import re
+from pathlib import Path
+from typing import Any
+
+from tree_sitter import Node as TSNode
+
+from chunkhound.core.types.common import Language
+from chunkhound.parsers.mappings.base import MAX_CONSTANT_VALUE_LENGTH, BaseMapping
+from chunkhound.parsers.universal_engine import UniversalConcept
+
+
+class RubyMapping(BaseMapping):
+    """Ruby-specific tree-sitter mapping implementation.
+
+    Handles Ruby's core definition constructs:
+    - Modules and classes (with inheritance via ``superclass``)
+    - Instance methods (``method``) and class methods (``singleton_method``)
+    - Constant assignments (UPPER_SNAKE_CASE / CamelCase constants)
+    - Comments
+    - ``require`` / ``require_relative`` imports
+    """
+
+    def __init__(self) -> None:
+        """Initialize Ruby mapping."""
+        super().__init__(Language.RUBY)
+
+    # BaseMapping required (legacy) methods -------------------------------
+
+    def get_function_query(self) -> str:
+        """Get tree-sitter query pattern for Ruby method definitions."""
+        return """
+            (method
+                name: (identifier) @function_name
+            ) @function_def
+
+            (singleton_method
+                name: (identifier) @function_name
+            ) @function_def
+        """
+
+    def get_class_query(self) -> str:
+        """Get tree-sitter query pattern for Ruby class/module definitions."""
+        return """
+            (class
+                name: (_) @class_name
+            ) @class_def
+
+            (module
+                name: (_) @class_name
+            ) @class_def
+        """
+
+    def get_comment_query(self) -> str:
+        """Get tree-sitter query pattern for Ruby comments."""
+        return """
+            (comment) @comment
+        """
+
+    def extract_function_name(self, node: TSNode | None, source: str) -> str:
+        """Extract method name from a method definition node."""
+        if node is None:
+            return self.get_fallback_name(node, "method")
+
+        name_node = node.child_by_field_name("name")
+        if name_node:
+            return self.get_node_text(name_node, source).strip()
+
+        return self.get_fallback_name(node, "method")
+
+    def extract_class_name(self, node: TSNode | None, source: str) -> str:
+        """Extract class/module name from a class or module definition node."""
+        if node is None:
+            return self.get_fallback_name(node, "class")
+
+        name_node = node.child_by_field_name("name")
+        if name_node:
+            return self.get_node_text(name_node, source).strip()
+
+        return self.get_fallback_name(node, "class")
+
+    # LanguageMapping protocol methods -----------------------------------
+
+    def get_query_for_concept(self, concept: UniversalConcept) -> str | None:
+        """Get tree-sitter query for a universal concept in Ruby."""
+
+        if concept == UniversalConcept.DEFINITION:
+            # name: (_) covers both plain constants (Foo) and scoped names
+            # (Foo::Bar) for class/module definitions.
+            return """
+            (class
+                name: (_) @name
+            ) @definition
+
+            (module
+                name: (_) @name
+            ) @definition
+
+            (method
+                name: (identifier) @name
+            ) @definition
+
+            (singleton_method
+                name: (identifier) @name
+            ) @definition
+
+            ; Constant assignment (left side is a constant node)
+            (assignment
+                left: (constant) @lhs
+                right: (_) @rhs
+            ) @definition
+            """
+
+        elif concept == UniversalConcept.BLOCK:
+            return """
+            (do_block) @block
+            (block) @block
+            (if) @block
+            (unless) @block
+            (while) @block
+            (until) @block
+            (for) @block
+            (case) @block
+            (begin) @block
+            """
+
+        elif concept == UniversalConcept.COMMENT:
+            return """
+            (comment) @definition
+            """
+
+        elif concept == UniversalConcept.IMPORT:
+            return """
+            (call
+                method: (identifier) @_m
+                (#match? @_m "^(require|require_relative|load|autoload)$")
+            ) @definition
+            """
+
+        elif concept == UniversalConcept.STRUCTURE:
+            return """
+            (program) @definition
+            """
+
+        return None
+
+    def extract_name(
+        self, concept: UniversalConcept, captures: dict[str, TSNode], content: bytes
+    ) -> str:
+        """Extract a name from captures for this concept."""
+
+        source = content.decode("utf-8")
+
+        if concept == UniversalConcept.DEFINITION:
+            # Prefer explicit name capture (class/module/method/singleton_method)
+            if "name" in captures:
+                name = self.get_node_text(captures["name"], source).strip()
+                if name:
+                    return name
+
+            # Constant assignment: use the left-hand constant
+            if "lhs" in captures:
+                name = self.get_node_text(captures["lhs"], source).strip()
+                if name:
+                    return name
+
+            if "definition" in captures:
+                node = captures["definition"]
+                line = node.start_point[0] + 1
+                return f"definition_line_{line}"
+
+            return "unnamed_definition"
+
+        elif concept == UniversalConcept.BLOCK:
+            if "block" in captures:
+                node = captures["block"]
+                line = node.start_point[0] + 1
+                return f"{node.type}_line_{line}"
+
+            return "unnamed_block"
+
+        elif concept == UniversalConcept.COMMENT:
+            if "definition" in captures:
+                node = captures["definition"]
+                line = node.start_point[0] + 1
+                return f"comment_line_{line}"
+
+            return "unnamed_comment"
+
+        elif concept == UniversalConcept.IMPORT:
+            if "definition" in captures:
+                def_text = self.get_node_text(captures["definition"], source).strip()
+                match = re.search(
+                    r"(?:require_relative|require|load|autoload)\s*[\(\s]*"
+                    r'["\']([^"\']+)["\']',
+                    def_text,
+                )
+                if match:
+                    target = match.group(1)
+                    leaf = target.split("/")[-1]
+                    return f"require_{leaf}"
+
+            return "unnamed_import"
+
+        elif concept == UniversalConcept.STRUCTURE:
+            return "file_structure"
+
+        return "unnamed"
+
+    def extract_content(
+        self, concept: UniversalConcept, captures: dict[str, TSNode], content: bytes
+    ) -> str:
+        """Extract the source content for this concept."""
+
+        source = content.decode("utf-8")
+
+        if concept == UniversalConcept.BLOCK and "block" in captures:
+            return self.get_node_text(captures["block"], source)
+        elif "definition" in captures:
+            return self.get_node_text(captures["definition"], source)
+        elif captures:
+            node = list(captures.values())[0]
+            return self.get_node_text(node, source)
+
+        return ""
+
+    def extract_metadata(
+        self, concept: UniversalConcept, captures: dict[str, TSNode], content: bytes
+    ) -> dict[str, Any]:
+        """Extract Ruby-specific metadata from captures."""
+
+        source = content.decode("utf-8")
+        metadata: dict[str, Any] = {}
+
+        if concept == UniversalConcept.DEFINITION:
+            def_node = captures.get("definition")
+            if def_node:
+                metadata["node_type"] = def_node.type
+
+                if def_node.type == "class":
+                    metadata["kind"] = "class"
+                    superclass = def_node.child_by_field_name("superclass")
+                    if superclass:
+                        # superclass node text includes the leading "< "
+                        text = self.get_node_text(superclass, source).strip()
+                        metadata["superclass"] = text.lstrip("<").strip()
+                elif def_node.type == "module":
+                    metadata["kind"] = "module"
+                    # Ruby modules are namespaces (and mixin containers); the
+                    # engine has no "module" kind, so steer it explicitly rather
+                    # than falling through to the FUNCTION default.
+                    metadata["chunk_type_hint"] = "namespace"
+                elif def_node.type == "method":
+                    metadata["kind"] = "method"
+                elif def_node.type == "singleton_method":
+                    metadata["kind"] = "singleton_method"
+                    metadata["is_class_method"] = True
+                elif def_node.type == "assignment":
+                    metadata["kind"] = "constant"
+
+        elif concept == UniversalConcept.IMPORT:
+            if "definition" in captures:
+                import_text = self.get_node_text(captures["definition"], source).strip()
+                match = re.search(
+                    r"(?:require_relative|require|load|autoload)\s*[\(\s]*"
+                    r'["\']([^"\']+)["\']',
+                    import_text,
+                )
+                if match:
+                    metadata["module"] = match.group(1)
+                if import_text.startswith("require_relative"):
+                    metadata["import_type"] = "require_relative"
+                elif import_text.startswith("require"):
+                    metadata["import_type"] = "require"
+
+        elif concept == UniversalConcept.COMMENT:
+            if "definition" in captures:
+                comment_text = self.get_node_text(captures["definition"], source)
+                clean_text = self.clean_comment_text(comment_text)
+                comment_type = "regular"
+                is_doc = False
+
+                if clean_text:
+                    upper_text = clean_text.upper()
+                    if any(
+                        prefix in upper_text
+                        for prefix in ["TODO:", "FIXME:", "HACK:", "NOTE:", "WARNING:"]
+                    ):
+                        comment_type = "annotation"
+                        is_doc = True
+                    elif clean_text.startswith("#!/"):
+                        comment_type = "shebang"
+                        is_doc = True
+
+                metadata["comment_type"] = comment_type
+                if is_doc:
+                    metadata["is_doc_comment"] = True
+
+        return metadata
+
+    def clean_comment_text(self, text: str) -> str:
+        """Strip Ruby comment markers from comment text."""
+        cleaned = text.strip()
+        if cleaned.startswith("#"):
+            cleaned = cleaned[1:]
+        return cleaned.strip()
+
+    def extract_constants(
+        self, concept: UniversalConcept, captures: dict[str, TSNode], content: bytes
+    ) -> list[dict[str, str]] | None:
+        """Extract constant definitions from Ruby code.
+
+        Ruby constants begin with an uppercase letter; the grammar exposes the
+        left-hand side as a ``constant`` node, so any captured constant
+        assignment qualifies.
+        """
+        if concept != UniversalConcept.DEFINITION:
+            return None
+
+        source = content.decode("utf-8")
+
+        lhs = captures.get("lhs")
+        if lhs is None or lhs.type != "constant":
+            return None
+
+        name = self.get_node_text(lhs, source).strip()
+        if not name:
+            return None
+
+        value = ""
+        rhs = captures.get("rhs")
+        if rhs is not None:
+            value = self.get_node_text(rhs, source).strip()
+            if len(value) > MAX_CONSTANT_VALUE_LENGTH:
+                value = value[:MAX_CONSTANT_VALUE_LENGTH]
+
+        return [{"name": name, "value": value}]
+
+    def resolve_import_paths(
+        self, import_text: str, base_dir: Path, source_file: Path
+    ) -> list[Path]:
+        """Resolve a Ruby require/require_relative target to a file path."""
+        # require_relative is resolved relative to the requiring file.
+        match = re.search(r'require_relative\s*[\(\s]*["\']([^"\']+)["\']', import_text)
+        if match:
+            target = match.group(1)
+            if not target.endswith(".rb"):
+                target += ".rb"
+            resolved = (source_file.parent / target).resolve()
+            if resolved.exists():
+                return [resolved]
+            return []
+
+        # require is resolved against load paths; approximate with base_dir and
+        # common Rails source roots.
+        match = re.search(r'require\s*[\(\s]*["\']([^"\']+)["\']', import_text)
+        if match:
+            target = match.group(1)
+            if not target.endswith(".rb"):
+                target += ".rb"
+            for root in (base_dir, base_dir / "lib", base_dir / "app"):
+                candidate = root / target
+                if candidate.exists():
+                    return [candidate]
+
+        return []

--- a/chunkhound/parsers/parser_factory.py
+++ b/chunkhound/parsers/parser_factory.py
@@ -74,6 +74,7 @@ from chunkhound.parsers.mappings import (
     PDFMapping,
     PHPMapping,
     PythonMapping,
+    RubyMapping,
     RustMapping,
     ScssMapping,
     SqlMapping,
@@ -98,6 +99,7 @@ _swift_lang = _get_lang("swift")
 _yaml_lang = _get_lang("yaml")
 _hcl_lang = _get_lang("hcl")
 _dart_lang = _get_lang("dart")
+_ruby_lang = _get_lang("ruby")
 
 
 class _LanguagePackWrapper:
@@ -116,6 +118,7 @@ ts_swift = _LanguagePackWrapper(_swift_lang)
 ts_yaml = _LanguagePackWrapper(_yaml_lang)
 ts_hcl = _LanguagePackWrapper(_hcl_lang)
 ts_dart = _LanguagePackWrapper(_dart_lang)
+ts_ruby = _LanguagePackWrapper(_ruby_lang)
 
 _scss_lang = _get_lang("scss")
 ts_scss: _LanguagePackWrapper | None = (
@@ -229,6 +232,7 @@ LANGUAGE_CONFIGS: dict[Language, LanguageConfig] = {
     ),
     # Haskell (required dependency in pyproject.toml)
     Language.ELIXIR: LanguageConfig(ts_elixir, ElixirMapping, True, "elixir"),
+    Language.RUBY: LanguageConfig(ts_ruby, RubyMapping, True, "ruby"),
     Language.HASKELL: LanguageConfig(ts_haskell, HaskellMapping, True, "haskell"),
     Language.HCL: LanguageConfig(ts_hcl, HclMapping, True, "hcl"),
     # Language pack languages (required via tree-sitter-language-pack)
@@ -333,6 +337,14 @@ EXTENSION_TO_LANGUAGE: dict[str, Language] = {
     # Elixir
     ".ex": Language.ELIXIR,
     ".exs": Language.ELIXIR,
+    # Ruby
+    ".rb": Language.RUBY,
+    ".rake": Language.RUBY,
+    ".gemspec": Language.RUBY,
+    "Gemfile": Language.RUBY,
+    "gemfile": Language.RUBY,
+    "Rakefile": Language.RUBY,
+    "rakefile": Language.RUBY,
     ".mm": Language.OBJC,
     # PHP
     ".php": Language.PHP,

--- a/tests/test_e2e_chunk_size_constraints.py
+++ b/tests/test_e2e_chunk_size_constraints.py
@@ -255,6 +255,15 @@ LARGE_LANGUAGE_SAMPLES: dict[Language, tuple[str, str, str]] = {
         # Normal
         "function greet(name)\n    return 'Hello, ' .. name\nend",
     ),
+    Language.RUBY: (
+        ".rb",
+        # Large method - triggers line-based split
+        "def process_data(items)\n"
+        + _make_large_statements("  x = 1")
+        + "\n  x\nend",
+        # Normal
+        'def greet(name)\n  "Hello, #{name}"\nend',
+    ),
     Language.BASH: (
         ".sh",
         # Large script

--- a/tests/test_language_extensions.py
+++ b/tests/test_language_extensions.py
@@ -260,7 +260,6 @@ class TestExtensionConsistency:
 
         # Test extensions that are NOT in the parser system
         unsupported_extensions = [
-            ".rb",  # Ruby (no parser)
             ".scala",  # Scala (no parser)
             ".r",  # R language (no parser)
             ".xyz",  # Completely invalid

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -49,6 +49,7 @@ LANGUAGE_SAMPLES = {
     Language.SCSS: "$color: red; .btn { color: $color; }",
     Language.JINJA: "<section id='main'>{{ title }}</section>",
     Language.ELIXIR: "defmodule Hello do\n  def world, do: :ok\nend",
+    Language.RUBY: "module Hello\n  def world\n    :ok\n  end\nend",
     Language.TWINCAT: '<?xml version="1.0" encoding="utf-8"?>\n<TcPlcObject Version="1.1.0.1">\n  <POU Name="PRG_Main" Id="{00000000-0000-0000-0000-000000000000}" SpecialFunc="None">\n    <Declaration><![CDATA[PROGRAM PRG_Main\nVAR\n    x : INT;\nEND_VAR\n]]></Declaration>\n    <Implementation>\n      <ST><![CDATA[x := 1;\n]]></ST>\n    </Implementation>\n  </POU>\n</TcPlcObject>',
 }
 

--- a/tests/test_qa_deterministic.py
+++ b/tests/test_qa_deterministic.py
@@ -420,6 +420,7 @@ function qaTestFunction() {
             Language.PDF: None,  # PDF is binary, skip content template
             Language.SQL: '-- SQL QA test\nCREATE TABLE qa_test (\n    id INTEGER PRIMARY KEY,\n    content TEXT DEFAULT \'sql_qa_unique\'\n);',
             Language.ELIXIR: 'defmodule QATest do\n  # Elixir QA test\n  def test, do: "elixir_qa_unique"\nend',
+            Language.RUBY: 'module QATest\n  # Ruby QA test\n  def test\n    "ruby_qa_unique"\n  end\nend',
             Language.HTML: '<!DOCTYPE html>\n<html>\n<body>\n  <!-- HTML QA test -->\n  <p>html_qa_unique</p>\n</body>\n</html>',
             Language.CSS: '/* CSS QA test */\n.qa-test {\n  content: "css_qa_unique";\n  color: blue;\n}',
             Language.SCSS: '/* SCSS QA test */\n$color: blue;\n.qa-test {\n  content: "scss_qa_unique";\n  color: $color;\n}',
@@ -465,6 +466,7 @@ function qaTestFunction() {
             Language.PDF: ".pdf",
             Language.SQL: ".sql",
             Language.ELIXIR: ".ex",
+            Language.RUBY: ".rb",
             Language.HTML: ".html",
             Language.CSS: ".css",
             Language.SCSS: ".scss",

--- a/tests/test_ruby_parser.py
+++ b/tests/test_ruby_parser.py
@@ -1,0 +1,154 @@
+"""Tests for Ruby language parser."""
+
+import pytest
+
+from chunkhound.core.types.common import ChunkType, FileId, Language
+from chunkhound.parsers.mappings.ruby import RubyMapping
+from chunkhound.parsers.parser_factory import get_parser_factory
+
+
+class TestRubyFileDetection:
+    """Property 1: File Extension Recognition."""
+
+    def test_rb_extension(self):
+        assert Language.from_file_extension("app/models/user.rb") == Language.RUBY
+
+    def test_rake_extension(self):
+        assert Language.from_file_extension("lib/tasks/db.rake") == Language.RUBY
+
+    def test_gemspec_extension(self):
+        assert Language.from_file_extension("foo.gemspec") == Language.RUBY
+
+    def test_gemfile_by_name(self):
+        assert Language.from_file_extension("Gemfile") == Language.RUBY
+
+    def test_rakefile_by_name(self):
+        assert Language.from_file_extension("Rakefile") == Language.RUBY
+
+    def test_is_programming_language(self):
+        assert Language.RUBY.is_programming_language
+
+    def test_supports_classes(self):
+        assert Language.RUBY.supports_classes
+
+
+class TestRubyMapping:
+    """Test RubyMapping extraction logic."""
+
+    def test_language_is_ruby(self):
+        assert RubyMapping().language == Language.RUBY
+
+    def test_clean_comment_text(self):
+        mapping = RubyMapping()
+        assert mapping.clean_comment_text("# hello world") == "hello world"
+        assert mapping.clean_comment_text("#comment") == "comment"
+
+
+class TestRubyParser:
+    """Test Ruby parser functionality against user-visible chunk contracts."""
+
+    @pytest.fixture
+    def parser(self):
+        return get_parser_factory().create_parser(Language.RUBY)
+
+    def test_parser_loads(self, parser):
+        assert parser is not None
+
+    def test_parse_module(self, parser, tmp_path):
+        f = tmp_path / "test.rb"
+        f.write_text("module AssessmentFunctions\n  def register; end\nend\n")
+        chunks = parser.parse_file(f, FileId(1))
+
+        symbols = [c.symbol for c in chunks]
+        assert any(s == "AssessmentFunctions" for s in symbols)
+        # Ruby modules are namespaces, not functions
+        module_chunks = [c for c in chunks if c.symbol == "AssessmentFunctions"]
+        assert any(c.chunk_type == ChunkType.NAMESPACE for c in module_chunks)
+
+    def test_parse_class_with_inheritance(self, parser, tmp_path):
+        f = tmp_path / "test.rb"
+        f.write_text("class BookingCandidate < ApplicationRecord\nend\n")
+        chunks = parser.parse_file(f, FileId(1))
+
+        class_chunks = [c for c in chunks if c.symbol == "BookingCandidate"]
+        assert class_chunks, [c.symbol for c in chunks]
+        assert any(c.chunk_type == ChunkType.CLASS for c in class_chunks)
+
+    def test_parse_instance_method(self, parser, tmp_path):
+        f = tmp_path / "test.rb"
+        f.write_text("def register_assessments(x)\n  x + 1\nend\n")
+        chunks = parser.parse_file(f, FileId(1))
+
+        method_chunks = [c for c in chunks if c.chunk_type == ChunkType.METHOD]
+        assert any(c.symbol == "register_assessments" for c in method_chunks)
+
+    def test_parse_singleton_method(self, parser, tmp_path):
+        f = tmp_path / "test.rb"
+        f.write_text("class C\n  def self.build(args)\n    new(args)\n  end\nend\n")
+        chunks = parser.parse_file(f, FileId(1))
+
+        symbols = [c.symbol for c in chunks]
+        assert "build" in symbols
+
+    def test_parse_constant(self, parser, tmp_path):
+        f = tmp_path / "test.rb"
+        f.write_text("MAX_RETRIES = 3\n")
+        chunks = parser.parse_file(f, FileId(1))
+
+        const_chunks = [c for c in chunks if c.symbol == "MAX_RETRIES"]
+        assert const_chunks
+        assert any(c.chunk_type == ChunkType.VARIABLE for c in const_chunks)
+
+    def test_parse_requires(self, parser, tmp_path):
+        f = tmp_path / "test.rb"
+        f.write_text('require "json"\nrequire_relative "../lib/foo"\n')
+        chunks = parser.parse_file(f, FileId(1))
+
+        import_chunks = [c for c in chunks if c.chunk_type == ChunkType.IMPORT]
+        import_content = " ".join(c.code for c in import_chunks)
+        assert "json" in import_content
+        assert "foo" in import_content
+
+    def test_method_name_extraction_is_clean(self, parser, tmp_path):
+        """Property 3: extract the name, not 'def' or the full signature."""
+        f = tmp_path / "test.rb"
+        f.write_text('def full_name\n  "#{first} #{last}"\nend\n')
+        chunks = parser.parse_file(f, FileId(1))
+
+        method_chunks = [c for c in chunks if c.chunk_type == ChunkType.METHOD]
+        assert any(c.symbol == "full_name" for c in method_chunks), (
+            f"Expected 'full_name' in {[c.symbol for c in method_chunks]}"
+        )
+
+
+class TestRubyImportResolution:
+    """Tests for Ruby require/require_relative path resolution."""
+
+    @pytest.fixture
+    def mapping(self):
+        return RubyMapping()
+
+    def test_require_relative_resolves(self, mapping, tmp_path):
+        target = tmp_path / "lib" / "foo.rb"
+        target.parent.mkdir(parents=True)
+        target.write_text("module Foo; end")
+
+        source = tmp_path / "lib" / "bar.rb"
+        result = mapping.resolve_import_paths(
+            'require_relative "foo"', tmp_path, source
+        )
+        assert result == [target]
+
+    def test_require_resolves_against_lib(self, mapping, tmp_path):
+        target = tmp_path / "lib" / "helpers.rb"
+        target.parent.mkdir(parents=True)
+        target.write_text("module Helpers; end")
+
+        source = tmp_path / "app" / "thing.rb"
+        result = mapping.resolve_import_paths('require "helpers"', tmp_path, source)
+        assert result == [target]
+
+    def test_unresolvable_returns_empty(self, mapping, tmp_path):
+        source = tmp_path / "app" / "thing.rb"
+        result = mapping.resolve_import_paths('require "nope"', tmp_path, source)
+        assert result == []

--- a/tests/test_ruby_parser.py
+++ b/tests/test_ruby_parser.py
@@ -120,6 +120,37 @@ class TestRubyParser:
             f"Expected 'full_name' in {[c.symbol for c in method_chunks]}"
         )
 
+    @pytest.mark.parametrize(
+        "source,expected_symbol",
+        [
+            ("def name=(value)\n  @name = value\nend\n", "name="),
+            ("def [](key)\n  @data[key]\nend\n", "[]"),
+            ("def <=>(other)\n  0\nend\n", "<=>"),
+            ("def +(other)\n  dup\nend\n", "+"),
+        ],
+    )
+    def test_non_identifier_method_names_extracted(
+        self, parser, tmp_path, source, expected_symbol
+    ):
+        """Setter and operator methods must become searchable METHOD chunks.
+
+        Ruby method names are not always ``identifier`` nodes: setters
+        (``name=``) are ``setter`` nodes and operators (``[]``, ``<=>``,
+        ``+``) are ``operator`` nodes. The DEFINITION query must match every
+        shape (upstream tree-sitter-ruby tags.scm uses ``name: (_)``); the
+        narrower ``name: (identifier)`` drops these methods from the index
+        entirely. One method per file keeps the cAST greedy-merge pass from
+        absorbing the chunk under a neighbour's name.
+        """
+        f = tmp_path / "test.rb"
+        f.write_text(source)
+        chunks = parser.parse_file(f, FileId(1))
+
+        method_chunks = [c for c in chunks if c.chunk_type == ChunkType.METHOD]
+        assert any(c.symbol == expected_symbol for c in method_chunks), (
+            f"Expected {expected_symbol!r} in {[c.symbol for c in method_chunks]}"
+        )
+
 
 class TestRubyImportResolution:
     """Tests for Ruby require/require_relative path resolution."""

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -512,6 +512,7 @@ class TestParserLoading:
             Language.PDF: "hello world",
             Language.SWIFT: "struct Point { let x: Int; let y: Int }",
             Language.ELIXIR: "defmodule M do\n  def hello, do: :world\nend",
+            Language.RUBY: "module M\n  def hello\n    :world\n  end\nend",
         }
 
         factory = get_parser_factory()


### PR DESCRIPTION
## Why
Ruby source files (.rb, .rake, .gemspec, Gemfile, Rakefile) were classified as UNKNOWN and silently skipped at scan time. Ruby/Rails repositories could be indexed but searches never returned any Ruby source - only docs, config, and JS. The tree-sitter Ruby grammar already ships in tree-sitter-language-pack; only the wiring into ChunkHound was missing.

## What
- New `RubyMapping` using the named-node pattern (modeled on `python.py`), extracting modules, classes, instance/singleton methods, constants, comments, and require/require_relative imports with path resolution
- Ruby modules map to `NAMESPACE` chunks rather than the `FUNCTION` default
- Registered the `Language.RUBY` enum, grammar load, `LanguageConfig`, and extension/filename mappings
- Added Ruby to the per-language test registries that enforce full-language coverage, plus a dedicated `tests/test_ruby_parser.py` (20 contract tests)

## Testing
- `uv run pytest tests/test_smoke.py -v -n auto` - all pass
- Full suite: 3829 passed; remaining failures are pre-existing and environment-dependent (unrelated to this change)
- Verified module / class / method / singleton_method / constant extraction on real Rails-style source

Built by AI agents per project convention.