### PR TITLE
docs: document chunkhound-native trusted publisher setup and fix stale TestPyPI references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,17 +94,23 @@ git push origin vX.Y.Za1
 # 4. Revert remote back to original
 git remote set-url origin "$ORIGINAL_REMOTE"
 
-# 5. Update uv.lock (only needed when chunkhound[native] extra is re-enabled)
+# 5. Update uv.lock — pyproject.toml only pins a floor version, so this must be
+#    bumped every release to pick up the version that was just published
 uv lock --upgrade-package chunkhound-native
 git add uv.lock
 git commit -m "chore: bump chunkhound-native in lockfile to vX.Y.Za1"
 ```
 
-PyPI trusted publisher required for `release-rc.yml`:
+PyPI trusted publisher required for `release-rc.yml` (on the `chunkhound` project):
 - Owner: `chunkhound`
 - Repository: `chunkhound`
 - Workflow: `release-rc.yml`
 - Environment: `pypi`
+
+This same tag push also publishes `chunkhound-native` via the `publish-rc-native` job, which needs
+its own trusted publisher registered on the **`chunkhound-native`** PyPI project (Workflow:
+`release-rc.yml`, Environment: `pypi-native`) — see `RELEASING.md` prerequisites for the full
+setup and the environment-scoping gotcha that causes a confusing `403` if it's misconfigured.
 
 ## DB_PATH_GOTCHAS
 - **Preferred: pass project directory as positional arg** — `chunkhound search "query" /path/to/project` — this reads `.chunkhound.json` and resolves the DB correctly

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,28 +8,44 @@ documented below.
 
 ### 1. OIDC Trusted Publishing — PyPI
 
-Configure Trusted Publisher on **PyPI** for the release workflow:
+Configure Trusted Publisher on **PyPI** for the **`chunkhound`** project, covering both the
+release and RC workflows (RC pre-releases publish to PyPI, not TestPyPI):
 
 - Project: `chunkhound`
 - Owner: `chunkhound`
 - Repository: `chunkhound`
-- Workflow: `release.yml`
-- Environment: `pypi`
+- Workflow: `release.yml`, Environment: `pypi`
+- Workflow: `release-rc.yml`, Environment: `pypi`
 
-Repeat for **TestPyPI** for the RC workflow:
+Separately, configure Trusted Publisher on **PyPI** for the **`chunkhound-native`** project — it
+is a distinct PyPI project published by the `publish-native`/`publish-rc-native` jobs in the same
+two workflows:
 
-- Workflow: `release-rc.yml`
-- Environment: `testpypi`
+- Project: `chunkhound-native`
+- Owner: `chunkhound`
+- Repository: `chunkhound`
+- Workflow: `release.yml`, Environment: `pypi-native`
+- Workflow: `release-rc.yml`, Environment: `pypi-native`
+
+**Each project's trusted publisher must only claim the environment name its own jobs actually
+declare.** An overly broad "any environment" entry on `chunkhound` will intercept the OIDC token
+exchange meant for `chunkhound-native` (or vice versa) — the upload then fails with a `403 Invalid
+API Token: OIDC scoped token is not valid for project '...'` error even though both projects look
+correctly configured in isolation. If you see that error, check whether the *other* project has an
+unscoped or wrongly-scoped entry stealing the match.
 
 ### 2. GitHub Environments
 
-Create three environments in **Settings → Environments**:
+Create four environments in **Settings → Environments**:
 
 | Environment | Purpose | Protection rules |
 |---|---|---|
-| `pypi` | Production PyPI publish | Required reviewers: maintainer team |
-| `testpypi` | TestPyPI RC publish | None required (tag push is the gate) |
+| `pypi` | Production + RC PyPI publish for `chunkhound` | Required reviewers: maintainer team |
+| `pypi-native` | Production + RC PyPI publish for `chunkhound-native` | Same trusted-publisher scoping as `pypi`, kept as a separate environment since it's a distinct PyPI project |
 | `maintainers` | Deprecation approvals | Required reviewers: maintainer team |
+
+There is no `testpypi` environment — RC releases publish pre-release versions to the real PyPI
+index (see `release-rc.yml`), not TestPyPI.
 
 ### 3. Tag Protection Rules
 
@@ -47,7 +63,7 @@ Add `PYPI_API_TOKEN` to the `maintainers` environment secrets. This token must h
 
 ## RC Release
 
-Use this to validate a build on TestPyPI before cutting the real release.
+Use this to validate a build on PyPI (as a pre-release) before cutting the real release.
 
 ```bash
 # Create and push a pre-release tag — this triggers the RC workflow automatically
@@ -55,19 +71,24 @@ uv run scripts/update_version.py 1.2.0rc1
 git push origin v1.2.0rc1
 ```
 
-The `release-rc.yml` workflow builds and publishes to TestPyPI via OIDC. No manual approval needed — the tag push itself is the human gate (only maintainers can push `v*` tags).
+The `release-rc.yml` workflow builds and publishes to the real PyPI index (not TestPyPI) via OIDC, tagged as a pre-release. No manual approval needed — the tag push itself is the human gate (only maintainers can push `v*` tags).
 
 **Validate the RC:**
 ```bash
-pip install --index-url https://test.pypi.org/simple/ chunkhound==1.2.0rc1
+pip install chunkhound==1.2.0rc1
 ```
 
-**Update the lockfile** (only needed when `chunkhound[native]` extra is re-enabled):
+**Update the lockfile** — `pyproject.toml` only pins a floor version
+(`chunkhound-native>=X.Y.Z`), so `uv.lock` must be bumped by hand every release to pick up the
+version that was just published:
 ```bash
 uv lock --upgrade-package chunkhound-native
 git add uv.lock
 git commit -m "chore: bump chunkhound-native in lockfile to v1.2.0rc1"
 ```
+If this fails with "no matching version found," the native wheels haven't finished publishing yet
+(or PyPI's index hasn't propagated) — retry in a minute, or force a fresh index fetch with
+`uv lock --upgrade-package chunkhound-native --refresh-package chunkhound-native`.
 
 ---
 
@@ -92,6 +113,20 @@ git commit -m "chore: bump chunkhound-native in lockfile to v1.2.0rc1"
    Publishing triggers `release.yml`, which builds and publishes to PyPI via OIDC. The `pypi` environment requires maintainer approval before the publish step runs.
 
 4. **If the build or publish fails** — the cleanup step runs only if the main `chunkhound` publish fails; it deletes the GitHub Release and its tag so you can retry from step 1. If `publish-native` fails after the main package is already live, the GitHub Release remains published and cleanup does not run. In that case re-trigger `publish-native` manually via Actions (it is idempotent), or upload the native wheel directly with a PyPI token scoped to `chunkhound-native`.
+
+   **If `build-native-wheel` itself fails** (before `publish`/`publish-native` even start), cleanup
+   does *not* run either — it's gated on the `publish` job failing, and `publish` never starts if a
+   `needs` dependency failed. You'll be left with a published GitHub Release and tag pointing at a
+   broken build, with nothing actually shipped to PyPI. Recover by: fixing the issue, deleting the
+   release and tag (`gh release delete vX.Y.Z --cleanup-tag --yes`), then retrying from step 1 with
+   a new tag on the fixed commit. Common `build-native-wheel` failure modes (all fixed as of v5.2.0,
+   documented inline in `release.yml`/`release-rc.yml`'s `Build native wheel`/`Smoke test native
+   wheel` steps): `setup-uv@v3` dropping the `python-version` input, `maturin build` having no
+   `--set-version` flag (Cargo.toml's version must be patched directly), Cargo requiring strict
+   SemVer while git tags use PEP 440 (needs a hyphen before any pre-release suffix), maturin
+   misreading the repo's own `pyproject.toml` as authoritative package metadata, and the repo's
+   `chunkhound_native/__init__.py` dev-workflow stub shadowing the installed wheel during the smoke
+   test.
 
 ---
 


### PR DESCRIPTION
[…](docs: document chunkhound-native trusted publisher setup and fix stale TestPyPI references)