### PR TITLE
feat(parsers): index .haml files via text fallback

### DIFF
--- a/chunkhound/core/types/common.py
+++ b/chunkhound/core/types/common.py
@@ -319,6 +319,10 @@ class Language(Enum):
             # Use text fallback parser instead of silently producing
             # misaligned / empty chunks.
             ".sass": cls.TEXT,
+            # .haml has no bundled tree-sitter grammar (absent from
+            # tree-sitter-language-pack); index as text so files are searchable
+            # rather than silently skipped, mirroring the .sass fallback.
+            ".haml": cls.TEXT,
             ".jinja": cls.JINJA,
             ".j2": cls.JINJA,
             ".njk": cls.JINJA,

--- a/chunkhound/parsers/parser_factory.py
+++ b/chunkhound/parsers/parser_factory.py
@@ -382,6 +382,9 @@ EXTENSION_TO_LANGUAGE: dict[str, Language] = {
     # .sass uses indented syntax (no braces/semicolons) which is structurally
     # incompatible with the tree-sitter SCSS grammar — fall back to text parser.
     ".sass": Language.TEXT,
+    # .haml has no bundled tree-sitter grammar; fall back to the text parser so
+    # files are indexed and searchable rather than silently skipped.
+    ".haml": Language.TEXT,
     ".make": Language.MAKEFILE,
     # Text files (fallback)
     ".txt": Language.TEXT,

--- a/tests/test_language_extensions.py
+++ b/tests/test_language_extensions.py
@@ -355,6 +355,7 @@ class TestIssue277UnknownExtensions:
             (".properties", "Java properties files"),
             (".conf", "Generic config files"),
             (".cfg", "Generic config files (alt extension)"),
+            (".haml", "HAML templates (text fallback)"),
         ],
     )
     def test_common_text_extensions_indexed(self, ext, description):
@@ -399,6 +400,7 @@ class TestIssue277UnknownExtensions:
             ("test.properties", "Java properties"),
             ("test.conf", "Config file"),
             ("test.cfg", "Config file alt"),
+            ("test.haml", "HAML template"),
             ("Dockerfile", "Docker"),
             ("Jenkinsfile", "Jenkinsfile"),
         ],


### PR DESCRIPTION
## What

`.haml` files currently resolve to `Language.UNKNOWN` and are silently skipped by the indexer - they're absent from the extension maps, so the file walker never generates a discovery glob for them.

This maps `.haml` to `Language.TEXT`, so HAML files are indexed and searchable as text (cAST chunks). HAML structure is not parsed - there is no symbol extraction.

## Why a text fallback

There is no HAML grammar in `tree-sitter-language-pack` (`get_language("haml")` raises `LookupError`), and no `tree-sitter-haml` package in the dependency tree. Rather than vendor an external grammar, this mirrors the existing fallback already used for `.sass` (indented syntax, grammar-incompatible) and `.proto` / `.xml`.

## Changes

- Map `.haml` to `Language.TEXT` in both extension maps: `from_file_extension` (`core/types/common.py`) and `EXTENSION_TO_LANGUAGE` (`parsers/parser_factory.py`).
- Add `.haml` to the issue #277 coverage tests so it cannot silently regress to `UNKNOWN`.

3 files changed, 9 insertions.

## Testing

- `tests/test_language_extensions.py` and `tests/test_parsers.py` pass.
- `tests/test_smoke.py` passes.
- Verified end to end on a real Rails app: HAML view templates now index and return in search, where they previously returned nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
