### PR TITLE
fix: keep makefile rule chunks within embedding budget

### DIFF
--- a/chunkhound/parsers/makefile_parser.py
+++ b/chunkhound/parsers/makefile_parser.py
@@ -31,6 +31,40 @@ class MakefileChunkSplitter(ChunkSplitter):
     preserving target/recipe semantic coherence.
     """
 
+    def _rule_content_limits(self, target: str) -> tuple[int, int]:
+        """Return content limits after reserving rule_target embedding context."""
+        rule_target_header = f"[target: {target}]"
+        rule_target_chars = sum(1 for char in rule_target_header if not char.isspace())
+        rule_target_tokens = estimate_tokens_chunking(rule_target_header)
+        return (
+            max(1, self.config.max_chunk_size - rule_target_chars),
+            max(1, self.config.safe_token_limit - rule_target_tokens),
+        )
+
+    def _emergency_split_with_limits(
+        self,
+        chunk: UniversalChunk,
+        max_chunk_size: int,
+        safe_token_limit: int,
+    ) -> list[UniversalChunk]:
+        """Emergency-split with Makefile rule_target budget already reserved."""
+        if (
+            max_chunk_size == self.config.max_chunk_size
+            and safe_token_limit == self.config.safe_token_limit
+        ):
+            return self._emergency_split(chunk)
+
+        constrained = ChunkSplitter(
+            CASTConfig(
+                max_chunk_size=max_chunk_size,
+                min_chunk_size=min(self.config.min_chunk_size, max_chunk_size),
+                merge_threshold=self.config.merge_threshold,
+                greedy_merge=self.config.greedy_merge,
+                safe_token_limit=safe_token_limit,
+            )
+        )
+        return constrained._emergency_split(chunk)
+
     def validate_and_split(self, chunk: UniversalChunk) -> list[UniversalChunk]:
         """Validate chunk size and split if necessary.
 
@@ -69,6 +103,8 @@ class MakefileChunkSplitter(ChunkSplitter):
         if not recipe_lines:
             return self._recursive_split(chunk)
 
+        max_chunk_size, safe_token_limit = self._rule_content_limits(target_line)
+
         # Group recipe lines into size-limited chunks
         result: list[UniversalChunk] = []
         current_group: list[str] = []
@@ -84,8 +120,8 @@ class MakefileChunkSplitter(ChunkSplitter):
             test_tokens = estimate_tokens_chunking(test_content)
 
             if (
-                test_metrics.non_whitespace_chars <= self.config.max_chunk_size
-                and test_tokens <= self.config.safe_token_limit
+                test_metrics.non_whitespace_chars <= max_chunk_size
+                and test_tokens <= safe_token_limit
             ):
                 current_group.append(recipe_line)
             else:
@@ -121,11 +157,15 @@ class MakefileChunkSplitter(ChunkSplitter):
             metrics = ChunkMetrics.from_content(rule_chunk.content)
             tokens = estimate_tokens_chunking(rule_chunk.content)
             if (
-                metrics.non_whitespace_chars > self.config.max_chunk_size
-                or tokens > self.config.safe_token_limit
+                metrics.non_whitespace_chars > max_chunk_size
+                or tokens > safe_token_limit
             ):
                 # Single recipe line exceeds limit - use emergency split
-                validated_result.extend(self._emergency_split(rule_chunk))
+                validated_result.extend(
+                    self._emergency_split_with_limits(
+                        rule_chunk, max_chunk_size, safe_token_limit
+                    )
+                )
             else:
                 validated_result.append(rule_chunk)
 

--- a/tests/fixtures/fake_providers.py
+++ b/tests/fixtures/fake_providers.py
@@ -573,8 +573,8 @@ class ValidatingEmbeddingProvider(FakeEmbeddingProvider):
         """
         if not text.startswith("# "):
             return None
-        # Look for language in parentheses within first 200 chars
-        match = re.search(r"\((\w+)\)\n", text[:200])
+        header = text.split("\n", 1)[0]
+        match = re.search(r"\((\w+)\)", header)
         return match.group(1).lower() if match else None
 
     async def embed(self, texts: list[str]) -> list[list[float]]:

--- a/tests/test_chunk_splitter.py
+++ b/tests/test_chunk_splitter.py
@@ -253,6 +253,33 @@ def test_makefile_split_contiguous_line_ranges() -> None:
         assert not part.content.startswith(target)
 
 
+def test_makefile_split_reserves_rule_target_embedding_context() -> None:
+    """Rule content leaves room for the target metadata added to embeddings."""
+    splitter = MakefileChunkSplitter()
+    target = "all:"
+    recipe_lines = ['\techo "building"' for _ in range(500)]
+    content = "\n".join([target] + recipe_lines)
+    chunk = _make_chunk(
+        content,
+        name="all",
+        start_line=1,
+        concept=UniversalConcept.DEFINITION,
+        metadata={"kind": "rule"},
+        language_node_type="rule",
+    )
+    rule_target_chars = sum(1 for char in f"[target: {target}]" if not char.isspace())
+
+    result = splitter.validate_and_split(chunk)
+
+    assert len(result) > 1
+    for part in result:
+        metrics = ChunkMetrics.from_content(part.content)
+        assert (
+            metrics.non_whitespace_chars + rule_target_chars
+            <= splitter.config.max_chunk_size
+        )
+
+
 def test_makefile_split_target_only_oversized_rule() -> None:
     """Oversized rule with no recipe lines falls back to _recursive_split."""
     splitter = MakefileChunkSplitter()

--- a/tests/test_e2e_chunk_size_constraints.py
+++ b/tests/test_e2e_chunk_size_constraints.py
@@ -509,6 +509,14 @@ async def validating_db(tmp_path):
     yield services, validating_provider, tmp_path
 
 
+def test_validating_provider_extracts_language_from_target_header():
+    provider = ValidatingEmbeddingProvider()
+    long_path = "/private/tmp/" + ("a" * 240) + "/large_makefile.mk"
+    text = f'# {long_path} (makefile) [target: all:]\n\techo "building"'
+
+    assert provider._extract_language_from_header(text) == "makefile"
+
+
 @pytest.mark.asyncio
 async def test_all_parsers_respect_chunk_size_constraints(validating_db):
     """Verify ALL parsers using cAST NEVER produce chunks exceeding size constraints.


### PR DESCRIPTION
Fixes #352

Summary:
- Reserve the Makefile rule-target metadata budget when splitting large rule recipes, so recipe chunks plus `[target: ...]` context stay within the embedding-size budget.
- Parse the language from the full embedding header line in the validating fake provider, including Makefile headers with target metadata.

Validation:
- Reproduced the issue before the fix with `LONG_TMP=/tmp/ch352_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa TMPDIR="$LONG_TMP" uv run pytest tests/test_e2e_chunk_size_constraints.py::test_all_parsers_respect_chunk_size_constraints -q`: failed with 5 Makefile chunks at 1352-1356 non-whitespace chars.
- After the fix, the same `LONG_TMP=... TMPDIR=... uv run pytest tests/test_e2e_chunk_size_constraints.py::test_all_parsers_respect_chunk_size_constraints -q` command passed.
- `uv run pytest tests/test_e2e_chunk_size_constraints.py::test_all_parsers_respect_chunk_size_constraints tests/test_e2e_chunk_size_constraints.py::test_validating_provider_extracts_language_from_target_header -q` passed.
- `uv run pytest tests/test_chunk_splitter.py -q` passed: 23 passed.
- `uv run pytest tests/test_smoke.py -v -n auto` passed: 18 passed.
- `npm ci --prefix site && npm run build --prefix site && uv run pytest tests/site -v` passed: 52 passed.
- `uv run ruff check chunkhound/parsers/makefile_parser.py` passed.
- `git diff --check` passed.
- `uv run pytest tests/ -v` reached 4055 passed, 109 skipped, 2 xfailed, with 3 local-environment failures: missing Codex vendor binary and OpenCode CLI insufficient balance.
- `uv run ruff check chunkhound` still reports 752 pre-existing lint issues outside this patch.
- `uv run mypy chunkhound` still reports 1083 pre-existing type errors in 93 files outside this patch.