### PR TITLE
fix(tokens): count special-token literals instead of failing the embedding batch

### DIFF
--- a/chunkhound/core/utils/token_utils.py
+++ b/chunkhound/core/utils/token_utils.py
@@ -183,7 +183,10 @@ def _estimate_tokens_openai(
     if enc is None and cl100k_fallback_ok:
         enc = _cl100k_base_safe()
     if enc is not None:
-        return len(enc.encode(text))
+        # disallowed_special=() so a source file containing a special-token
+        # literal (e.g. "<|endoftext|>") is counted as ordinary text instead of
+        # raising and failing the whole embedding batch. #315
+        return len(enc.encode(text, disallowed_special=()))
     # EMBEDDING_CHARS_PER_TOKEN (not LLM_CHARS_PER_TOKEN) because this function
     # is only called from estimate_tokens() for embedding providers; LLM callers
     # use estimate_tokens_llm() directly.

--- a/tests/unit/core/utils/test_token_utils.py
+++ b/tests/unit/core/utils/test_token_utils.py
@@ -45,6 +45,13 @@ class TestEstimateTokens:
         result = estimate_tokens("hello world", provider="azure_openai")
         assert result > 0
 
+    def test_special_token_literal_does_not_raise(self):
+        """A tiktoken special-token literal must be counted, not crash. #315."""
+        result = estimate_tokens(
+            "def f():  # <|endoftext|>\n    return 1", provider="azure_openai"
+        )
+        assert result > 0
+
     def test_empty_string_returns_zero(self):
         """Empty input short-circuits to 0, bypassing tiktoken entirely."""
         assert (
@@ -74,7 +81,7 @@ class TestEstimateTokensChunking:
 class _FakeEnc:
     """Fake tiktoken encoding — `// 2` distinguishes it from the `// 3` heuristic."""
 
-    def encode(self, text):
+    def encode(self, text, disallowed_special=()):
         return [0] * (len(text) // 2)
 
 


### PR DESCRIPTION
## Why

A source file containing a literal tiktoken special token (e.g. `<|endoftext|>`)
makes the real cl100k encoder raise `ValueError: Encountered text corresponding
to disallowed special token`. That exception propagates out of token counting and
aborts the **entire embedding batch**, so indexing reports `Embeddings: 0` — one
ordinary-looking source file silently breaks the whole run.

This is token *counting*, not prompting: a special-token literal in source is just
text, and one file must never fail the batch. Passing `disallowed_special=()` to the
sole `.encode()` call in `_estimate_tokens_openai()` makes tiktoken treat such
literals as ordinary text and count them normally.

The crash is on the official OpenAI / Azure path (and the cl100k fallback), so the
fix is warranted even though compatible proxies already skip tiktoken.

## Test

Added a real-component contract test (`provider="azure_openai"` reaches the actual
cl100k encoder): a source string with a `<|endoftext|>` literal must return a
positive count. Fails on `main` (ValueError), passes with the fix.

All smoke tests pass.

Closes #315
