### PR TITLE
feat(parsers): add PowerShell language support

### DIFF
--- a/chunkhound/core/types/common.py
+++ b/chunkhound/core/types/common.py
@@ -183,6 +183,7 @@ class Language(Enum):
     DART = "dart"
     ELIXIR = "elixir"
     LUA = "lua"
+    POWERSHELL = "powershell"
     TWINCAT = "twincat"
 
     # Web languages
@@ -309,6 +310,8 @@ class Language(Enum):
             ".ex": cls.ELIXIR,
             ".exs": cls.ELIXIR,
             ".lua": cls.LUA,
+            ".ps1": cls.POWERSHELL,
+            ".psm1": cls.POWERSHELL,
             ".scss": cls.SCSS if SCSS_AVAILABLE else cls.TEXT,
             ".html": cls.HTML,
             ".htm": cls.HTML,
@@ -378,6 +381,7 @@ class Language(Enum):
             Language.DART,
             Language.ELIXIR,
             Language.LUA,
+            Language.POWERSHELL,
             Language.TWINCAT,
         }
 
@@ -401,6 +405,7 @@ class Language(Enum):
             Language.SVELTE,
             Language.SWIFT,
             Language.DART,
+            Language.POWERSHELL,
         }
 
     @property

--- a/chunkhound/parsers/mappings/__init__.py
+++ b/chunkhound/parsers/mappings/__init__.py
@@ -29,6 +29,7 @@ from .matlab import MatlabMapping
 from .objc import ObjCMapping
 from .pdf import PDFMapping
 from .php import PHPMapping
+from .powershell import PowerShellMapping
 from .python import PythonMapping
 from .rust import RustMapping
 from .scss import ScssMapping
@@ -71,6 +72,7 @@ __all__ = [
     "ObjCMapping",
     "PDFMapping",
     "PHPMapping",
+    "PowerShellMapping",
     "PythonMapping",
     "RustMapping",
     "ScssMapping",

--- a/chunkhound/parsers/mappings/powershell.py
+++ b/chunkhound/parsers/mappings/powershell.py
@@ -1,0 +1,159 @@
+"""PowerShell language mapping for the unified parser architecture.
+
+Provides PowerShell-specific tree-sitter queries and extraction logic so that
+PowerShell users get function/class/method-aware chunks instead of the generic
+UNKNOWN fallback. The grammar ships with tree-sitter-language-pack.
+
+Handled constructs (real grammar node types):
+- function_statement      -> FUNCTION  (covers `function` and `filter`)
+- class_statement         -> CLASS
+- class_method_definition -> METHOD
+- class_property_definition-> PROPERTY
+- enum_statement          -> ENUM
+"""
+
+from typing import Any
+
+from tree_sitter import Node as TSNode
+
+from chunkhound.core.types.common import Language
+from chunkhound.parsers.universal_engine import UniversalConcept
+
+from .base import BaseMapping
+
+# AST node type -> semantic kind. The router (universal_parser) maps "kind"
+# to a ChunkType. We deliberately route on "kind" alone and never expose the
+# raw node_type: "class_method_definition" / "class_property_definition" both
+# contain the substring "class", which the router's `"class" in node_type`
+# check would otherwise mis-route to ChunkType.CLASS.
+_KIND_BY_TYPE = {
+    "function_statement": "function",
+    "class_statement": "class",
+    "class_method_definition": "method",
+    "class_property_definition": "property",
+    "enum_statement": "enum",
+}
+
+
+class PowerShellMapping(BaseMapping):
+    """PowerShell-specific tree-sitter mapping for semantic code extraction."""
+
+    def __init__(self) -> None:
+        """Initialize PowerShell mapping."""
+        super().__init__(Language.POWERSHELL)
+
+    # Legacy query interface (required abstract methods) -------------------
+
+    def get_function_query(self) -> str:
+        """Tree-sitter query for PowerShell function/filter definitions."""
+        return """
+        (function_statement) @function_def
+        (class_method_definition) @function_def
+        """
+
+    def get_class_query(self) -> str:
+        """Tree-sitter query for PowerShell class/enum definitions."""
+        return """
+        (class_statement) @class_def
+        (enum_statement) @class_def
+        """
+
+    def get_comment_query(self) -> str:
+        """Tree-sitter query for PowerShell comments (# and <# #>)."""
+        return """
+        (comment) @comment
+        """
+
+    def extract_function_name(self, node: TSNode | None, source: str) -> str:
+        """Extract a function/method name from a definition node."""
+        if node is None:
+            return self.get_fallback_name(node, "function")
+        return self._extract_definition_name(node, source)
+
+    def extract_class_name(self, node: TSNode | None, source: str) -> str:
+        """Extract a class/enum name from a definition node."""
+        if node is None:
+            return self.get_fallback_name(node, "type")
+        return self._extract_definition_name(node, source)
+
+    # Universal concept interface -----------------------------------------
+
+    def get_query_for_concept(self, concept: "UniversalConcept") -> str | None:
+        """Get tree-sitter query for a universal concept in PowerShell."""
+        if concept == UniversalConcept.DEFINITION:
+            return """
+            (function_statement) @definition
+            (class_statement) @definition
+            (class_method_definition) @definition
+            (class_property_definition) @definition
+            (enum_statement) @definition
+            """
+        elif concept == UniversalConcept.COMMENT:
+            return """
+            (comment) @definition
+            """
+        return None
+
+    def extract_name(
+        self, concept: "UniversalConcept", captures: dict[str, TSNode], content: bytes
+    ) -> str:
+        """Extract the symbol name from captures for this concept."""
+        source = content.decode("utf-8")
+        node = captures.get("definition")
+        if node is None:
+            return "unnamed"
+
+        if concept == UniversalConcept.DEFINITION:
+            return self._extract_definition_name(node, source)
+        elif concept == UniversalConcept.COMMENT:
+            return f"comment_line_{node.start_point[0] + 1}"
+        return "unnamed"
+
+    def extract_content(
+        self, concept: "UniversalConcept", captures: dict[str, TSNode], content: bytes
+    ) -> str:
+        """Extract the source text from captures for this concept."""
+        source = content.decode("utf-8")
+        node = captures.get("definition")
+        if node is None and captures:
+            node = next(iter(captures.values()))
+        return self.get_node_text(node, source)
+
+    def extract_metadata(
+        self, concept: "UniversalConcept", captures: dict[str, TSNode], content: bytes
+    ) -> dict[str, Any]:
+        """Extract PowerShell-specific metadata (drives ChunkType routing)."""
+        metadata: dict[str, Any] = {}
+        if concept != UniversalConcept.DEFINITION:
+            return metadata
+
+        node = captures.get("definition")
+        if node is None:
+            return metadata
+
+        kind = _KIND_BY_TYPE.get(node.type)
+        if kind:
+            metadata["kind"] = kind
+        return metadata
+
+    # Helpers --------------------------------------------------------------
+
+    def _extract_definition_name(self, node: TSNode, source: str) -> str:
+        """Resolve the symbol name for any PowerShell definition node."""
+        node_type = node.type
+
+        if node_type == "function_statement":
+            name_node = self.find_child_by_type(node, "function_name")
+        elif node_type == "class_property_definition":
+            # Property name lives in a `variable` child, e.g. `$Size`.
+            var_node = self.find_child_by_type(node, "variable")
+            if var_node:
+                return self.get_node_text(var_node, source).lstrip("$").strip()
+            name_node = None
+        else:
+            # class_statement, class_method_definition, enum_statement
+            name_node = self.find_child_by_type(node, "simple_name")
+
+        if name_node:
+            return self.get_node_text(name_node, source).strip()
+        return self.get_fallback_name(node, "definition")

--- a/chunkhound/parsers/parser_factory.py
+++ b/chunkhound/parsers/parser_factory.py
@@ -73,6 +73,7 @@ from chunkhound.parsers.mappings import (
     ObjCMapping,
     PDFMapping,
     PHPMapping,
+    PowerShellMapping,
     PythonMapping,
     RustMapping,
     ScssMapping,
@@ -98,6 +99,7 @@ _swift_lang = _get_lang("swift")
 _yaml_lang = _get_lang("yaml")
 _hcl_lang = _get_lang("hcl")
 _dart_lang = _get_lang("dart")
+_powershell_lang = _get_lang("powershell")
 
 
 class _LanguagePackWrapper:
@@ -116,6 +118,7 @@ ts_swift = _LanguagePackWrapper(_swift_lang)
 ts_yaml = _LanguagePackWrapper(_yaml_lang)
 ts_hcl = _LanguagePackWrapper(_hcl_lang)
 ts_dart = _LanguagePackWrapper(_dart_lang)
+ts_powershell = _LanguagePackWrapper(_powershell_lang)
 
 _scss_lang = _get_lang("scss")
 ts_scss: _LanguagePackWrapper | None = (
@@ -238,6 +241,9 @@ LANGUAGE_CONFIGS: dict[Language, LanguageConfig] = {
     Language.OBJC: LanguageConfig(ts_objc, ObjCMapping, True, "objc"),
     Language.SQL: LanguageConfig(ts_sql, SqlMapping, True, "sql"),
     Language.SWIFT: LanguageConfig(ts_swift, SwiftMapping, True, "swift"),
+    Language.POWERSHELL: LanguageConfig(
+        ts_powershell, PowerShellMapping, True, "powershell"
+    ),
     # Languages that use TypeScript parser
     Language.VUE: LanguageConfig(
         ts_typescript, VueMapping, True, "vue"
@@ -347,6 +353,9 @@ EXTENSION_TO_LANGUAGE: dict[str, Language] = {
     ".swift": Language.SWIFT,
     ".swiftinterface": Language.SWIFT,
     ".lua": Language.LUA,
+    # PowerShell
+    ".ps1": Language.POWERSHELL,
+    ".psm1": Language.POWERSHELL,
     ".vue": Language.VUE,
     ".svelte": Language.SVELTE,
     # Config & Data

--- a/tests/test_e2e_chunk_size_constraints.py
+++ b/tests/test_e2e_chunk_size_constraints.py
@@ -255,6 +255,17 @@ LARGE_LANGUAGE_SAMPLES: dict[Language, tuple[str, str, str]] = {
         # Normal
         "function greet(name)\n    return 'Hello, ' .. name\nend",
     ),
+    Language.POWERSHELL: (
+        ".ps1",
+        # Large function
+        "function Get-Data {\n"
+        + _make_large_statements("    $x = 1")
+        + "\n    return $x\n}",
+        # Normal
+        'function Get-Greeting {\n'
+        '    param([string]$Name)\n'
+        '    return "Hello, $Name"\n}',
+    ),
     Language.BASH: (
         ".sh",
         # Large script

--- a/tests/test_language_extensions.py
+++ b/tests/test_language_extensions.py
@@ -291,6 +291,7 @@ class TestExtensionCoverage:
             ".php", ".phtml", ".php3", ".php4", ".php5", ".phps",  # PHP variants
             ".zig",  # Zig
             ".vue",  # Vue
+            ".ps1", ".psm1",  # PowerShell
         ],
     )
     def test_language_variant_extensions_supported(self, ext):

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -43,6 +43,7 @@ LANGUAGE_SAMPLES = {
     Language.SWIFT: "class MyClass {\n    func hello() -> String {\n        return \"world\"\n    }\n}",
     Language.DART: "void main() { }",
     Language.LUA: "function hello() print('world') end",
+    Language.POWERSHELL: "function Get-Hello {\n    Write-Output 'world'\n}",
     Language.SQL: "CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(100));\nCREATE VIEW active_users AS SELECT * FROM users;\nCREATE FUNCTION get_user_count() RETURNS INT BEGIN RETURN 0; END;\nCREATE TRIGGER audit_insert AFTER INSERT ON users FOR EACH ROW BEGIN INSERT INTO audit_log VALUES (NEW.id); END;\nCREATE INDEX idx_users_name ON users (name);",
     Language.HTML: "<section><h1>Hello</h1></section>",
     Language.CSS: "body { color: red; }",

--- a/tests/test_powershell_mapping.py
+++ b/tests/test_powershell_mapping.py
@@ -1,0 +1,85 @@
+"""Tests for PowerShell language mapping and parsing.
+
+These are contract tests through the real parser: they fail on a build that
+routes .ps1 through the UNKNOWN fallback (which only emits generic chunks) and
+pass once PowerShell is wired with function/class/method-aware chunking.
+"""
+
+from pathlib import Path
+
+from chunkhound.core.detection import detect_language
+from chunkhound.core.types.common import ChunkType, FileId, Language
+from chunkhound.parsers.parser_factory import get_parser_factory
+
+
+def parse_powershell(content: str):
+    """Parse PowerShell content through the real parser factory."""
+    factory = get_parser_factory()
+    parser = factory.create_parser(Language.POWERSHELL)
+    return parser.parse_content(content, "test.ps1", FileId(1))
+
+
+def test_ps1_routes_to_powershell():
+    """.ps1 / .psm1 must resolve to Language.POWERSHELL (not UNKNOWN)."""
+    assert detect_language(Path("x.ps1")) == Language.POWERSHELL
+    assert detect_language(Path("x.psm1")) == Language.POWERSHELL
+
+
+class TestPowerShellTypedChunks:
+    """The fallback parser cannot emit these typed symbols — only the real
+    PowerShell mapping can."""
+
+    def test_function_class_method_chunks(self):
+        content = """function Get-Foo {
+    param([string]$Name)
+    Write-Output "Hello $Name"
+    Write-Output "again $Name"
+}
+
+class Widget {
+    [int]$Size
+
+    [int] Spin() {
+        $result = $this.Size * 2
+        Write-Output "spinning to $result"
+        return $result
+    }
+}
+"""
+        chunks = parse_powershell(content)
+
+        def has(chunk_type, symbol):
+            return any(
+                c.chunk_type == chunk_type and c.symbol == symbol for c in chunks
+            )
+
+        symbols = sorted(c.symbol for c in chunks)
+        assert has(ChunkType.FUNCTION, "Get-Foo"), symbols
+        assert has(ChunkType.CLASS, "Widget"), symbols
+        assert has(ChunkType.METHOD, "Spin"), symbols
+        assert has(ChunkType.PROPERTY, "Size"), symbols
+
+    def test_filter_is_a_function(self):
+        """PowerShell `filter` uses function_statement and chunks as FUNCTION."""
+        content = """filter Convert-Upper {
+    $_.ToString().ToUpper()
+    Write-Output "converted"
+}
+"""
+        chunks = parse_powershell(content)
+        assert any(
+            c.chunk_type == ChunkType.FUNCTION and c.symbol == "Convert-Upper"
+            for c in chunks
+        ), sorted(c.symbol for c in chunks)
+
+    def test_enum_chunk(self):
+        content = """enum Color {
+    Red
+    Green
+    Blue
+}
+"""
+        chunks = parse_powershell(content)
+        assert any(
+            c.chunk_type == ChunkType.ENUM and c.symbol == "Color" for c in chunks
+        ), sorted(c.symbol for c in chunks)

--- a/tests/test_qa_deterministic.py
+++ b/tests/test_qa_deterministic.py
@@ -416,6 +416,7 @@ function qaTestFunction() {
             Language.OBJC: '// Objective-C QA test\n@implementation QATest\n- (NSString *)qaTestMethod {\n    return @"objc_qa_unique";\n}\n@end',
             Language.PHP: '<?php\n// PHP QA test\nfunction qa_test_function() {\n    return "php_qa_unique";\n}',
             Language.SWIFT: '// Swift QA test\nfunc qaTestFunction() -> String {\n    return "swift_qa_unique"\n}',
+            Language.POWERSHELL: '# PowerShell QA test\nfunction Get-QaTest {\n    return "powershell_qa_unique"\n}',
             Language.ZIG: '// Zig QA test\nfn qa_test_function() []const u8 {\n    return "zig_qa_unique";\n}',
             Language.PDF: None,  # PDF is binary, skip content template
             Language.SQL: '-- SQL QA test\nCREATE TABLE qa_test (\n    id INTEGER PRIMARY KEY,\n    content TEXT DEFAULT \'sql_qa_unique\'\n);',
@@ -461,6 +462,7 @@ function qaTestFunction() {
             Language.OBJC: ".m",
             Language.PHP: ".php",
             Language.SWIFT: ".swift",
+            Language.POWERSHELL: ".ps1",
             Language.ZIG: ".zig",
             Language.PDF: ".pdf",
             Language.SQL: ".sql",


### PR DESCRIPTION
## What

Adds first-class PowerShell support to ChunkHound. `.ps1` / `.psm1` files now
route through a dedicated tree-sitter mapping that emits
function/class/method/property/enum-aware chunks instead of falling through to
the generic `UNKNOWN` text parser.

## Why

On `main`, PowerShell files are unsupported: `detect_language` returns
`Language.UNKNOWN` and a `.ps1` file yields only a couple of *untyped* fallback
chunks. PowerShell users (and AI assistants searching their codebases) get no
function/class/method structure to search against. This change gives them the
same typed, semantically-aware chunking every other supported language already
enjoys.

## How

- The PowerShell grammar already ships with `tree-sitter-language-pack`, so no
  new pip dependency is needed. It is wired via the existing
  `_LanguagePackWrapper` path (`_get_lang("powershell")`), exactly like
  `matlab` / `swift` / `objc`.
- New `PowerShellMapping` (`chunkhound/parsers/mappings/powershell.py`) maps the
  real grammar node types:

  | node type                   | ChunkType |
  |-----------------------------|-----------|
  | `function_statement`        | FUNCTION (covers `function` and `filter`) |
  | `class_statement`           | CLASS     |
  | `class_method_definition`   | METHOD    |
  | `class_property_definition` | PROPERTY  |
  | `enum_statement`            | ENUM      |

- **Landmine handled:** the router in `universal_parser` checks
  `elif kind == "class" or "class" in node_type`. Both
  `class_method_definition` and `class_property_definition` contain the
  substring `"class"`, so exposing the raw `node_type` would mis-route methods
  and properties to `ChunkType.CLASS`. The mapping therefore routes on the
  `kind` metadata **only** and never sets `node_type`.

### Touchpoints

- `chunkhound/core/types/common.py` — `Language.POWERSHELL`; `.ps1`/`.psm1`
  in the detection extension map; added to `is_programming_language` and
  `supports_classes`.
- `chunkhound/parsers/parser_factory.py` — language-pack wrapper, mapping
  import, `LANGUAGE_CONFIGS` entry, `EXTENSION_TO_LANGUAGE` entries.
- `chunkhound/parsers/mappings/powershell.py` — new mapping.
- `chunkhound/parsers/mappings/__init__.py` — export.
- Tests — new `tests/test_powershell_mapping.py`; PowerShell samples added to
  `test_parsers.py`, `test_language_extensions.py`,
  `test_e2e_chunk_size_constraints.py`, `test_qa_deterministic.py`.

## Evidence (before → after)

### 1. Routing flips (wiring proof)

```
$ chunkhound … detect_language(Path('x.ps1'))
main:        Language.UNKNOWN
this branch: Language.POWERSHELL
```

### 2. Typed chunks (behavior proof)

`main` only emits a couple of untyped fallback chunks for a `.ps1`. On this
branch, parsing through the real parser
(`create_parser(Language.POWERSHELL).parse_content(...)`) yields:

```
function   Get-Foo
class      Widget
property   Size
method     Spin
```

The new contract test (`tests/test_powershell_mapping.py`) asserts
`ChunkType.FUNCTION == "Get-Foo"`, `ChunkType.CLASS == "Widget"`,
`ChunkType.METHOD == "Spin"`, `ChunkType.PROPERTY == "Size"` — typed symbols the
UNKNOWN fallback cannot produce, so the test fails on `main` and passes here.

### 3. CLI end-to-end (real pipeline)

```
$ chunkhound index <dir> --db <db> --no-embeddings
Processed: 1 files
Total chunks: 4

$ chunkhound search --regex "Get-Foo" <dir> --db <db>
[1] sample.ps1  Lines 1-5
    function Get-Foo { … }
```

## Quality gate

- `pytest tests/test_powershell_mapping.py tests/test_language_extensions.py tests/test_parsers.py` — **145 passed**
- `pytest tests/test_smoke.py -n auto` — **18 passed** (mandatory gate)
- `ruff check` on changed files — clean (the only remaining ruff hits are
  pre-existing import-ordering issues already present on `main`)
- `mypy chunkhound/parsers/mappings/powershell.py` — clean

### Note on the new-language coverage tests

`Language` enum members are guarded by coverage tests
(`test_qa_deterministic`, `test_e2e_chunk_size_constraints`,
`test_parsers`) that require a sample for every language; PowerShell samples
were added to each. Pre-existing, unrelated full-suite failures on this machine
(node/`tests/site/*` build tests, `git tag` docs-version contract tests, and a
makefile chunk-size assertion) reproduce identically on clean `main` and are
not touched by this change.

## Notes / scope

- `.psd1` (data manifests) is intentionally **not** routed to the PS grammar —
  `.ps1` and `.psm1` are the script extensions that benefit from code-aware
  chunking.
- Small adjacent same-kind members (e.g. two tiny methods in one class) merge
  under the generic cAST greedy-merge, identical to every other language — this
  is existing chunking behavior, not PowerShell-specific.
