### PR TITLE
feat(embedding): add 'voyage' rerank format for native VoyageAI endpoints

### DIFF
--- a/chunkhound/core/config/embedding_config.py
+++ b/chunkhound/core/config/embedding_config.py
@@ -26,7 +26,7 @@ from ._utils import _parse_env_bool
 
 # Error message constants for consistent messaging across config and provider
 RERANK_MODEL_REQUIRED_COHERE = (
-    "rerank_model is required when using rerank_format='cohere'. "
+    "rerank_model is required when using rerank_format='cohere' or 'voyage'. "
     "Either provide rerank_model or use rerank_format='tei'."
 )
 RERANK_BASE_URL_REQUIRED = (
@@ -70,7 +70,7 @@ def validate_rerank_configuration(
 
     Args:
         provider: Embedding provider name
-        rerank_format: Reranking API format ('cohere', 'tei', or 'auto')
+        rerank_format: Reranking API format ('cohere', 'tei', 'voyage', or 'auto')
         rerank_model: Model name for reranking (optional for TEI)
         rerank_url: Rerank endpoint URL
         base_url: Base URL for API (required for relative rerank_url)
@@ -82,8 +82,8 @@ def validate_rerank_configuration(
     if provider == "voyageai" and not rerank_url:
         return
 
-    # For Cohere format, rerank_model is required
-    if rerank_format == "cohere" and not rerank_model:
+    # Cohere and Voyage-native formats both require an explicit rerank_model
+    if rerank_format in ("cohere", "voyage") and not rerank_model:
         raise ValueError(RERANK_MODEL_REQUIRED_COHERE)
 
     # If using reranking (model set or TEI format with URL), validate URL config
@@ -184,12 +184,14 @@ class EmbeddingConfig(BaseSettings):
         ),
     )
 
-    rerank_format: Literal["cohere", "tei", "auto"] = Field(
+    rerank_format: Literal["cohere", "tei", "voyage", "auto"] = Field(
         default="auto",
         description=(
             "Reranking API format. 'cohere' for Cohere-compatible "
             "APIs (requires model in request), 'tei' for Hugging "
-            "Face TEI (model set at deployment), 'auto' for "
+            "Face TEI (model set at deployment), 'voyage' for native "
+            "VoyageAI-compatible endpoints such as MongoDB Atlas "
+            "(uses 'top_k' and returns a 'data' array), 'auto' for "
             "automatic format detection from response."
         ),
     )

--- a/chunkhound/core/config/embedding_config.py
+++ b/chunkhound/core/config/embedding_config.py
@@ -25,7 +25,7 @@ from chunkhound.core.utils.voyageai_utils import is_official_voyageai_endpoint
 from ._utils import _parse_env_bool
 
 # Error message constants for consistent messaging across config and provider
-RERANK_MODEL_REQUIRED_COHERE = (
+RERANK_MODEL_REQUIRED = (
     "rerank_model is required when using rerank_format='cohere' or 'voyage'. "
     "Either provide rerank_model or use rerank_format='tei'."
 )
@@ -84,7 +84,7 @@ def validate_rerank_configuration(
 
     # Cohere and Voyage-native formats both require an explicit rerank_model
     if rerank_format in ("cohere", "voyage") and not rerank_model:
-        raise ValueError(RERANK_MODEL_REQUIRED_COHERE)
+        raise ValueError(RERANK_MODEL_REQUIRED)
 
     # If using reranking (model set or TEI format with URL), validate URL config
     is_using_reranking = rerank_model or (rerank_format == "tei" and rerank_url)

--- a/chunkhound/providers/embeddings/voyageai_provider.py
+++ b/chunkhound/providers/embeddings/voyageai_provider.py
@@ -254,6 +254,9 @@ class VoyageAIEmbeddingProvider:
             rerank_format: Reranking API format when using rerank_url.
                 'cohere' for Cohere-compatible APIs (requires rerank_model),
                 'tei' for HuggingFace TEI (model set at deployment),
+                'voyage' for native VoyageAI-compatible endpoints such as
+                MongoDB Atlas (uses 'top_k' request param and a 'data'
+                response; requires rerank_model),
                 'auto' to detect from response (default).
             max_concurrent_batches: Maximum number of concurrent embed() calls.
                 Defaults to 1 for custom endpoints (e.g. Azure ML) to avoid
@@ -1064,12 +1067,22 @@ class VoyageAIEmbeddingProvider:
     def _build_rerank_payload(
         self, query: str, documents: list[str], top_k: int | None
     ) -> dict:
-        """Build rerank request payload for TEI or Cohere format."""
+        """Build rerank request payload for TEI, Cohere, or Voyage-native format."""
         fmt = self._rerank_format
         if fmt == "tei":
             return {"query": query, "texts": documents}
-        elif fmt == "cohere":
+        elif fmt == "voyage":
+            # Native VoyageAI-compatible endpoints (e.g. MongoDB Atlas
+            # ai.mongodb.com) expect "top_k" — they reject Cohere's "top_n" —
+            # and return the ranking under "data" (see _parse_rerank_response).
             payload: dict = {"query": query, "documents": documents}
+            if self._rerank_model:
+                payload["model"] = self._rerank_model
+            if top_k is not None:
+                payload["top_k"] = top_k
+            return payload
+        elif fmt == "cohere":
+            payload = {"query": query, "documents": documents}
             if self._rerank_model:
                 payload["model"] = self._rerank_model
             if top_k is not None:
@@ -1090,7 +1103,12 @@ class VoyageAIEmbeddingProvider:
     def _parse_rerank_response(
         self, data: dict, num_documents: int
     ) -> list[RerankResult]:
-        """Parse reranker HTTP response (Cohere or TEI format) into RerankResult list."""
+        """Parse a reranker HTTP response into RerankResult items."""
+        # Native VoyageAI-compatible endpoints (e.g. MongoDB Atlas) return the
+        # ranking under "data" rather than Cohere/TEI's "results"; the item shape
+        # (index + relevance_score/score) is identical, so treat it as an alias.
+        if "results" not in data and "data" in data:
+            data = {"results": data["data"]}
         if "results" not in data:
             raise ValueError(
                 f"Invalid rerank response: missing 'results' field. Got: {list(data.keys())}"

--- a/chunkhound/providers/embeddings/voyageai_provider.py
+++ b/chunkhound/providers/embeddings/voyageai_provider.py
@@ -59,6 +59,15 @@ class VoyageModelConfig(TypedDict):
     default_dimension: int
 
 
+# Request param that carries the result limit, keyed by rerank format. Native
+# VoyageAI-compatible endpoints (e.g. MongoDB Atlas ai.mongodb.com) expect
+# "top_k" and reject Cohere's "top_n"; they also return the ranking under
+# "data" rather than "results" (see _parse_rerank_response). Formats absent
+# from this map are not Cohere-style: TEI sends no limit at all, and "auto"
+# probes Cohere-style only when a rerank_model is configured.
+_RERANK_LIMIT_PARAM = {"voyage": "top_k", "cohere": "top_n"}
+
+
 # Official VoyageAI model configuration based on API documentation
 VOYAGE_MODEL_CONFIG: dict[str, VoyageModelConfig] = {
     # Models with 120,000 token limit per batch
@@ -1069,36 +1078,21 @@ class VoyageAIEmbeddingProvider:
     ) -> dict:
         """Build rerank request payload for TEI, Cohere, or Voyage-native format."""
         fmt = self._rerank_format
-        if fmt == "tei":
+        limit_param = _RERANK_LIMIT_PARAM.get(fmt)
+
+        # TEI carries no model and names the document list "texts". Auto mode
+        # with no rerank_model has no model to send either, so it starts as TEI.
+        if fmt == "tei" or (limit_param is None and not self._rerank_model):
             return {"query": query, "texts": documents}
-        elif fmt == "voyage":
-            # Native VoyageAI-compatible endpoints (e.g. MongoDB Atlas
-            # ai.mongodb.com) expect "top_k" — they reject Cohere's "top_n" —
-            # and return the ranking under "data" (see _parse_rerank_response).
-            payload: dict = {"query": query, "documents": documents}
-            if self._rerank_model:
-                payload["model"] = self._rerank_model
-            if top_k is not None:
-                payload["top_k"] = top_k
-            return payload
-        elif fmt == "cohere":
-            payload = {"query": query, "documents": documents}
-            if self._rerank_model:
-                payload["model"] = self._rerank_model
-            if top_k is not None:
-                payload["top_n"] = top_k
-            return payload
-        else:  # auto: try Cohere if model provided, else TEI
-            if self._rerank_model:
-                payload = {
-                    "query": query,
-                    "documents": documents,
-                    "model": self._rerank_model,
-                }
-                if top_k is not None:
-                    payload["top_n"] = top_k
-                return payload
-            return {"query": query, "texts": documents}
+
+        # Cohere-style body, shared by 'cohere', 'voyage' and auto-with-model.
+        payload: dict[str, Any] = {"query": query, "documents": documents}
+        if self._rerank_model:
+            payload["model"] = self._rerank_model
+        if top_k is not None:
+            # 'auto' is absent from the map but probes Cohere-style first.
+            payload[limit_param or "top_n"] = top_k
+        return payload
 
     def _parse_rerank_response(
         self, data: dict, num_documents: int

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -470,6 +470,53 @@ def test_tei_format_validation_without_model() -> None:
     assert config.rerank_format == "tei"
 
 
+def test_voyage_format_propagates_through_config() -> None:
+    """rerank_format='voyage' should be accepted and flow into the provider."""
+    from chunkhound.core.config.embedding_config import EmbeddingConfig
+    from chunkhound.core.config.embedding_factory import EmbeddingProviderFactory
+
+    config = EmbeddingConfig(
+        provider="voyageai",
+        base_url="https://ai.mongodb.com/v1",
+        model="voyage-3.5",
+        rerank_model="rerank-2.5",
+        rerank_format="voyage",
+    )
+    assert config.rerank_format == "voyage"
+
+    provider = EmbeddingProviderFactory.create_provider(config)
+    assert provider._rerank_format == "voyage"
+
+
+def test_voyage_format_requires_model() -> None:
+    """Voyage-native format, like Cohere, needs an explicit rerank_model."""
+    from chunkhound.core.config.embedding_config import EmbeddingConfig
+
+    with pytest.raises(ValueError, match="rerank_model is required"):
+        EmbeddingConfig(
+            provider="voyageai",
+            base_url="https://ai.mongodb.com/v1",
+            model="voyage-3.5",
+            rerank_url="/rerank",
+            rerank_format="voyage",
+        )
+
+
+def test_official_voyage_config_stays_on_sdk_rerank() -> None:
+    """Adding the 'voyage' format must not shift the official-API default:
+    official VoyageAI (no base_url) keeps rerank_format='auto' and no
+    rerank_url, so reranking stays on the SDK path, never the HTTP path."""
+    from chunkhound.core.config.embedding_config import EmbeddingConfig
+
+    config = EmbeddingConfig(
+        provider="voyageai",
+        model="voyage-3.5",
+        rerank_model="rerank-2.5",
+    )
+    assert config.rerank_format == "auto"
+    assert config.rerank_url is None
+
+
 def test_supports_reranking_with_incomplete_cohere_config() -> None:
     """Fail-fast validation should reject incomplete Cohere rerank config."""
     with pytest.raises(ValueError, match="rerank_model is required.*cohere"):

--- a/tests/unit/test_voyageai_provider.py
+++ b/tests/unit/test_voyageai_provider.py
@@ -315,6 +315,26 @@ class TestBuildRerankPayload:
         assert "documents" not in payload
         assert "model" not in payload
 
+    def test_voyage_format_with_model_and_top_k(self):
+        """Voyage-native format sends top_k (not Cohere's top_n) plus the model."""
+        p = self._provider("voyage", model="rerank-2.5")
+        payload = p._build_rerank_payload("q", ["d1", "d2"], top_k=1)
+        assert payload == {
+            "query": "q",
+            "documents": ["d1", "d2"],
+            "model": "rerank-2.5",
+            "top_k": 1,
+        }
+        assert "top_n" not in payload
+
+    def test_voyage_format_with_model_no_top_k(self):
+        """Voyage-native format omits top_k when it is not requested."""
+        p = self._provider("voyage", model="rerank-2.5")
+        payload = p._build_rerank_payload("q", ["d1"], top_k=None)
+        assert payload == {"query": "q", "documents": ["d1"], "model": "rerank-2.5"}
+        assert "top_k" not in payload
+        assert "top_n" not in payload
+
 
 # ===========================================================================
 # 5. _parse_rerank_response (sync method)
@@ -425,6 +445,29 @@ class TestParseRerankResponse:
         assert len(results) == 1
         assert results[0].index == 0
         assert results[0].score == pytest.approx(0.9)
+
+    def test_voyage_data_field_treated_as_results(self, p):
+        """Voyage-native endpoints return the ranking under 'data', not 'results'."""
+        data = {
+            "data": [
+                {"index": 0, "relevance_score": 0.9},
+                {"index": 1, "relevance_score": 0.4},
+            ]
+        }
+        results = p._parse_rerank_response(data, num_documents=2)
+        assert len(results) == 2
+        assert results[0].index == 0
+        assert results[0].score == pytest.approx(0.9)
+
+    def test_results_key_takes_precedence_over_data(self, p):
+        """When both keys are present, canonical 'results' wins over 'data'."""
+        data = {
+            "results": [{"index": 0, "score": 0.9}],
+            "data": [{"index": 1, "score": 0.1}],
+        }
+        results = p._parse_rerank_response(data, num_documents=2)
+        assert len(results) == 1
+        assert results[0].index == 0
 
 
 # ===========================================================================

--- a/tests/unit/test_voyageai_provider.py
+++ b/tests/unit/test_voyageai_provider.py
@@ -335,6 +335,23 @@ class TestBuildRerankPayload:
         assert "top_k" not in payload
         assert "top_n" not in payload
 
+    def test_unknown_format_with_model_falls_back_to_cohere_style(self):
+        """An unrecognised format string keeps auto's Cohere-style behaviour."""
+        p = self._provider("Cohere", model="my-reranker")
+        payload = p._build_rerank_payload("q", ["d1"], top_k=2)
+        assert payload == {
+            "query": "q",
+            "documents": ["d1"],
+            "model": "my-reranker",
+            "top_n": 2,
+        }
+
+    def test_unknown_format_without_model_falls_back_to_tei_style(self):
+        """An unrecognised format string with no model still probes TEI-style."""
+        p = self._provider("Cohere")
+        payload = p._build_rerank_payload("q", ["d1"], top_k=2)
+        assert payload == {"query": "q", "texts": ["d1"]}
+
 
 # ===========================================================================
 # 5. _parse_rerank_response (sync method)


### PR DESCRIPTION
### Why

Custom VoyageAI-compatible endpoints that expose a native `/rerank` route — e.g. MongoDB Atlas's gateway at `https://ai.mongodb.com/v1` serving `rerank-2.5` — speak VoyageAI's own rerank dialect: the request uses `top_k` (not Cohere's `top_n`) and the ranking is returned under a `data` key (not `results`).

Today the HTTP rerank path only speaks Cohere and TEI. Because `rerank_model` + `base_url` auto-derives `rerank_url`, such a config takes the HTTP path with `rerank_format="auto"` → Cohere shape → the endpoint rejects `top_n` and the parser rejects the `data` response, so reranking silently degrades to raw vector similarity.

Fixes #382.

### What

- New `rerank_format="voyage"`: builds `{query, documents, model, top_k}`.
- `_parse_rerank_response` accepts `data` as an alias for `results`, but only when `results` is absent — `cohere`/`tei` responses are unaffected.
- Config `Literal` + `validate_rerank_configuration` updated: `voyage` requires a `rerank_model` (like `cohere`).

### Safety / scope

- The **official VoyageAI API is untouched** — it reranks via the SDK, not this HTTP path. A regression test pins that an official config (no `base_url`) stays on the SDK path.
- `auto` / `cohere` still send `top_n`; existing tests pin this.

### Tests

- Payload sends `top_k` (not `top_n`); a `data` response is parsed; `results`-precedence guard.
- Config accepts `rerank_format="voyage"` and requires a model.
- `tests/unit/test_voyageai_provider.py` + `tests/test_embeddings.py` pass; smoke suite green.

🤖 Generated with [Claude Code](https://claude.ai/code)
