### PR TITLE
fix(quickresearch): exit orphaned _quickresearch child when parent dies

### DIFF
--- a/chunkhound/api/cli/commands/quickresearch.py
+++ b/chunkhound/api/cli/commands/quickresearch.py
@@ -1,7 +1,9 @@
 """Quickresearch command — index into memory, then research."""
 
 import argparse
+import os
 import sys
+import threading
 
 from chunkhound.core.config.config import Config
 from chunkhound.database_factory import create_services
@@ -9,6 +11,39 @@ from chunkhound.services.directory_indexing_service import DirectoryIndexingServ
 
 from ..utils.rich_output import RichOutputFormatter
 from .research import run_research, setup_embedding_llm
+
+_ORPHAN_POLL_INTERVAL = 2.0
+
+
+def _orphan_exit() -> None:
+    """Die immediately — parent is gone, no reason to keep spending tokens.
+
+    Uses os._exit so we bypass atexit and coroutine finally blocks that would
+    otherwise try to write to now-dead stdio pipes. The diagnostic print is
+    guarded because on the MCP path stderr is a PIPE whose read end closes
+    once the parent dies — without the guard, BrokenPipeError would unwind
+    before os._exit ran and the watchdog task would fail silently.
+    """
+    try:
+        print("_quickresearch: parent died, exiting", file=sys.stderr, flush=True)
+    except (BrokenPipeError, OSError):
+        pass
+    os._exit(1)
+
+
+def _orphan_watchdog_thread(initial_ppid: int, stop: threading.Event) -> None:
+    """Poll getppid() from a daemon thread; call _orphan_exit when it changes.
+
+    Runs off the event loop so it fires even when the main thread is blocked
+    in sync file I/O — the indexing_coordinator change-detection phase does
+    per-file stat/hash without yielding, which would delay an asyncio-based
+    watchdog. Windows is skipped by the caller because getppid() there is not
+    updated on parent death (no PID-1 reparent semantics).
+    """
+    while not stop.wait(_ORPHAN_POLL_INTERVAL):
+        if os.getppid() != initial_ppid:
+            _orphan_exit()
+            return  # unreachable in prod; keeps the loop testable
 
 
 async def quickresearch_command(args: argparse.Namespace, config: Config) -> None:
@@ -24,50 +59,69 @@ async def quickresearch_command(args: argparse.Namespace, config: Config) -> Non
         formatter.error(f"Path does not exist or is not a directory: {args.path}")
         sys.exit(1)
 
-    # _quickresearch is only invoked by `chunkhound websearch` and the websearch
-    # MCP tool, which point it at a tempdir of fetched pages. User-supplied
-    # include/exclude (from .chunkhound.json, --config, env vars, or global
-    # config) would zero out files in that tempdir. Reset to library defaults.
-    # System tempdirs typically have no .gitignore/.chignore, so the remaining
-    # ignore knobs (workspace_gitignore_*, chignore_file) are de-facto inert.
-    config.indexing.reset_user_include_exclude()
-
-    embedding_manager, llm_manager = setup_embedding_llm(formatter, config)
-
-    # Single create_services call owns the only :memory: connection.
-    # Unlike file-backed DBs (where a second connection hits the same data and
-    # causes a hard DuckDB lock error), each duckdb.connect(":memory:") creates
-    # a fully isolated, independent database — a second call would silently
-    # return zero results with no error.  Pass services.indexing_coordinator
-    # directly so indexing and research share the exact same connection.
+    watchdog_stop: threading.Event | None = None
+    if sys.platform != "win32":
+        # Immediate check closes the startup race: if our parent died during
+        # interpreter startup, getppid() already returns the reparent PID and
+        # would never equal the authoritative value the parent handed us.
+        if os.getppid() != args.parent_pid:
+            _orphan_exit()
+        watchdog_stop = threading.Event()
+        threading.Thread(
+            target=_orphan_watchdog_thread,
+            args=(args.parent_pid, watchdog_stop),
+            daemon=True,
+            name="quickresearch-orphan-watchdog",
+        ).start()
     try:
-        services = create_services(":memory:", config, embedding_manager)
-    except Exception as e:
-        formatter.error(f"Failed to initialize services: {e}")
-        sys.exit(1)
+        # _quickresearch is only invoked by `chunkhound websearch` and the websearch
+        # MCP tool, which point it at a tempdir of fetched pages. User-supplied
+        # include/exclude (from .chunkhound.json, --config, env vars, or global
+        # config) would zero out files in that tempdir. Reset to library defaults.
+        # System tempdirs typically have no .gitignore/.chignore, so the remaining
+        # ignore knobs (workspace_gitignore_*, chignore_file) are de-facto inert.
+        config.indexing.reset_user_include_exclude()
 
-    formatter.info(f"Indexing {args.path} into memory...")
-    try:
-        svc = DirectoryIndexingService(
-            indexing_coordinator=services.indexing_coordinator,
-            config=config,
-            progress_callback=formatter.progress_indicator,
+        embedding_manager, llm_manager = setup_embedding_llm(formatter, config)
+
+        # Single create_services call owns the only :memory: connection.
+        # Unlike file-backed DBs (where a second connection hits the same data and
+        # causes a hard DuckDB lock error), each duckdb.connect(":memory:") creates
+        # a fully isolated, independent database — a second call would silently
+        # return zero results with no error.  Pass services.indexing_coordinator
+        # directly so indexing and research share the exact same connection.
+        try:
+            services = create_services(":memory:", config, embedding_manager)
+        except Exception as e:
+            formatter.error(f"Failed to initialize services: {e}")
+            sys.exit(1)
+
+        formatter.info(f"Indexing {args.path} into memory...")
+        try:
+            svc = DirectoryIndexingService(
+                indexing_coordinator=services.indexing_coordinator,
+                config=config,
+                progress_callback=formatter.progress_indicator,
+            )
+            await svc.process_directory(args.path)
+        except Exception as e:
+            formatter.error(f"Indexing failed: {e}")
+            sys.exit(1)
+
+        formatter.info(
+            f"Researching {args.path}"
+            + (f" (filter: {args.path_filter})" if args.path_filter else "")
         )
-        await svc.process_directory(args.path)
-    except Exception as e:
-        formatter.error(f"Indexing failed: {e}")
-        sys.exit(1)
-
-    formatter.info(
-        f"Researching {args.path}"
-        + (f" (filter: {args.path_filter})" if args.path_filter else "")
-    )
-    await run_research(
-        services,
-        embedding_manager,
-        llm_manager,
-        args.query,
-        args.path_filter,
-        config,
-        formatter,
-    )
+        await run_research(
+            services,
+            embedding_manager,
+            llm_manager,
+            args.query,
+            args.path_filter,
+            config,
+            formatter,
+        )
+    finally:
+        if watchdog_stop is not None:
+            # Unblock the polling loop; daemon=True means we skip the join.
+            watchdog_stop.set()

--- a/chunkhound/api/cli/commands/websearch.py
+++ b/chunkhound/api/cli/commands/websearch.py
@@ -31,12 +31,15 @@ def _build_quickresearch_argv(args: argparse.Namespace, tmpdir: Path, config: Co
     _tmp = argparse.ArgumentParser(add_help=False)
     qr_parser = add_quickresearch_subparser(_tmp.add_subparsers())
 
-    cmd = build_quickresearch_argv_core(args.query, tmpdir, config)
+    cmd = build_quickresearch_argv_core(
+        args.query, tmpdir, config, parent_pid=os.getpid()
+    )
     cmd.extend(build_forwarded_argv(
         qr_parser,
         args,
         # path_filter: defensive — forwarding would zero out results (flat tmpdir).
-        skip_dests={"help", "path_filter", "config"},
+        # parent_pid: emitted explicitly above; skip to avoid double-forwarding.
+        skip_dests={"help", "path_filter", "config", "parent_pid"},
     ))
     return cmd
 

--- a/chunkhound/api/cli/parsers/quickresearch_parser.py
+++ b/chunkhound/api/cli/parsers/quickresearch_parser.py
@@ -38,6 +38,17 @@ def add_quickresearch_subparser(subparsers: Any) -> argparse.ArgumentParser:
         help="Optional path filter (e.g., 'src/', 'tests/')",
     )
 
+    # Parent hands down its PID so the orphan watchdog compares against an
+    # authoritative reference instead of a post-fork getppid() snapshot (which
+    # would already be the reparent PID if the parent died during interpreter
+    # startup, and would misidentify a Docker-entrypoint parent as PID 1).
+    p.add_argument(
+        "--parent-pid",
+        type=int,
+        required=True,
+        help=argparse.SUPPRESS,
+    )
+
     add_common_arguments(p)
     add_config_arguments(p, ["embedding", "llm", "research"])
 

--- a/chunkhound/mcp_server/tools.py
+++ b/chunkhound/mcp_server/tools.py
@@ -889,7 +889,9 @@ async def websearch_impl(
             mapping=mapping,
         )
 
-        cmd = build_quickresearch_argv_core(query, tmpdir, config)
+        cmd = build_quickresearch_argv_core(
+            query, tmpdir, config, parent_pid=os.getpid()
+        )
         # Scrub CHUNKHOUND_MCP_MODE so the child's RichOutputFormatter.error()
         # is not silenced — we rely on its stderr output to populate the
         # MCPError tail on subprocess failure.

--- a/chunkhound/utils/websearch_core.py
+++ b/chunkhound/utils/websearch_core.py
@@ -716,12 +716,16 @@ def build_quickresearch_argv_core(
     query: str,
     tmpdir: Path,
     config: Config,
+    parent_pid: int,
 ) -> list[str]:
     """Build argv to invoke _quickresearch as a subprocess.
 
     Forwards the config source file as an absolute path so the child process
     does not need to re-run config discovery (which would otherwise fall back
     to env vars / defaults under the MCP server's working directory).
+
+    ``parent_pid`` is the caller's own PID (``os.getpid()``); the child uses
+    it as the reference for its orphan watchdog.
     """
     cmd: list[str] = [
         sys.executable,
@@ -729,6 +733,7 @@ def build_quickresearch_argv_core(
         "_quickresearch",
         query,
         str(tmpdir),
+        "--parent-pid", str(parent_pid),
     ]
     source = config.config_file or config.local_config_file
     if source is not None:

--- a/tests/helpers/sitecustomize.py
+++ b/tests/helpers/sitecustomize.py
@@ -143,7 +143,7 @@ def _patch_websearch_for_tests() -> None:
                 if mapping is not None:
                     mapping[name] = url
 
-        def _stub_build_argv(query, tmpdir, config):
+        def _stub_build_argv(query, tmpdir, config, parent_pid):
             # -S skips site init so this sitecustomize isn't re-loaded in the
             # grandchild — avoids a recursive chunkhound cold-import that
             # blew past the 30s tools/call budget on Windows.

--- a/tests/unit/test_quickresearch_ignores_indexing_filters.py
+++ b/tests/unit/test_quickresearch_ignores_indexing_filters.py
@@ -13,6 +13,7 @@ five filter-related `IndexingConfig` fields are reset to library defaults.
 from __future__ import annotations
 
 import argparse
+import os
 from pathlib import Path
 from typing import Any
 
@@ -71,6 +72,9 @@ async def test_quickresearch_ignores_user_include_exclude_filters(
         path=tmp_path,
         path_filter=None,
         verbose=False,
+        # Match our own ppid so the startup orphan check passes and the
+        # watchdog thread stays quiet for the duration of the test.
+        parent_pid=os.getppid(),
     )
 
     await qr_mod.quickresearch_command(args, config)

--- a/tests/unit/test_quickresearch_orphan_watchdog.py
+++ b/tests/unit/test_quickresearch_orphan_watchdog.py
@@ -1,0 +1,94 @@
+"""Watchdog tests for `_quickresearch` — die when the parent process is gone.
+
+See `test_orphan_watchdog_triggers_shutdown_when_orphaned` in
+tests/unit/test_client_proxy.py for the daemon precedent.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+
+import pytest
+
+import chunkhound.api.cli.commands.quickresearch as qr_mod
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows has no ppid reparenting")
+def test_orphan_watchdog_calls_exit_when_ppid_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The watchdog invokes _orphan_exit once getppid() diverges from initial."""
+    monkeypatch.setattr(qr_mod, "_ORPHAN_POLL_INTERVAL", 0.0)
+    monkeypatch.setattr(qr_mod.os, "getppid", lambda: 9999)
+
+    called = threading.Event()
+    monkeypatch.setattr(qr_mod, "_orphan_exit", called.set)
+
+    stop = threading.Event()
+    qr_mod._orphan_watchdog_thread(initial_ppid=1234, stop=stop)
+
+    assert called.is_set()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows has no ppid reparenting")
+def test_orphan_watchdog_does_not_exit_when_ppid_stable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stable ppid keeps the watchdog looping without firing _orphan_exit."""
+    monkeypatch.setattr(qr_mod, "_ORPHAN_POLL_INTERVAL", 0.01)
+    monkeypatch.setattr(qr_mod.os, "getppid", lambda: 1234)
+
+    called = False
+
+    def fake_exit() -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(qr_mod, "_orphan_exit", fake_exit)
+
+    stop = threading.Event()
+    thread = threading.Thread(
+        target=qr_mod._orphan_watchdog_thread,
+        args=(1234, stop),
+        daemon=True,
+    )
+    thread.start()
+    time.sleep(0.05)  # let it poll several times
+    stop.set()
+    thread.join(timeout=1.0)
+
+    assert not thread.is_alive()
+    assert called is False
+
+
+def test_orphan_exit_calls_os_exit_even_when_stderr_raises_broken_pipe() -> None:
+    """Regression for the MCP-path BrokenPipeError case (stderr=PIPE).
+
+    The MCP server spawns _quickresearch with stderr=PIPE (tools.py:903). When
+    the parent dies, the pipe's read end closes and the next write raises
+    BrokenPipeError. _orphan_exit must swallow that and still reach os._exit.
+    """
+    script = textwrap.dedent(
+        """
+        import sys
+        from chunkhound.api.cli.commands.quickresearch import _orphan_exit
+
+        class BrokenPipeStderr:
+            def write(self, _s):
+                raise BrokenPipeError(32, "Broken pipe")
+            def flush(self):
+                raise BrokenPipeError(32, "Broken pipe")
+
+        sys.stderr = BrokenPipeStderr()
+        _orphan_exit()
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+    )
+    assert result.returncode == 1

--- a/tests/unit/test_websearch_mcp_errors.py
+++ b/tests/unit/test_websearch_mcp_errors.py
@@ -82,7 +82,7 @@ async def _stub_fetch_and_save_noop(
     return None
 
 
-def _stub_build_argv(query, tmpdir, config):
+def _stub_build_argv(query, tmpdir, config, parent_pid):
     # Argv content is irrelevant — subprocess is patched out.
     return ["/bin/true"]
 


### PR DESCRIPTION
**Note**: This PR was generated by an AI agent. If you'd like to talk with other humans, drop by our [Discord](https://discord.gg/BAepHEXXnX)!

---

## `_quickresearch`: exit when orphaned

The `_quickresearch` subprocess (spawned by `chunkhound websearch` and the websearch MCP tool) had no way to notice its parent had died — so if the MCP server or CLI got killed mid-run, the child kept indexing and burning LLM tokens against a dead pipe. This PR adds a small orphan watchdog that polls `os.getppid()` every 2s and calls `os._exit(1)` when it flips, mirroring the pattern already in `daemon/client_proxy.py`.

Two design details worth flagging: the watchdog runs in a daemon **thread**, not an asyncio task, because indexing's change-detection phase does blocking per-file stat/hash without yielding — an asyncio watchdog would sit starved behind it. And the parent PID is passed down explicitly via `--parent-pid` (SUPPRESSed from help) rather than relying on the child's own `getppid()`; if the parent dies during interpreter startup, the child's first `getppid()` already returns the reparent PID and the watchdog would never fire. There's also a hardened `_orphan_exit` that swallows `BrokenPipeError` on the stderr diagnostic — otherwise the MCP-path stderr=PIPE case would unwind before `os._exit` ran.

No behavior change for anyone not orphaning a subprocess. Windows is skipped (no PID-1 reparent semantics). Signatures of `build_quickresearch_argv_core` and the `_quickresearch` CLI grew a required `parent_pid` / `--parent-pid`, but both are internal to the websearch path and updated in the same commit. Three new unit tests cover the ppid-changed, ppid-stable, and broken-pipe paths.
[AGENT_REVIEW.md](https://github.com/user-attachments/files/29595078/AGENT_REVIEW.md)
