### PR TITLE
feat(config): make DB execute timeout configurable via JSON/env/CLI

### DIFF
--- a/chunkhound/core/config/database_config.py
+++ b/chunkhound/core/config/database_config.py
@@ -77,6 +77,22 @@ class DatabaseConfig(BaseModel):
         "Does not disable the fixed compaction boundaries in chunkhound index.",
     )
 
+    # Serial executor operation timeout (execute_sync waits only)
+    execute_timeout_seconds: float | None = Field(
+        default=None,
+        gt=0.0,
+        description=(
+            "Timeout for synchronous serial DB executor waits (seconds). "
+            "Applies to execute_sync / _execute_in_db_thread_sync only; "
+            "async dispatch (execute_async) remains unbounded. "
+            "None = built-in defaults (30s normal, 660s compaction). "
+            "When set, replaces both defaults for every sync operation "
+            "including compaction. "
+            "Env: CHUNKHOUND_DATABASE__EXECUTE_TIMEOUT_SECONDS or legacy "
+            "CHUNKHOUND_DB_EXECUTE_TIMEOUT. CLI: --db-execute-timeout."
+        ),
+    )
+
     @field_validator("path")
     def validate_path(cls, v: Path | None) -> Path | None:
         """Convert string paths to Path objects."""
@@ -177,6 +193,17 @@ class DatabaseConfig(BaseModel):
                  "(default: 30%%)",
         )
 
+        parser.add_argument(
+            "--db-execute-timeout",
+            type=float,
+            help=(
+                "Timeout for synchronous serial DB executor waits in seconds. "
+                "When unset: 30s normal, 660s compaction. When set: applies "
+                "to every sync operation including compaction (replaces both "
+                "defaults). Does not apply to async executor dispatch."
+            ),
+        )
+
     @classmethod
     def load_from_env(cls) -> dict[str, Any]:
         """Load database config from environment variables."""
@@ -209,6 +236,16 @@ class DatabaseConfig(BaseModel):
                 config["fragmentation_threshold_pct"] = float(threshold_pct)
             except ValueError:
                 pass
+
+        # Executor timeout: canonical name first, then legacy flat alias
+        if execute_timeout := (
+            os.getenv("CHUNKHOUND_DATABASE__EXECUTE_TIMEOUT_SECONDS")
+            or os.getenv("CHUNKHOUND_DB_EXECUTE_TIMEOUT")
+        ):
+            try:
+                config["execute_timeout_seconds"] = float(execute_timeout)
+            except ValueError:
+                pass
         return config
 
     @classmethod
@@ -227,6 +264,11 @@ class DatabaseConfig(BaseModel):
             overrides["read_only"] = True
         if hasattr(args, "fragmentation_threshold_pct") and args.fragmentation_threshold_pct is not None:
             overrides["fragmentation_threshold_pct"] = float(args.fragmentation_threshold_pct)
+        if (
+            hasattr(args, "db_execute_timeout")
+            and args.db_execute_timeout is not None
+        ):
+            overrides["execute_timeout_seconds"] = float(args.db_execute_timeout)
         return overrides
 
     def __repr__(self) -> str:
@@ -236,4 +278,6 @@ class DatabaseConfig(BaseModel):
             parts.append(f"max_disk_usage_mb={self.max_disk_usage_mb}")
         if self.fragmentation_threshold_pct is not None:
             parts.append(f"fragmentation_threshold_pct={self.fragmentation_threshold_pct}")
+        if self.execute_timeout_seconds is not None:
+            parts.append(f"execute_timeout_seconds={self.execute_timeout_seconds}")
         return f"DatabaseConfig({', '.join(parts)})"

--- a/chunkhound/providers/database/serial_database_provider.py
+++ b/chunkhound/providers/database/serial_database_provider.py
@@ -54,8 +54,15 @@ class SerialDatabaseProvider(ABC):
         self.config = config
         self._db_path = db_path
 
-        # Create serial executor for all database operations
-        self._executor = SerialDatabaseExecutor()
+        # Create serial executor for all database operations.
+        # Timeout comes from DatabaseConfig (JSON/env/CLI); None keeps the
+        # built-in per-operation defaults (30s normal, 660s compaction).
+        execute_timeout = (
+            config.execute_timeout_seconds if config is not None else None
+        )
+        self._executor = SerialDatabaseExecutor(
+            execute_timeout_seconds=execute_timeout
+        )
 
         # Service layer components
         self._indexing_coordinator: IndexingCoordinator | None = None

--- a/chunkhound/providers/database/serial_executor.py
+++ b/chunkhound/providers/database/serial_executor.py
@@ -6,7 +6,6 @@ Requires single-threaded execution for database operations.
 import asyncio
 import concurrent.futures
 import contextvars
-import os
 import random
 import threading
 import time
@@ -114,8 +113,16 @@ class SerialDatabaseExecutor:
     concurrent access from multiple threads.
     """
 
-    def __init__(self) -> None:
-        """Initialize serial executor with single-threaded pool."""
+    def __init__(self, execute_timeout_seconds: float | None = None) -> None:
+        """Initialize serial executor with single-threaded pool.
+
+        Args:
+            execute_timeout_seconds: Optional timeout for sync
+                ``execute_sync`` waits only (async dispatch is unbounded).
+                When None, uses built-in defaults (30s normal, 660s
+                compaction). When set, applies to every sync operation
+                including compaction.
+        """
         # Create single-threaded executor for all database operations
         # This ensures complete serialization and prevents concurrent access issues
         self._db_executor = ThreadPoolExecutor(
@@ -125,6 +132,21 @@ class SerialDatabaseExecutor:
         # Shared visibility for callers outside the executor thread so they
         # fail fast instead of queueing behind a long compaction.
         self._compaction_in_progress = threading.Event()
+        self._execute_timeout_seconds = execute_timeout_seconds
+
+    def resolve_timeout(self, operation_name: str) -> float:
+        """Resolve the wait timeout for a named ``execute_sync`` operation.
+
+        Used only by ``execute_sync`` (async dispatch has no timeout).
+        When ``execute_timeout_seconds`` is configured, that value is used for
+        every sync operation (including compaction). Otherwise compaction ops
+        get the extended default and all other ops get 30s.
+        """
+        if self._execute_timeout_seconds is not None:
+            return self._execute_timeout_seconds
+        if operation_name.startswith("compact"):
+            return _COMPACTION_OPERATION_TIMEOUT_SECONDS
+        return 30.0
 
     def set_compaction_in_progress(self, active: bool) -> None:
         """Publish compaction state to callers before they enqueue work."""
@@ -189,19 +211,9 @@ class SerialDatabaseExecutor:
             op_func = getattr(provider, f"_executor_{operation_name}")
             return op_func(conn, state, *args, **kwargs)
 
-        # Run in executor synchronously with timeout (env override)
+        # Run in executor synchronously with configured timeout
         future = self._db_executor.submit(executor_operation)
-        default_timeout = (
-            _COMPACTION_OPERATION_TIMEOUT_SECONDS
-            if operation_name.startswith("compact")
-            else 30.0
-        )
-        try:
-            timeout_s = float(
-                os.getenv("CHUNKHOUND_DB_EXECUTE_TIMEOUT", str(default_timeout))
-            )
-        except Exception:
-            timeout_s = default_timeout
+        timeout_s = self.resolve_timeout(operation_name)
         try:
             result = future.result(timeout=timeout_s)
         except concurrent.futures.TimeoutError:

--- a/site/src/pages/docs/configuration.md
+++ b/site/src/pages/docs/configuration.md
@@ -199,6 +199,7 @@ Fast analytical queries and efficient storage.
 |---|---|---|---|
 | `max_disk_usage_mb` | `number` | `null` | Max DB size in MB before indexing stops (CLI flag uses GB) |
 | `fragmentation_threshold_pct` | `number` | `30` | Background/auto-compaction trigger: file-size overhead above the provider's estimated live DB size (%). 30 = compact when the DB is ~30% larger than live data. 0 = always, null = never. This does not disable the fixed `chunkhound index` compaction boundaries. CLI: `--fragmentation-threshold-pct`. |
+| `execute_timeout_seconds` | `number` | `null` | Timeout for **synchronous** serial DB executor waits (`execute_sync` / `_execute_in_db_thread_sync`) in seconds. `null` = built-in defaults (30s normal ops, 660s compaction). When set, replaces both defaults for every sync operation including compaction, HNSW rebuild, and queries. Does **not** apply to async dispatch (`execute_async`), which remains unbounded. CLI: `--db-execute-timeout`. Env: `CHUNKHOUND_DATABASE__EXECUTE_TIMEOUT_SECONDS` (or legacy `CHUNKHOUND_DB_EXECUTE_TIMEOUT`). |
 | `lancedb_index_type` | `string` | `null` | LanceDB vector index type: `auto`, `ivf_hnsw_sq`, or `ivf_rq` |
 | `lancedb_optimize_fragment_threshold` | `number` | `100` | Fragment count to trigger LanceDB compaction |
 
@@ -397,6 +398,11 @@ Most environment variables use the `CHUNKHOUND_` prefix with `__` (double unders
 | `CHUNKHOUND_DATABASE__PROVIDER` | Database backend (`duckdb` or `lancedb`) |
 | `CHUNKHOUND_DATABASE__PATH` | Database storage path |
 | `CHUNKHOUND_DATABASE__MAX_DISK_USAGE_GB` | Max database size in GB |
+| `CHUNKHOUND_DATABASE__EXECUTE_TIMEOUT_SECONDS` | Sync serial DB executor timeout in seconds (overrides 30s/660s defaults when set; async dispatch unbounded) |
+| `CHUNKHOUND_DATABASE__FRAGMENTATION_THRESHOLD_PCT` | Auto-compaction fragmentation threshold (%) |
+| `CHUNKHOUND_DATABASE__READ_ONLY` | Open DB read-only (`true`/`1`/`yes`) |
+| `CHUNKHOUND_DATABASE__LANCEDB_INDEX_TYPE` | LanceDB vector index type |
+| `CHUNKHOUND_DATABASE__LANCEDB_OPTIMIZE_FRAGMENT_THRESHOLD` | LanceDB fragment count to trigger optimize |
 | `CHUNKHOUND_LLM_PROVIDER` | LLM provider for research |
 | `CHUNKHOUND_LLM_MODEL` | LLM model shorthand that sets both utility and synthesis roles |
 | `CHUNKHOUND_LLM_UTILITY_MODEL` | LLM model for utility tasks (fast, lower cost) |
@@ -453,7 +459,7 @@ Most environment variables use the `CHUNKHOUND_` prefix with `__` (double unders
 | `CHUNKHOUND_INDEXING__WORKSPACE_GITIGNORE_OVERLAY` | Apply CH root .gitignore as global overlay across repos (default: false) |
 | `CHUNKHOUND_INDEXING__WORKSPACE_GITIGNORE_NONREPO` | Use CH root .gitignore only for non-repo paths (default: true) |
 | `CHUNKHOUND_INDEXING__REALTIME_BACKEND` | Filesystem monitoring backend: `watchman`, `watchdog`, or `polling` |
-| `CHUNKHOUND_DB_EXECUTE_TIMEOUT` | Database executor timeout |
+| `CHUNKHOUND_DB_EXECUTE_TIMEOUT` | Legacy alias for `CHUNKHOUND_DATABASE__EXECUTE_TIMEOUT_SECONDS` |
 | `CHUNKHOUND_YAML_ENGINE` | YAML parser engine (`rapid` or `tree`) |
 | `CHUNKHOUND_CONFIG_FILE` | Path to config file (alternative to `--config`) |
 | `CHUNKHOUND_WEBSEARCH_TIMEOUT_SECONDS` | Web search subprocess timeout in seconds (default: 600) |

--- a/tests/unit/test_db_execute_timeout_config.py
+++ b/tests/unit/test_db_execute_timeout_config.py
@@ -1,0 +1,282 @@
+"""Contract tests for database execute timeout configuration."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from chunkhound.core.config.config import Config
+from chunkhound.core.config.database_config import DatabaseConfig
+from chunkhound.providers.database.serial_executor import (
+    _COMPACTION_OPERATION_TIMEOUT_SECONDS,
+    SerialDatabaseExecutor,
+)
+
+
+class TestDatabaseConfigExecuteTimeout:
+    """DatabaseConfig field, env, and CLI contracts for execute_timeout_seconds."""
+
+    def test_default_is_none(self) -> None:
+        config = DatabaseConfig()
+        assert config.execute_timeout_seconds is None
+
+    def test_custom_value(self) -> None:
+        config = DatabaseConfig(execute_timeout_seconds=120.0)
+        assert config.execute_timeout_seconds == 120.0
+
+    def test_rejects_non_positive(self) -> None:
+        with pytest.raises(ValueError):
+            DatabaseConfig(execute_timeout_seconds=0)
+        with pytest.raises(ValueError):
+            DatabaseConfig(execute_timeout_seconds=-1.0)
+
+    def test_load_from_env_canonical(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CHUNKHOUND_DATABASE__EXECUTE_TIMEOUT_SECONDS", "90.5")
+        monkeypatch.delenv("CHUNKHOUND_DB_EXECUTE_TIMEOUT", raising=False)
+
+        config = DatabaseConfig.load_from_env()
+        assert config["execute_timeout_seconds"] == 90.5
+
+    def test_load_from_env_legacy_alias(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(
+            "CHUNKHOUND_DATABASE__EXECUTE_TIMEOUT_SECONDS", raising=False
+        )
+        monkeypatch.setenv("CHUNKHOUND_DB_EXECUTE_TIMEOUT", "45")
+
+        config = DatabaseConfig.load_from_env()
+        assert config["execute_timeout_seconds"] == 45.0
+
+    def test_load_from_env_canonical_wins_over_legacy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CHUNKHOUND_DATABASE__EXECUTE_TIMEOUT_SECONDS", "100")
+        monkeypatch.setenv("CHUNKHOUND_DB_EXECUTE_TIMEOUT", "50")
+
+        config = DatabaseConfig.load_from_env()
+        assert config["execute_timeout_seconds"] == 100.0
+
+    def test_load_from_env_invalid_ignored(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(
+            "CHUNKHOUND_DATABASE__EXECUTE_TIMEOUT_SECONDS", "not-a-number"
+        )
+
+        config = DatabaseConfig.load_from_env()
+        assert "execute_timeout_seconds" not in config
+
+    def test_extract_cli_overrides(self) -> None:
+        args = SimpleNamespace(
+            db=None,
+            database_path=None,
+            database_provider=None,
+            max_disk_usage_gb=None,
+            read_only=False,
+            fragmentation_threshold_pct=None,
+            db_execute_timeout=180.0,
+        )
+
+        overrides = DatabaseConfig.extract_cli_overrides(args)
+        assert overrides == {"execute_timeout_seconds": 180.0}
+
+    def test_repr_includes_timeout(self) -> None:
+        config = DatabaseConfig(execute_timeout_seconds=60.0)
+        assert "execute_timeout_seconds=60.0" in repr(config)
+
+
+class TestConfigFileExecuteTimeout:
+    """Config precedence for database.execute_timeout_seconds."""
+
+    def test_json_config_file_sets_timeout(self, tmp_path) -> None:
+        config_path = tmp_path / ".chunkhound.json"
+        config_path.write_text(
+            json.dumps({"database": {"execute_timeout_seconds": 120}}),
+            encoding="utf-8",
+        )
+
+        config = Config(target_dir=tmp_path)
+        assert config.database.execute_timeout_seconds == 120.0
+
+    def test_config_from_env_only_canonical(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch, clean_environment
+    ) -> None:
+        """Env-only deployments (e.g. MCP) must surface the canonical var."""
+        monkeypatch.setenv("CHUNKHOUND_DATABASE__EXECUTE_TIMEOUT_SECONDS", "75")
+        # Empty project dir: no local JSON, no global discovery interference
+        config = Config(target_dir=tmp_path)
+        assert config.database.execute_timeout_seconds == 75.0
+
+    def test_config_from_env_only_legacy(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch, clean_environment
+    ) -> None:
+        """Legacy CHUNKHOUND_DB_EXECUTE_TIMEOUT still reaches Config."""
+        monkeypatch.setenv("CHUNKHOUND_DB_EXECUTE_TIMEOUT", "88")
+        config = Config(target_dir=tmp_path)
+        assert config.database.execute_timeout_seconds == 88.0
+
+    def test_local_json_overrides_env(
+        self, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CHUNKHOUND_DB_EXECUTE_TIMEOUT", "30")
+        config_path = tmp_path / ".chunkhound.json"
+        config_path.write_text(
+            json.dumps({"database": {"execute_timeout_seconds": 200}}),
+            encoding="utf-8",
+        )
+
+        config = Config(target_dir=tmp_path)
+        assert config.database.execute_timeout_seconds == 200.0
+
+    def test_cli_overrides_local_json(self, tmp_path) -> None:
+        config_path = tmp_path / ".chunkhound.json"
+        config_path.write_text(
+            json.dumps({"database": {"execute_timeout_seconds": 50}}),
+            encoding="utf-8",
+        )
+        args = SimpleNamespace(
+            command=None,
+            config=None,
+            path=None,
+            debug=False,
+            verbose=False,
+            db=None,
+            database_path=None,
+            database_provider=None,
+            max_disk_usage_gb=None,
+            read_only=False,
+            fragmentation_threshold_pct=None,
+            db_execute_timeout=300.0,
+        )
+
+        config = Config(args, target_dir=tmp_path)
+        assert config.database.execute_timeout_seconds == 300.0
+
+
+class TestSerialExecutorTimeoutResolution:
+    """SerialDatabaseExecutor timeout resolution contract."""
+
+    def test_defaults_when_unset(self) -> None:
+        executor = SerialDatabaseExecutor()
+        assert executor.resolve_timeout("search_semantic") == 30.0
+        assert (
+            executor.resolve_timeout("compact_database")
+            == _COMPACTION_OPERATION_TIMEOUT_SECONDS
+        )
+        assert (
+            executor.resolve_timeout("compact_if_needed")
+            == _COMPACTION_OPERATION_TIMEOUT_SECONDS
+        )
+
+    def test_explicit_timeout_applies_to_all_ops(self) -> None:
+        executor = SerialDatabaseExecutor(execute_timeout_seconds=120.0)
+        assert executor.resolve_timeout("search_semantic") == 120.0
+        assert executor.resolve_timeout("compact_database") == 120.0
+        assert executor.resolve_timeout("ensure_all_hnsw_indexes") == 120.0
+
+    def test_hnsw_rebuild_uses_normal_default(self) -> None:
+        executor = SerialDatabaseExecutor()
+        assert executor.resolve_timeout("ensure_all_hnsw_indexes") == 30.0
+        assert executor.resolve_timeout("drop_all_hnsw_indexes") == 30.0
+
+    def test_execute_sync_passes_timeout_to_future_result(self) -> None:
+        """User-visible timeout must reach future.result(timeout=...)."""
+        executor = SerialDatabaseExecutor(execute_timeout_seconds=42.0)
+
+        provider = MagicMock()
+        provider.get_base_directory.return_value = None
+        # Bypass connection/thread-local path; only assert timeout wiring
+        captured: list[float] = []
+
+        mock_future = MagicMock()
+        mock_future.result.side_effect = lambda timeout=None: (
+            captured.append(timeout),
+            "ok",
+        )[1]
+
+        # Skip real executor work and auto-compaction side effects
+        executor._db_executor = MagicMock()
+        executor._db_executor.submit.return_value = mock_future
+        executor._maybe_run_sampled_auto_compaction = MagicMock()  # type: ignore[method-assign]
+
+        # Provide a no-op executor method so getattr succeeds if called
+        provider._executor_search_semantic = MagicMock(return_value="ok")
+
+        result = executor.execute_sync(provider, "search_semantic")
+
+        assert result == "ok"
+        assert captured == [42.0]
+        mock_future.result.assert_called_once_with(timeout=42.0)
+
+    def test_execute_sync_default_compact_timeout_to_future_result(
+        self,
+    ) -> None:
+        executor = SerialDatabaseExecutor()
+
+        provider = MagicMock()
+        provider.get_base_directory.return_value = None
+        mock_future = MagicMock()
+        mock_future.result.return_value = True
+
+        executor._db_executor = MagicMock()
+        executor._db_executor.submit.return_value = mock_future
+        executor._maybe_run_sampled_auto_compaction = MagicMock()  # type: ignore[method-assign]
+        provider._executor_compact_database = MagicMock(return_value=True)
+
+        executor.execute_sync(provider, "compact_database")
+
+        mock_future.result.assert_called_once_with(
+            timeout=_COMPACTION_OPERATION_TIMEOUT_SECONDS
+        )
+
+
+class TestProviderWiresExecutorTimeout:
+    """SerialDatabaseProvider passes config timeout into the executor."""
+
+    def test_provider_passes_timeout_from_config(self, tmp_path) -> None:
+        from chunkhound.providers.database.serial_database_provider import (
+            SerialDatabaseProvider,
+        )
+
+        class _StubProvider(SerialDatabaseProvider):
+            def _create_connection(self):
+                return object()
+
+            def _get_schema_sql(self):
+                return None
+
+        cfg = DatabaseConfig(
+            path=tmp_path / "db",
+            execute_timeout_seconds=99.0,
+        )
+        provider = _StubProvider(
+            db_path=tmp_path / "db" / "chunks.db",
+            base_directory=tmp_path,
+            config=cfg,
+        )
+        assert provider._executor.resolve_timeout("any_op") == 99.0
+
+    def test_provider_without_config_uses_defaults(self, tmp_path) -> None:
+        from chunkhound.providers.database.serial_database_provider import (
+            SerialDatabaseProvider,
+        )
+
+        class _StubProvider(SerialDatabaseProvider):
+            def _create_connection(self):
+                return object()
+
+            def _get_schema_sql(self):
+                return None
+
+        provider = _StubProvider(
+            db_path=tmp_path / "db" / "chunks.db",
+            base_directory=tmp_path,
+            config=None,
+        )
+        assert provider._executor.resolve_timeout("search") == 30.0
+        assert (
+            provider._executor.resolve_timeout("compact_database")
+            == _COMPACTION_OPERATION_TIMEOUT_SECONDS
+        )


### PR DESCRIPTION
## Summary

- Make the serial DB executor timeout configurable from `.chunkhound.json`, env, and CLI — not only the legacy runtime env var `CHUNKHOUND_DB_EXECUTE_TIMEOUT`.
- Add `database.execute_timeout_seconds` to `DatabaseConfig`, wire it through `SerialDatabaseProvider` → `SerialDatabaseExecutor`, and document the option.
- Keep backward-compatible defaults and the legacy env alias.

## Motivation

Operators (especially on large indexes) need a longer wait for slow sync ops such as HNSW rebuild or heavy queries. Today the only control is a flat process env read inside `execute_sync`, which cannot live in project config and bypasses the normal ChunkHound config system.

## Changes

| Area | Change |
|------|--------|
| `DatabaseConfig` | New field `execute_timeout_seconds: float \| None` (`gt=0`) |
| Env | `CHUNKHOUND_DATABASE__EXECUTE_TIMEOUT_SECONDS` (canonical) + `CHUNKHOUND_DB_EXECUTE_TIMEOUT` (legacy) |
| CLI | `--db-execute-timeout` |
| Executor | Timeout set at construction; `resolve_timeout()`; no per-call `os.getenv` |
| Docs | Database options + env tables updated |
| Tests | Contract suite for field/env/CLI/precedence/wiring/`future.result(timeout=…)` |

### Example

```json
{
  "database": {
    "execute_timeout_seconds": 120
  }
}
```
export CHUNKHOUND_DATABASE__EXECUTE_TIMEOUT_SECONDS=120
### legacy still works:
export CHUNKHOUND_DB_EXECUTE_TIMEOUT=120

chunkhound index --db-execute-timeout 120

## Major design decisions

1. None default (not 30.0)

 When unset, behavior matches today:

• Normal ops → 30s
• Ops whose name starts with compact → 660s

 If the field defaulted to 30.0, compaction would silently lose its extended allowance. None means “use built-in dual defaults.”

2. Explicit value flattens both defaults

 Same as the old env var: once set, one timeout applies to every sync operation (including compaction and HNSW rebuild). That preserves existing env semantics and avoids inventing a second knob.

 Trade-off: setting e.g. 60 to help a slow query also caps compaction at 60s. Docs and CLI help call this out.

3. Config system over per-call os.getenv

 Timeout is resolved at provider construction via DatabaseConfig, then held on the executor. Benefits:

• Normal precedence: CLI > config file > local JSON > global > env > defaults
• JSON can override env (matches the rest of ChunkHound)
• No second, ad-hoc env path that ignores .chunkhound.json

 Legacy CHUNKHOUND_DB_EXECUTE_TIMEOUT is loaded in load_from_env (canonical name preferred when both are set), not   read on every execute_sync.

4. Sync-only (no execute_async timeout)

 execute_async was already unbounded; this PR does not change that. Docs, Field description, and CLI help state clearly that the setting applies only to execute_sync / _execute_in_db_thread_sync. Bounding async would be a separate behavior change.

5. HNSW rebuild is not special-cased

 Standalone ensure_all_hnsw_indexes / drop_all_hnsw_indexes keep the 30s default when unset (name does not start with compact). Raising execute_timeout_seconds is the supported way to give large rebuilds more time. Compaction-internal HNSW work still rides under the outer compact_* 660s budget when unset.

6. Naming and surfaces

• Field: execute_timeout_seconds (aligned with per_file_timeout_seconds, etc.)
• Env: CHUNKHOUND_DATABASE__EXECUTE_TIMEOUT_SECONDS plus legacy flat alias
• CLI: --db-execute-timeout (parity with other database flags)

## Out of scope

• Timeout on execute_async
• Separate compaction-only timeout config
• Changing the 30s / 660s built-in defaults