### PR TITLE
fix(claude-cli): disable CLI auto-updater for subprocess invocations

### DIFF
--- a/chunkhound/providers/llm/claude_code_cli_provider.py
+++ b/chunkhound/providers/llm/claude_code_cli_provider.py
@@ -132,6 +132,10 @@ class ClaudeCodeCLIProvider(BaseCLIProvider):
         env = os.environ.copy()
         env["CLAUDE_USE_SUBSCRIPTION"] = "true"
 
+        # Suppress the CLI's auto-updater: updates should be driven by the
+        # user's interactive `claude` sessions, not ChunkHound subprocess calls.
+        env["DISABLE_AUTOUPDATER"] = "1"
+
         # Remove ANTHROPIC_API_KEY if present to force subscription auth
         env.pop("ANTHROPIC_API_KEY", None)
 


### PR DESCRIPTION
**Note**: This PR was generated by an AI agent. If you'd like to talk with other humans, drop by our [Discord](https://discord.gg/BAepHEXXnX)!

---

# Disable Claude CLI auto-updater for ChunkHound subprocess calls

When the Claude Code CLI's auto-updater fires inside a `claude --print` subprocess we spawn for deep research, it can stall the process, contend on the same install path another `claude` session is using, or write update logs into our captured stderr. The fix is a one-liner: export `DISABLE_AUTOUPDATER=1` in the env we hand to the subprocess in `chunkhound/providers/llm/claude_code_cli_provider.py`. Updates still happen normally during the user's own interactive `claude` sessions — we just don't piggyback the upgrade onto a ChunkHound call.

No behavior change for users who already keep their CLI fresh, no breaking changes, no new config surface. It's a defensive env tweak alongside the existing `CLAUDE_USE_SUBSCRIPTION=true` / `ANTHROPIC_API_KEY` handling in the same block.

[AGENT_REVIEW.md](https://github.com/user-attachments/files/29331412/AGENT_REVIEW.md)