### PR TITLE
feat(research): add per-step timing printouts to Phase 1.5 and Phase 2

### DIFF
--- a/chunkhound/api/cli/utils/tree_progress.py
+++ b/chunkhound/api/cli/utils/tree_progress.py
@@ -110,6 +110,8 @@ class TreeProgressDisplay:
             "main_complete": "🎉",
             "error": "❌",
             "evidence_ledger": "📊",
+            "gap_step": "▶",
+            "fact_extraction": "🧮",
         }
         return symbols.get(event_type, "•")
 

--- a/chunkhound/services/research/factory.py
+++ b/chunkhound/services/research/factory.py
@@ -89,6 +89,7 @@ def _create_v2_service(
         db_services=db_services,
         config=config.research,
         import_resolver=import_resolver,
+        progress=progress,
     )
 
     return PluggableResearchService(
@@ -138,6 +139,7 @@ def _create_v3_service(
         db_services=db_services,
         config=config.research,
         import_resolver=import_resolver,
+        progress=progress,
     )
 
     parallel_strategy = ParallelExplorationStrategy(

--- a/chunkhound/services/research/shared/depth_exploration.py
+++ b/chunkhound/services/research/shared/depth_exploration.py
@@ -64,6 +64,8 @@ class DepthExplorationService(ProgressEmitterMixin):
     while maintaining coverage-first philosophy.
     """
 
+    _default_depth = 2  # all gap_step events are nested under the current phase
+
     def __init__(
         self,
         llm_manager: LLMManager,

--- a/chunkhound/services/research/shared/depth_exploration.py
+++ b/chunkhound/services/research/shared/depth_exploration.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
     from chunkhound.api.cli.utils.tree_progress import TreeProgressDisplay
 
 from chunkhound.core.config.research_config import ResearchConfig
-from chunkhound.services.research.shared.progress_mixin import ProgressEmitterMixin
 from chunkhound.database_factory import DatabaseServices
 from chunkhound.embeddings import EmbeddingManager
 from chunkhound.llm_manager import LLMManager
@@ -52,6 +51,7 @@ from chunkhound.services.research.shared.models import (
     IMPORT_DEFAULT_SCORE,
     ResearchContext,
 )
+from chunkhound.services.research.shared.progress_mixin import ProgressEmitterMixin
 from chunkhound.services.research.shared.unified_search import UnifiedSearch
 
 
@@ -176,7 +176,8 @@ class DepthExplorationService(ProgressEmitterMixin):
         )
         await self._emit_event(
             "gap_step",
-            f"Step 1.5.2: Generated {total_queries} queries across {len(exploration_queries)} files",
+            f"Step 1.5.2: Generated {total_queries} queries"
+            f" across {len(exploration_queries)} files",
             duration=perf_counter() - t,
         )
 
@@ -216,7 +217,8 @@ class DepthExplorationService(ProgressEmitterMixin):
         )
         await self._emit_event(
             "gap_step",
-            f"Step 1.5.4: Global dedup: {total_results} → {len(unified_exploration_chunks)} unique chunks",
+            f"Step 1.5.4: Global dedup: {total_results}"
+            f" → {len(unified_exploration_chunks)} unique chunks",
             duration=perf_counter() - t,
         )
 
@@ -233,7 +235,8 @@ class DepthExplorationService(ProgressEmitterMixin):
         )
         await self._emit_event(
             "gap_step",
-            f"Step 1.5.5: Final merge: {len(covered_chunks)} + {len(unified_exploration_chunks)} → {len(expanded_chunks)} total",
+            f"Step 1.5.5: Final merge: {len(covered_chunks)}"
+            f" + {len(unified_exploration_chunks)} → {len(expanded_chunks)} total",
             duration=perf_counter() - t,
         )
 
@@ -271,7 +274,8 @@ class DepthExplorationService(ProgressEmitterMixin):
         )
         await self._emit_event(
             "gap_step",
-            f"Depth exploration complete: +{total_added} chunks added ({len(expanded_chunks)} total)",
+            f"Depth exploration complete: +{total_added} chunks added"
+            f" ({len(expanded_chunks)} total)",
             duration=elapsed_total,
         )
 

--- a/chunkhound/services/research/shared/depth_exploration.py
+++ b/chunkhound/services/research/shared/depth_exploration.py
@@ -16,9 +16,13 @@ Key Invariants:
 """
 
 import asyncio
-from typing import Any, cast
+from time import perf_counter
+from typing import TYPE_CHECKING, Any, cast
 
 from loguru import logger
+
+if TYPE_CHECKING:
+    from chunkhound.api.cli.utils.tree_progress import TreeProgressDisplay
 
 from chunkhound.core.config.research_config import ResearchConfig
 from chunkhound.database_factory import DatabaseServices
@@ -67,6 +71,7 @@ class DepthExplorationService:
         config: ResearchConfig,
         import_resolver: Any | None = None,
         import_context_service: ImportContextService | None = None,
+        progress: "TreeProgressDisplay | None" = None,
     ):
         """Initialize depth exploration service.
 
@@ -77,6 +82,7 @@ class DepthExplorationService:
             config: Research configuration
             import_resolver: Optional ImportResolverService for import resolution
             import_context_service: Optional ImportContextService for header injection
+            progress: Optional TreeProgressDisplay for terminal UI (None for MCP)
         """
         self._llm_manager = llm_manager
         self._embedding_manager = embedding_manager
@@ -84,7 +90,25 @@ class DepthExplorationService:
         self._config = config
         self._import_resolver = import_resolver
         self._import_context_service = import_context_service
+        self._progress = progress
         self._unified_search = UnifiedSearch(db_services, embedding_manager, config)
+
+    async def _emit_event(
+        self,
+        event_type: str,
+        message: str,
+        depth: int = 2,
+        **metadata: Any,
+    ) -> None:
+        """Emit a progress event to the terminal display."""
+        if not self._progress:
+            return
+        await self._progress.emit_event(
+            event_type=event_type,
+            message=message,
+            depth=depth,
+            metadata=metadata,
+        )
 
     async def explore_coverage_depth(
         self,
@@ -116,19 +140,36 @@ class DepthExplorationService:
                 "chunks_added": 0,
             }
 
+        t_total = perf_counter()
         logger.info(
             f"Phase 1.5: Depth exploration starting with {len(covered_chunks)} chunks"
         )
+        await self._emit_event(
+            "gap_step",
+            f"Phase 1.5 depth exploration: {len(covered_chunks)} chunks → analyzing...",
+        )
 
         # Step 1: Group chunks by file and select top-K files
+        t = perf_counter()
         file_to_chunks = self._group_chunks_by_file(covered_chunks)
         top_files = self._select_top_files(
             file_to_chunks, self._config.max_exploration_files
         )
         logger.info(f"Step 1.5.1: Selected {len(top_files)} top files for exploration")
+        await self._emit_event(
+            "gap_step",
+            f"Step 1.5.1: Selected {len(top_files)} top files for exploration",
+            duration=perf_counter() - t,
+        )
 
         if not top_files:
             logger.info("No files selected for exploration")
+            elapsed = perf_counter() - t_total
+            await self._emit_event(
+                "gap_step",
+                "Depth exploration complete: no files selected",
+                duration=elapsed,
+            )
             return covered_chunks, {
                 "files_explored": 0,
                 "queries_generated": 0,
@@ -136,6 +177,7 @@ class DepthExplorationService:
             }
 
         # Step 2: Generate exploration queries for each file (parallel)
+        t = perf_counter()
         (
             exploration_queries,
             generation_metrics,
@@ -148,9 +190,20 @@ class DepthExplorationService:
             f"across {len(exploration_queries)} files "
             f"({generation_metrics.success_count}/{generation_metrics.total_operations} files succeeded)"
         )
+        await self._emit_event(
+            "gap_step",
+            f"Step 1.5.2: Generated {total_queries} queries across {len(exploration_queries)} files",
+            duration=perf_counter() - t,
+        )
 
         if not any(exploration_queries.values()):
             logger.info("No exploration queries generated")
+            elapsed = perf_counter() - t_total
+            await self._emit_event(
+                "gap_step",
+                "Depth exploration complete: no queries generated",
+                duration=elapsed,
+            )
             return covered_chunks, {
                 "files_explored": len(top_files),
                 "queries_generated": 0,
@@ -158,20 +211,33 @@ class DepthExplorationService:
             }
 
         # Step 3: Execute unified search for each query (parallel, independent)
+        t = perf_counter()
         exploration_results = await self._execute_exploration_queries(
             root_query, exploration_queries, phase1_threshold, path_filter
         )
         total_results = sum(len(r) for r in exploration_results)
         logger.info(f"Step 1.5.3: Exploration searches returned {total_results} chunks")
+        await self._emit_event(
+            "gap_step",
+            f"Step 1.5.3: Exploration searches returned {total_results} chunks",
+            duration=perf_counter() - t,
+        )
 
         # Step 4: Global deduplication (SYNC POINT)
+        t = perf_counter()
         unified_exploration_chunks = self._global_dedup(exploration_results)
         logger.info(
             f"Step 1.5.4: Global dedup: {total_results} -> "
             f"{len(unified_exploration_chunks)} unique exploration chunks"
         )
+        await self._emit_event(
+            "gap_step",
+            f"Step 1.5.4: Global dedup: {total_results} → {len(unified_exploration_chunks)} unique chunks",
+            duration=perf_counter() - t,
+        )
 
         # Step 5: Merge with coverage chunks
+        t = perf_counter()
         expanded_chunks = self._merge_coverage(
             covered_chunks, unified_exploration_chunks
         )
@@ -181,10 +247,16 @@ class DepthExplorationService:
             f"{len(unified_exploration_chunks)} -> {len(expanded_chunks)} total "
             f"({chunks_added} new chunks)"
         )
+        await self._emit_event(
+            "gap_step",
+            f"Step 1.5.5: Final merge: {len(covered_chunks)} + {len(unified_exploration_chunks)} → {len(expanded_chunks)} total",
+            duration=perf_counter() - t,
+        )
 
         # Step 6: Import resolution (if enabled)
         import_chunks_added = 0
         if self._config.import_resolution_enabled and self._import_resolver:
+            t = perf_counter()
             import_chunks = await resolve_and_fetch_imports(
                 chunks=expanded_chunks,
                 import_resolver=self._import_resolver,
@@ -200,6 +272,24 @@ class DepthExplorationService:
                     f"Step 1.5.6: Import resolution: added {import_chunks_added} chunks "
                     f"from {len({c.get('file_path') for c in import_chunks})} import files"
                 )
+            # Always emit — shows time even when import resolution returns nothing
+            await self._emit_event(
+                "gap_step",
+                f"Step 1.5.6: Import resolution: +{import_chunks_added} chunks",
+                duration=perf_counter() - t,
+            )
+
+        total_added = chunks_added + import_chunks_added
+        elapsed_total = perf_counter() - t_total
+        logger.info(
+            f"Phase 1.5: Depth exploration complete in {elapsed_total:.2f}s — "
+            f"+{total_added} chunks added ({len(expanded_chunks)} total)"
+        )
+        await self._emit_event(
+            "gap_step",
+            f"Depth exploration complete: +{total_added} chunks added ({len(expanded_chunks)} total)",
+            duration=elapsed_total,
+        )
 
         stats = {
             "files_explored": len(top_files),

--- a/chunkhound/services/research/shared/depth_exploration.py
+++ b/chunkhound/services/research/shared/depth_exploration.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from chunkhound.api.cli.utils.tree_progress import TreeProgressDisplay
 
 from chunkhound.core.config.research_config import ResearchConfig
+from chunkhound.services.research.shared.progress_mixin import ProgressEmitterMixin
 from chunkhound.database_factory import DatabaseServices
 from chunkhound.embeddings import EmbeddingManager
 from chunkhound.llm_manager import LLMManager
@@ -54,7 +55,7 @@ from chunkhound.services.research.shared.models import (
 from chunkhound.services.research.shared.unified_search import UnifiedSearch
 
 
-class DepthExplorationService:
+class DepthExplorationService(ProgressEmitterMixin):
     """Service for exploring existing coverage from multiple angles.
 
     Unlike gap detection (which finds missing external references), depth
@@ -92,23 +93,6 @@ class DepthExplorationService:
         self._import_context_service = import_context_service
         self._progress = progress
         self._unified_search = UnifiedSearch(db_services, embedding_manager, config)
-
-    async def _emit_event(
-        self,
-        event_type: str,
-        message: str,
-        depth: int = 2,
-        **metadata: Any,
-    ) -> None:
-        """Emit a progress event to the terminal display."""
-        if not self._progress:
-            return
-        await self._progress.emit_event(
-            event_type=event_type,
-            message=message,
-            depth=depth,
-            metadata=metadata,
-        )
 
     async def explore_coverage_depth(
         self,
@@ -296,7 +280,7 @@ class DepthExplorationService:
             "queries_generated": total_queries,
             "exploration_chunks_found": total_results,
             "exploration_chunks_unique": len(unified_exploration_chunks),
-            "chunks_added": chunks_added,
+            "chunks_added": total_added,  # expansion chunks + import resolution chunks
             "import_chunks_added": import_chunks_added,
             "total_chunks": len(expanded_chunks),
             "query_generation_failures": generation_metrics.to_dict(),

--- a/chunkhound/services/research/shared/exploration/wide_coverage_strategy.py
+++ b/chunkhound/services/research/shared/exploration/wide_coverage_strategy.py
@@ -4,11 +4,14 @@ Combines depth exploration (Phase 1.5) and gap detection (Phase 2)
 for comprehensive codebase coverage.
 """
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
 from chunkhound.core.config.research_config import ResearchConfig
+
+if TYPE_CHECKING:
+    from chunkhound.api.cli.utils.tree_progress import TreeProgressDisplay
 from chunkhound.database_factory import DatabaseServices
 from chunkhound.embeddings import EmbeddingManager
 from chunkhound.llm_manager import LLMManager
@@ -40,6 +43,7 @@ class WideCoverageStrategy:
         config: ResearchConfig,
         import_resolver: Any | None = None,
         import_context_service: ImportContextService | None = None,
+        progress: "TreeProgressDisplay | None" = None,
     ):
         """Initialize wide coverage strategy.
 
@@ -50,6 +54,7 @@ class WideCoverageStrategy:
             config: Research configuration (controls depth_exploration_enabled)
             import_resolver: Optional ImportResolverService for import resolution
             import_context_service: Optional ImportContextService for header injection
+            progress: Optional TreeProgressDisplay for terminal UI (None for MCP)
         """
         # Lazy imports to avoid circular dependency
         from chunkhound.services.research.shared.depth_exploration import (
@@ -70,6 +75,7 @@ class WideCoverageStrategy:
             config=config,
             import_resolver=import_resolver,
             import_context_service=import_context_service,
+            progress=progress,
         )
         self._gap_detection = GapDetectionService(
             llm_manager=llm_manager,
@@ -78,6 +84,7 @@ class WideCoverageStrategy:
             config=config,
             import_resolver=import_resolver,
             import_context_service=import_context_service,
+            progress=progress,
         )
 
     @property

--- a/chunkhound/services/research/shared/exploration/wide_coverage_strategy.py
+++ b/chunkhound/services/research/shared/exploration/wide_coverage_strategy.py
@@ -9,9 +9,6 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from chunkhound.core.config.research_config import ResearchConfig
-
-if TYPE_CHECKING:
-    from chunkhound.api.cli.utils.tree_progress import TreeProgressDisplay
 from chunkhound.database_factory import DatabaseServices
 from chunkhound.embeddings import EmbeddingManager
 from chunkhound.llm_manager import LLMManager
@@ -20,6 +17,9 @@ from chunkhound.services.research.shared.exploration.elbow_filter import (
 )
 from chunkhound.services.research.shared.file_reader import FileReader
 from chunkhound.services.research.shared.import_context import ImportContextService
+
+if TYPE_CHECKING:
+    from chunkhound.api.cli.utils.tree_progress import TreeProgressDisplay
 
 
 class WideCoverageStrategy:

--- a/chunkhound/services/research/shared/gap_detection.py
+++ b/chunkhound/services/research/shared/gap_detection.py
@@ -20,10 +20,14 @@ Key Invariants:
 
 import asyncio
 import math
-from typing import Any
+from time import perf_counter
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from loguru import logger
+
+if TYPE_CHECKING:
+    from chunkhound.api.cli.utils.tree_progress import TreeProgressDisplay
 from sklearn.cluster import (
     AgglomerativeClustering,
     KMeans,
@@ -77,6 +81,7 @@ class GapDetectionService:
         config: ResearchConfig,
         import_resolver: Any | None = None,
         import_context_service: ImportContextService | None = None,
+        progress: "TreeProgressDisplay | None" = None,
     ):
         """Initialize gap detection service.
 
@@ -87,6 +92,7 @@ class GapDetectionService:
             config: Research configuration
             import_resolver: Optional ImportResolverService for import resolution
             import_context_service: Optional ImportContextService for header injection
+            progress: Optional TreeProgressDisplay for terminal UI (None for MCP)
         """
         self._llm_manager = llm_manager
         self._embedding_manager = embedding_manager
@@ -94,7 +100,32 @@ class GapDetectionService:
         self._config = config
         self._import_resolver = import_resolver
         self._import_context_service = import_context_service
+        self._progress = progress
         self._unified_search = UnifiedSearch(db_services, embedding_manager, config)
+
+    async def _emit_event(
+        self,
+        event_type: str,
+        message: str,
+        depth: int = 2,
+        **metadata: Any,
+    ) -> None:
+        """Emit a progress event to the terminal display.
+
+        Args:
+            event_type: Event type identifier (e.g. "gap_step")
+            message: Human-readable description
+            depth: Tree indentation depth (2 = nested under Phase 2)
+            **metadata: Additional data (e.g. duration=0.62)
+        """
+        if not self._progress:
+            return
+        await self._progress.emit_event(
+            event_type=event_type,
+            message=message,
+            depth=depth,
+            metadata=metadata,
+        )
 
     async def detect_and_fill_gaps(
         self,
@@ -126,26 +157,55 @@ class GapDetectionService:
                 "chunks_added": 0,
             }
 
+        t_total = perf_counter()
         logger.info(
             f"Phase 2: Gap detection starting with {len(covered_chunks)} covered chunks"
         )
+        await self._emit_event(
+            "gap_step",
+            f"Phase 2 gap detection: {len(covered_chunks)} chunks → analyzing...",
+        )
 
         # Step 2.1: Cluster chunks with k-means
+        t = perf_counter()
         cluster_groups = await self._cluster_chunks_kmeans(covered_chunks)
         logger.info(f"Step 2.1: Clustered into {len(cluster_groups)} semantic groups")
+        await self._emit_event(
+            "gap_step",
+            f"Step 2.1: Clustered into {len(cluster_groups)} semantic groups",
+            duration=perf_counter() - t,
+        )
 
         # Step 2.2: Shard by token budget
+        t = perf_counter()
         shards = self._shard_by_tokens(cluster_groups)
         logger.info(f"Step 2.2: Created {len(shards)} shards from clusters")
+        await self._emit_event(
+            "gap_step",
+            f"Step 2.2: Created {len(shards)} shards",
+            duration=perf_counter() - t,
+        )
 
         # Step 2.3: Detect gaps in parallel
+        t = perf_counter()
         raw_gaps = await self._detect_gaps_parallel(
             root_query, shards, constants_context
         )
         logger.info(f"Step 2.3: Detected {len(raw_gaps)} raw gap candidates")
+        await self._emit_event(
+            "gap_step",
+            f"Step 2.3: Detected {len(raw_gaps)} raw gap candidates (from {len(shards)} shards)",
+            duration=perf_counter() - t,
+        )
 
         if not raw_gaps:
             logger.info("No gaps detected, returning original coverage")
+            elapsed = perf_counter() - t_total
+            await self._emit_event(
+                "gap_step",
+                "Gap detection complete: no gaps found",
+                duration=elapsed,
+            )
             return covered_chunks, {
                 "gaps_found": 0,
                 "gaps_filled": 0,
@@ -153,6 +213,7 @@ class GapDetectionService:
             }
 
         # Step 2.4a: Embed gap queries
+        t = perf_counter()
         gap_embeddings = await self._embed_gap_queries(raw_gaps)
 
         # Step 2.4b: Cluster gap queries by similarity
@@ -161,19 +222,42 @@ class GapDetectionService:
         logger.info(
             f"Step 2.4: Clustered {len(raw_gaps)} gaps into {num_clusters} groups"
         )
+        await self._emit_event(
+            "gap_step",
+            f"Step 2.4: Gap embedding + clustering → {num_clusters} groups",
+            duration=perf_counter() - t,
+        )
 
         # Step 2.5: Unify gap clusters
+        t = perf_counter()
         unified_gaps = await self._unify_gap_clusters(
             root_query, raw_gaps, cluster_labels
         )
         logger.info(f"Step 2.5: Unified to {len(unified_gaps)} gap queries")
+        await self._emit_event(
+            "gap_step",
+            f"Step 2.5: Unified to {len(unified_gaps)} gap queries",
+            duration=perf_counter() - t,
+        )
 
         # Step 2.6: Select gaps by elbow detection
+        t = perf_counter()
         selected_gaps = self._select_gaps_by_elbow(unified_gaps)
         logger.info(f"Step 2.6: Selected {len(selected_gaps)} gaps to fill")
+        await self._emit_event(
+            "gap_step",
+            f"Step 2.6: Selected {len(selected_gaps)} gaps to fill",
+            duration=perf_counter() - t,
+        )
 
         if not selected_gaps:
             logger.info("No gaps passed selection, returning original coverage")
+            elapsed = perf_counter() - t_total
+            await self._emit_event(
+                "gap_step",
+                "Gap detection complete: no gaps passed selection",
+                duration=elapsed,
+            )
             return covered_chunks, {
                 "gaps_found": len(raw_gaps),
                 "gaps_unified": len(unified_gaps),
@@ -182,28 +266,54 @@ class GapDetectionService:
             }
 
         # Step 2.7: Fill gaps in parallel (INDEPENDENT - no shared mutable state)
+        t = perf_counter()
         gap_results = await self._fill_gaps_parallel(
             root_query, selected_gaps, phase1_threshold, path_filter
         )
+        gaps_filled = len([r for r in gap_results if r])
+        chunks_from_fills = sum(len(r) for r in gap_results)
+        logger.info(
+            f"Step 2.7: Filled {gaps_filled}/{len(selected_gaps)} gaps → "
+            f"{chunks_from_fills} chunks"
+        )
+        await self._emit_event(
+            "gap_step",
+            f"Step 2.7: Filled {gaps_filled}/{len(selected_gaps)} gaps → {chunks_from_fills} chunks",
+            duration=perf_counter() - t,
+        )
 
         # Step 2.8: Global deduplication (SYNC POINT)
+        t = perf_counter()
         unified_gap_chunks = self._global_dedup(gap_results)
-        total_before_dedup = sum(len(r) for r in gap_results)
+        # Reuse chunks_from_fills — gap_results is not mutated between steps 2.7 and 2.8
+        total_before_dedup = chunks_from_fills
         logger.info(
             f"Step 2.8: Global dedup: {total_before_dedup} → "
             f"{len(unified_gap_chunks)} unique chunks"
         )
+        await self._emit_event(
+            "gap_step",
+            f"Step 2.8: Global dedup: {total_before_dedup} → {len(unified_gap_chunks)} unique chunks",
+            duration=perf_counter() - t,
+        )
 
         # Step 2.9: Merge coverage + gap chunks
+        t = perf_counter()
         all_chunks = self._merge_coverage(covered_chunks, unified_gap_chunks)
         logger.info(
             f"Step 2.9: Final merge: {len(covered_chunks)} + "
             f"{len(unified_gap_chunks)} → {len(all_chunks)} total"
         )
+        await self._emit_event(
+            "gap_step",
+            f"Step 2.9: Final merge: {len(covered_chunks)} + {len(unified_gap_chunks)} → {len(all_chunks)} total",
+            duration=perf_counter() - t,
+        )
 
         # Step 2.10: Import resolution (if enabled)
         import_chunks_added = 0
         if self._config.import_resolution_enabled and self._import_resolver:
+            t = perf_counter()
             import_chunks = await resolve_and_fetch_imports(
                 chunks=all_chunks,
                 import_resolver=self._import_resolver,
@@ -215,20 +325,39 @@ class GapDetectionService:
             if import_chunks:
                 all_chunks = self._merge_coverage(all_chunks, import_chunks)
                 import_chunks_added = len(import_chunks)
+                import_files = len({c.get("file_path") for c in import_chunks})
                 logger.info(
                     f"Step 2.10: Import resolution: added {import_chunks_added} chunks "
-                    f"from {len({c.get('file_path') for c in import_chunks})} import files"
+                    f"from {import_files} import files"
                 )
+            # Always emit — shows time even when import resolution returns nothing
+            await self._emit_event(
+                "gap_step",
+                f"Step 2.10: Import resolution: +{import_chunks_added} chunks",
+                duration=perf_counter() - t,
+            )
 
         # Extract gap queries for compound context in synthesis
         gap_queries = [gap.query for gap in selected_gaps]
+
+        chunks_added = len(unified_gap_chunks) + import_chunks_added
+        elapsed_total = perf_counter() - t_total
+        logger.info(
+            f"Phase 2: Gap detection complete in {elapsed_total:.2f}s — "
+            f"+{chunks_added} chunks added ({len(all_chunks)} total)"
+        )
+        await self._emit_event(
+            "gap_step",
+            f"Gap detection complete: +{chunks_added} chunks added ({len(all_chunks)} total)",
+            duration=elapsed_total,
+        )
 
         gap_stats = {
             "gaps_found": len(raw_gaps),
             "gaps_unified": len(unified_gaps),
             "gaps_selected": len(selected_gaps),
-            "gaps_filled": len([r for r in gap_results if r]),
-            "chunks_added": len(unified_gap_chunks),
+            "gaps_filled": gaps_filled,  # reuse variable from step 2.7
+            "chunks_added": chunks_added,  # unified gap chunks + import resolution chunks
             "import_chunks_added": import_chunks_added,
             "total_chunks": len(all_chunks),
             "gap_queries": gap_queries,  # For compound context in Phase 3

--- a/chunkhound/services/research/shared/gap_detection.py
+++ b/chunkhound/services/research/shared/gap_detection.py
@@ -28,6 +28,7 @@ from loguru import logger
 
 if TYPE_CHECKING:
     from chunkhound.api.cli.utils.tree_progress import TreeProgressDisplay
+
 from sklearn.cluster import (
     AgglomerativeClustering,
     KMeans,
@@ -171,7 +172,8 @@ class GapDetectionService(ProgressEmitterMixin):
         logger.info(f"Step 2.3: Detected {len(raw_gaps)} raw gap candidates")
         await self._emit_event(
             "gap_step",
-            f"Step 2.3: Detected {len(raw_gaps)} raw gap candidates (from {len(shards)} shards)",
+            f"Step 2.3: Detected {len(raw_gaps)} raw gap candidates"
+            f" (from {len(shards)} shards)",
             duration=perf_counter() - t,
         )
 
@@ -255,7 +257,8 @@ class GapDetectionService(ProgressEmitterMixin):
         )
         await self._emit_event(
             "gap_step",
-            f"Step 2.7: Filled {gaps_filled}/{len(selected_gaps)} gaps → {chunks_from_fills} chunks",
+            f"Step 2.7: Filled {gaps_filled}/{len(selected_gaps)} gaps"
+            f" → {chunks_from_fills} chunks",
             duration=perf_counter() - t,
         )
 
@@ -270,7 +273,8 @@ class GapDetectionService(ProgressEmitterMixin):
         )
         await self._emit_event(
             "gap_step",
-            f"Step 2.8: Global dedup: {total_before_dedup} → {len(unified_gap_chunks)} unique chunks",
+            f"Step 2.8: Global dedup: {total_before_dedup}"
+            f" → {len(unified_gap_chunks)} unique chunks",
             duration=perf_counter() - t,
         )
 
@@ -283,7 +287,8 @@ class GapDetectionService(ProgressEmitterMixin):
         )
         await self._emit_event(
             "gap_step",
-            f"Step 2.9: Final merge: {len(covered_chunks)} + {len(unified_gap_chunks)} → {len(all_chunks)} total",
+            f"Step 2.9: Final merge: {len(covered_chunks)}"
+            f" + {len(unified_gap_chunks)} → {len(all_chunks)} total",
             duration=perf_counter() - t,
         )
 
@@ -325,7 +330,8 @@ class GapDetectionService(ProgressEmitterMixin):
         )
         await self._emit_event(
             "gap_step",
-            f"Gap detection complete: +{chunks_added} chunks added ({len(all_chunks)} total)",
+            f"Gap detection complete: +{chunks_added} chunks added"
+            f" ({len(all_chunks)} total)",
             duration=elapsed_total,
         )
 
@@ -334,7 +340,7 @@ class GapDetectionService(ProgressEmitterMixin):
             "gaps_unified": len(unified_gaps),
             "gaps_selected": len(selected_gaps),
             "gaps_filled": gaps_filled,  # reuse variable from step 2.7
-            "chunks_added": chunks_added,  # unified gap chunks + import resolution chunks
+            "chunks_added": chunks_added,  # gap chunks + import resolution chunks
             "import_chunks_added": import_chunks_added,
             "total_chunks": len(all_chunks),
             "gap_queries": gap_queries,  # For compound context in Phase 3

--- a/chunkhound/services/research/shared/gap_detection.py
+++ b/chunkhound/services/research/shared/gap_detection.py
@@ -61,6 +61,7 @@ from chunkhound.services.research.shared.models import (
     IMPORT_DEFAULT_SCORE,
     ResearchContext,
 )
+from chunkhound.services.research.shared.progress_mixin import ProgressEmitterMixin
 from chunkhound.services.research.shared.unified_search import UnifiedSearch
 
 # Token budget per gap detection cluster (affects LLM context size)
@@ -70,7 +71,7 @@ GAP_CLUSTER_TOKEN_BUDGET = 50_000
 KMEANS_N_INIT = 10
 
 
-class GapDetectionService:
+class GapDetectionService(ProgressEmitterMixin):
     """Service for detecting and filling semantic gaps in code coverage."""
 
     def __init__(
@@ -102,30 +103,6 @@ class GapDetectionService:
         self._import_context_service = import_context_service
         self._progress = progress
         self._unified_search = UnifiedSearch(db_services, embedding_manager, config)
-
-    async def _emit_event(
-        self,
-        event_type: str,
-        message: str,
-        depth: int = 2,
-        **metadata: Any,
-    ) -> None:
-        """Emit a progress event to the terminal display.
-
-        Args:
-            event_type: Event type identifier (e.g. "gap_step")
-            message: Human-readable description
-            depth: Tree indentation depth (2 = nested under Phase 2)
-            **metadata: Additional data (e.g. duration=0.62)
-        """
-        if not self._progress:
-            return
-        await self._progress.emit_event(
-            event_type=event_type,
-            message=message,
-            depth=depth,
-            metadata=metadata,
-        )
 
     async def detect_and_fill_gaps(
         self,

--- a/chunkhound/services/research/shared/gap_detection.py
+++ b/chunkhound/services/research/shared/gap_detection.py
@@ -75,6 +75,8 @@ KMEANS_N_INIT = 10
 class GapDetectionService(ProgressEmitterMixin):
     """Service for detecting and filling semantic gaps in code coverage."""
 
+    _default_depth = 2  # all gap_step events are nested under the current phase
+
     def __init__(
         self,
         llm_manager: LLMManager,

--- a/chunkhound/services/research/shared/progress_mixin.py
+++ b/chunkhound/services/research/shared/progress_mixin.py
@@ -12,7 +12,7 @@ class ProgressEmitterMixin:
     Requires the subclass to set self._progress in its __init__.
     """
 
-    _progress: "TreeProgressDisplay | None"
+    _progress: "TreeProgressDisplay | None" = None
 
     async def _emit_event(
         self,

--- a/chunkhound/services/research/shared/progress_mixin.py
+++ b/chunkhound/services/research/shared/progress_mixin.py
@@ -13,16 +13,20 @@ class ProgressEmitterMixin:
     Requires the subclass to set self._progress in its __init__.
     If the subclass sets self._progress_lock (an asyncio.Lock), emits are
     serialized under that lock — needed when multiple coroutines emit concurrently.
+
+    Subclasses that emit exclusively nested step events (e.g. depth=2) can set
+    _default_depth as a class variable instead of passing depth= on every call.
     """
 
     _progress: "TreeProgressDisplay | None" = None
     _progress_lock: "asyncio.Lock | None" = None
+    _default_depth: int | None = None  # override in subclass for nested step events
 
     async def _emit_event(
         self,
         event_type: str,
         message: str,
-        depth: int | None = 2,
+        depth: int | None = None,
         node_id: int | None = None,
         **metadata: Any,
     ) -> None:
@@ -31,19 +35,20 @@ class ProgressEmitterMixin:
         Args:
             event_type: Event type identifier (e.g. "gap_step")
             message: Human-readable description
-            depth: Tree indentation depth (2 = nested under the current phase)
+            depth: Tree indentation depth. Falls back to _default_depth if None.
             node_id: Optional BFS node ID for tree placement
             **metadata: Additional data (e.g. duration=0.62)
         """
         if not self._progress:
             return
+        effective_depth = depth if depth is not None else self._default_depth
         if self._progress_lock is not None:
             async with self._progress_lock:
                 await self._progress.emit_event(
                     event_type=event_type,
                     message=message,
                     node_id=node_id,
-                    depth=depth,
+                    depth=effective_depth,
                     metadata=metadata,
                 )
         else:
@@ -51,6 +56,6 @@ class ProgressEmitterMixin:
                 event_type=event_type,
                 message=message,
                 node_id=node_id,
-                depth=depth,
+                depth=effective_depth,
                 metadata=metadata,
             )

--- a/chunkhound/services/research/shared/progress_mixin.py
+++ b/chunkhound/services/research/shared/progress_mixin.py
@@ -1,5 +1,6 @@
 """Mixin for emitting progress events to the terminal display."""
 
+import asyncio
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -10,15 +11,19 @@ class ProgressEmitterMixin:
     """Mixin that adds _emit_event to a service class.
 
     Requires the subclass to set self._progress in its __init__.
+    If the subclass sets self._progress_lock (an asyncio.Lock), emits are
+    serialized under that lock — needed when multiple coroutines emit concurrently.
     """
 
     _progress: "TreeProgressDisplay | None" = None
+    _progress_lock: "asyncio.Lock | None" = None
 
     async def _emit_event(
         self,
         event_type: str,
         message: str,
-        depth: int = 2,
+        depth: int | None = 2,
+        node_id: int | None = None,
         **metadata: Any,
     ) -> None:
         """Emit a progress event to the terminal display.
@@ -27,13 +32,25 @@ class ProgressEmitterMixin:
             event_type: Event type identifier (e.g. "gap_step")
             message: Human-readable description
             depth: Tree indentation depth (2 = nested under the current phase)
+            node_id: Optional BFS node ID for tree placement
             **metadata: Additional data (e.g. duration=0.62)
         """
         if not self._progress:
             return
-        await self._progress.emit_event(
-            event_type=event_type,
-            message=message,
-            depth=depth,
-            metadata=metadata,
-        )
+        if self._progress_lock is not None:
+            async with self._progress_lock:
+                await self._progress.emit_event(
+                    event_type=event_type,
+                    message=message,
+                    node_id=node_id,
+                    depth=depth,
+                    metadata=metadata,
+                )
+        else:
+            await self._progress.emit_event(
+                event_type=event_type,
+                message=message,
+                node_id=node_id,
+                depth=depth,
+                metadata=metadata,
+            )

--- a/chunkhound/services/research/shared/progress_mixin.py
+++ b/chunkhound/services/research/shared/progress_mixin.py
@@ -1,0 +1,39 @@
+"""Mixin for emitting progress events to the terminal display."""
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from chunkhound.api.cli.utils.tree_progress import TreeProgressDisplay
+
+
+class ProgressEmitterMixin:
+    """Mixin that adds _emit_event to a service class.
+
+    Requires the subclass to set self._progress in its __init__.
+    """
+
+    _progress: "TreeProgressDisplay | None"
+
+    async def _emit_event(
+        self,
+        event_type: str,
+        message: str,
+        depth: int = 2,
+        **metadata: Any,
+    ) -> None:
+        """Emit a progress event to the terminal display.
+
+        Args:
+            event_type: Event type identifier (e.g. "gap_step")
+            message: Human-readable description
+            depth: Tree indentation depth (2 = nested under the current phase)
+            **metadata: Additional data (e.g. duration=0.62)
+        """
+        if not self._progress:
+            return
+        await self._progress.emit_event(
+            event_type=event_type,
+            message=message,
+            depth=depth,
+            metadata=metadata,
+        )

--- a/chunkhound/services/research/v1/pluggable_research_service.py
+++ b/chunkhound/services/research/v1/pluggable_research_service.py
@@ -22,11 +22,11 @@ from chunkhound.embeddings import EmbeddingManager
 from chunkhound.llm_manager import LLMManager
 from chunkhound.services import prompts
 from chunkhound.services.clustering_service import ClusterGroup
+from chunkhound.services.research.shared.chunk_dedup import get_chunk_id
 from chunkhound.services.research.shared.chunk_range import (
     expand_to_natural_boundaries,
     get_chunk_expanded_range,
 )
-from chunkhound.services.research.shared.chunk_dedup import get_chunk_id
 from chunkhound.services.research.shared.citation_manager import CitationManager
 from chunkhound.services.research.shared.evidence_ledger import (
     EvidenceLedger,
@@ -42,6 +42,7 @@ from chunkhound.services.research.shared.models import (
     TOKEN_BUDGET_PER_FILE,
     ResearchContext,
 )
+from chunkhound.services.research.shared.progress_mixin import ProgressEmitterMixin
 from chunkhound.services.research.shared.unified_search import UnifiedSearch
 from chunkhound.services.research.v1.quality_validator import QualityValidator
 from chunkhound.services.research.v1.synthesis_engine import SynthesisEngine
@@ -51,7 +52,7 @@ if TYPE_CHECKING:
     from chunkhound.core.config.research_config import ResearchConfig
 
 
-class PluggableResearchService:
+class PluggableResearchService(ProgressEmitterMixin):
     """Service for performing deep research with pluggable exploration strategies.
 
     This service orchestrates the research pipeline while delegating exploration
@@ -89,7 +90,7 @@ class PluggableResearchService:
         self._llm_manager = llm_manager
         self._tool_name = tool_name
         self._node_counter = 0
-        self.progress = progress  # Store progress instance for event emission
+        self._progress = progress
         self._progress_lock: asyncio.Lock = asyncio.Lock()
         self._synthesis_engine = SynthesisEngine(llm_manager, database_services, self)
         self._citation_manager = CitationManager()
@@ -118,34 +119,6 @@ class PluggableResearchService:
         if self._config is not None:
             return self._config.num_expanded_queries
         return NUM_LLM_EXPANDED_QUERIES
-
-    async def _emit_event(
-        self,
-        event_type: str,
-        message: str,
-        node_id: int | None = None,
-        depth: int | None = None,
-        **metadata: Any,
-    ) -> None:
-        """Emit a progress event with lock protection.
-
-        Args:
-            event_type: Event type identifier
-            message: Human-readable event description
-            node_id: Optional BFS node ID
-            depth: Optional BFS depth level
-            **metadata: Additional event data (chunks, files, tokens, etc.)
-        """
-        if not self.progress:
-            return
-        async with self._progress_lock:
-            await self.progress.emit_event(
-                event_type=event_type,
-                message=message,
-                node_id=node_id,
-                depth=depth,
-                metadata=metadata,
-            )
 
     async def deep_research(self, query: str) -> dict[str, Any]:
         """Perform deep research on a query.


### PR DESCRIPTION
Thread TreeProgressDisplay through WideCoverageStrategy → DepthExplorationService and GapDetectionService. Each service gains an _emit_event helper and perf_counter() timing around every step, emitting gap_step events (▶) with per-step durations visible in the terminal progress tree.

Also fixes from code review:
- gap_stats["chunks_added"] now includes import_chunks_added, matching the completion event message
- Step 2.10 / 1.5.6 import-resolution timing event always emits (previously silently dropped when resolve_and_fetch_imports returns [])
- gaps_filled reuses the variable from step 2.7 instead of recomputing
- total_before_dedup reuses chunks_from_fills instead of re-iterating gap_results
- Add gap_step and fact_extraction symbols to TreeProgressDisplay