### PR TITLE
fix(websearch): guard zendriver Transaction against late completions after wait_for cancellation

### DIFF
--- a/chunkhound/utils/websearch_core.py
+++ b/chunkhound/utils/websearch_core.py
@@ -25,6 +25,7 @@ from typing import IO, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from http.client import HTTPMessage
+    from typing import Any
 
     import zendriver as zd
 
@@ -48,6 +49,64 @@ _CHROME_PATHS = [
     r"C:\Program Files\Google\Chrome\Application\chrome.exe",
     r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
 ]
+
+
+_late_completion_guard_installed = False
+
+
+def _install_late_completion_guard() -> None:
+    """Patch zendriver's Transaction.__call__ to drop late completions.
+
+    TODO: remove once zendriver fixes Connection.send to pop cancelled
+    transactions from connection.mapper (or guards Transaction.__call__
+    upstream). Revisit on every zendriver bump — the version-mismatch
+    warning below is the in-process signal that this may be stale.
+
+    zendriver 0.15.3's Connection.send (connection.py:561-572) does not pop the
+    Transaction from connection.mapper when its awaiter is cancelled — e.g. when
+    we wrap tab.send(cdp.page.navigate(...)) in asyncio.wait_for(..., timeout=30)
+    at _fetch_page. The Transaction Future transitions to CANCELLED but stays
+    registered. When Chrome later delivers the response, Listener.listener_loop
+    (connection.py:780) pops the orphan and calls tx(**message), which calls
+    set_result() on the cancelled Future and raises InvalidStateError. That
+    exception is uncaught in listener_loop and kills the listener task — the
+    asyncio "Task exception was never retrieved" log is the visible symptom; the
+    real damage is that the websocket recv stops draining and the browser
+    session becomes unusable.
+
+    Guarding __call__ with a Future.done() check makes the late completion a
+    no-op, mirroring the local ``on_response`` idempotency guard inside
+    ``_fetch_page``. Discarding the late result is correct: the only consumer
+    was the awaiter inside Connection.send, which already received
+    CancelledError.
+
+    Idempotent via module-level flag — safe to call from every fetch_and_save.
+    """
+    global _late_completion_guard_installed
+    if _late_completion_guard_installed:
+        return
+    import warnings
+
+    import zendriver
+    from zendriver.core.connection import Transaction
+
+    if zendriver.__version__ != "0.15.3":
+        warnings.warn(
+            f"zendriver {zendriver.__version__} != pinned 0.15.3; "
+            "late-completion guard may be redundant or broken",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+    _orig_call = Transaction.__call__
+
+    def _safe_call(self: Transaction, **response: dict[str, Any]) -> None:
+        if self.done():
+            return
+        _orig_call(self, **response)
+
+    Transaction.__call__ = _safe_call  # type: ignore[method-assign]
+    _late_completion_guard_installed = True
 
 
 def _check_chrome_version(chrome_path: str) -> None:
@@ -569,6 +628,9 @@ async def fetch_and_save(
     # Lazy import: pulls in websockets + CDP binding modules. Wasted cost
     # for CLI commands that never touch websearch (e.g. `chunkhound index`).
     import zendriver as zd
+
+    # Must run before any tab.send() creates a Transaction.
+    _install_late_completion_guard()
 
     # _resolve_chrome_path returns None for every "no usable Chrome >=124"
     # case (not installed, too old, --version probe failed) and emits its

--- a/chunkhound/utils/websearch_core.py
+++ b/chunkhound/utils/websearch_core.py
@@ -93,14 +93,15 @@ def _install_late_completion_guard() -> None:
     if zendriver.__version__ != "0.15.3":
         warnings.warn(
             f"zendriver {zendriver.__version__} != pinned 0.15.3; "
-            "late-completion guard may be redundant or broken",
+            "late-completion guard may now be redundant or broken — revisit "
+            "whether upstream fixed Connection.send or Transaction.__call__",
             RuntimeWarning,
             stacklevel=2,
         )
 
     _orig_call = Transaction.__call__
 
-    def _safe_call(self: Transaction, **response: dict[str, Any]) -> None:
+    def _safe_call(self: Transaction, **response: Any) -> None:
         if self.done():
             return
         _orig_call(self, **response)

--- a/tests/unit/test_websearch_late_completion_guard.py
+++ b/tests/unit/test_websearch_late_completion_guard.py
@@ -1,0 +1,57 @@
+"""Verify the zendriver Transaction late-completion guard.
+
+The guard prevents InvalidStateError from tearing down zendriver's
+Listener.listener_loop when a CDP response arrives for a Transaction whose
+awaiter was already cancelled by an outer asyncio.wait_for timeout. See
+_install_late_completion_guard in chunkhound/utils/websearch_core.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_cancelled_transaction_does_not_raise_on_late_response(
+    monkeypatch,
+) -> None:
+    pytest.importorskip("zendriver")
+    from zendriver import cdp
+    from zendriver.core.connection import Transaction
+
+    from chunkhound.utils import websearch_core
+
+    # The guard is process-global and idempotent by design — fetch_and_save
+    # calls _install_late_completion_guard on every invocation and the latch
+    # short-circuits repeats. Reset the latch so this test exercises the
+    # install path even when a prior test already ran it; the patch
+    # intentionally persists past teardown.
+    monkeypatch.setattr(websearch_core, "_late_completion_guard_installed", False)
+
+    websearch_core._install_late_completion_guard()
+
+    # Use a real CDP command so Transaction's constructor (which calls
+    # next(cdp_obj) to read method+params) succeeds.
+    tx = Transaction(cdp.page.navigate(url="about:blank"))
+    tx.cancel()
+    assert tx.cancelled()
+
+    # Simulate listener_loop's call shape from connection.py:780.
+    # Without the guard, set_result on the cancelled Future raises
+    # InvalidStateError; the guard short-circuits before that.
+    tx(result={
+        "frameId": "F" * 32,
+        "loaderId": "L" * 32,
+    })  # must not raise
+
+    # Happy path: the guard must still delegate to the original __call__
+    # for non-done Transactions, otherwise every CDP send would hang.
+    tx2 = Transaction(cdp.page.navigate(url="about:blank"))
+    assert not tx2.done()
+    tx2(result={
+        "frameId": "F" * 32,
+        "loaderId": "L" * 32,
+    })
+    assert tx2.done()
+    assert not tx2.cancelled()
+    assert tx2.exception() is None


### PR DESCRIPTION
**Note**: This PR was generated by an AI agent. If you'd like to talk with other humans, drop by our [Discord](https://discord.gg/BAepHEXXnX)!

---

## Summary

Fixes a latent bug where a single `_fetch_page` navigation timeout could kill the entire zendriver browser session for the rest of the process. zendriver 0.15.3 doesn't pop a `Transaction` from `Connection.mapper` when its awaiter is cancelled — so when our `asyncio.wait_for(..., timeout=30)` around `tab.send(cdp.page.navigate(...))` trips, the orphaned Transaction stays registered. When Chrome eventually delivers the response, `Listener.listener_loop` calls `tx(**message)`, which calls `set_result()` on a cancelled Future and raises `InvalidStateError`. That exception is unhandled inside the listener task, so the websocket recv loop dies, and every subsequent `tab.send(...)` hangs until its own `wait_for` fires. Visible symptom: the asyncio "Task exception was never retrieved" log. Real damage: the browser session becomes unusable mid-websearch.

The fix is a one-shot, idempotent monkey-patch of `zendriver.core.connection.Transaction.__call__` that no-ops when `self.done()` — discarding the late result is correct because the only consumer (the awaiter inside `Connection.send`) already received `CancelledError`. Install runs at the top of `fetch_and_save` before any tab is created, gated by a module-level latch, and warns at runtime if `zendriver.__version__` drifts from the pinned `0.15.3` (the in-process signal to revisit the workaround on every bump). A `TODO` block in the docstring points at the exact upstream lines (`connection.py:561-572` and `:780`) so the patch can be removed when zendriver fixes `Connection.send` or guards `Transaction.__call__` upstream.

Net change: +119 lines across one source file and one new unit test (`tests/unit/test_websearch_late_completion_guard.py`) that exercises both the cancelled-Transaction guard path and the happy delegate-through path with a real `cdp.page.navigate` Transaction. No public API changes, no config changes, no new deps.

[AGENT_REVIEW.md](https://github.com/user-attachments/files/29324577/AGENT_REVIEW.md)
