### PR TITLE
feat: inject indexed language metadata through research clustering and synthesis pipeline

### DIFF
--- a/chunkhound/services/clustering_service.py
+++ b/chunkhound/services/clustering_service.py
@@ -5,12 +5,14 @@ for budget-based clustering (subsequent passes) to group files into
 token-bounded clusters for parallel synthesis operations.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import numpy as np
 from loguru import logger
 from sklearn.cluster import HDBSCAN, KMeans  # type: ignore[import-untyped]
 
+from chunkhound.core.types.common import Language
+from chunkhound.core.utils import format_chunk_for_embedding
 from chunkhound.interfaces.embedding_provider import EmbeddingProvider
 from chunkhound.interfaces.llm_provider import LLMProvider
 
@@ -23,6 +25,7 @@ class ClusterGroup:
     file_paths: list[str]
     files_content: dict[str, str]  # file_path -> content
     total_tokens: int
+    file_languages: dict[str, str] = field(default_factory=dict)
 
 
 class ClusteringService:
@@ -42,14 +45,56 @@ class ClusteringService:
         self._embedding_provider = embedding_provider
         self._llm_provider = llm_provider
 
+    def _prepare_files_for_embedding(
+        self,
+        files: dict[str, str],
+        file_paths: list[str],
+        file_languages: dict[str, str],
+    ) -> list[str]:
+        """Prefix file content with its indexed language for embedding."""
+        return [
+            format_chunk_for_embedding(
+                code=files[file_path],
+                file_path=file_path,
+                language=file_languages.get(file_path)
+                or Language.from_file_extension(file_path).value,
+            )
+            for file_path in file_paths
+        ]
+
+    @staticmethod
+    def _create_cluster_group(
+        cluster_id: int,
+        file_paths: list[str],
+        files: dict[str, str],
+        total_tokens: int,
+        file_languages: dict[str, str],
+    ) -> ClusterGroup:
+        return ClusterGroup(
+            cluster_id=cluster_id,
+            file_paths=file_paths,
+            files_content={file_path: files[file_path] for file_path in file_paths},
+            total_tokens=total_tokens,
+            file_languages={
+                file_path: file_languages[file_path]
+                for file_path in file_paths
+                if file_path in file_languages
+            },
+        )
+
     async def cluster_files(
-        self, files: dict[str, str], n_clusters: int
+        self,
+        files: dict[str, str],
+        n_clusters: int,
+        file_languages: dict[str, str] | None = None,
     ) -> tuple[list[ClusterGroup], dict[str, int]]:
         """Cluster files into exactly n_clusters using k-means.
 
         Args:
             files: Dictionary mapping file_path -> file_content
             n_clusters: Exact number of clusters to produce
+            file_languages: Indexed language by file path. Overrides extension inference
+                in embedding headers and is retained by returned cluster groups.
 
         Returns:
             Tuple of (cluster_groups, metadata) where metadata contains:
@@ -63,6 +108,7 @@ class ClusteringService:
         """
         if not files:
             raise ValueError("Cannot cluster empty files dictionary")
+        file_languages = file_languages or {}
         if n_clusters < 1:
             raise ValueError("n_clusters must be at least 1")
 
@@ -82,11 +128,12 @@ class ClusteringService:
         # Special case: single cluster requested or single file
         if n_clusters == 1 or len(files) == 1:
             logger.info("Single cluster - will produce single output")
-            cluster_group = ClusterGroup(
+            cluster_group = self._create_cluster_group(
                 cluster_id=0,
-                file_paths=list(files.keys()),
-                files_content=files,
+                file_paths=list(files),
+                files=files,
                 total_tokens=total_tokens,
+                file_languages=file_languages,
             )
             metadata = {
                 "num_clusters": 1,
@@ -96,9 +143,11 @@ class ClusteringService:
             }
             return [cluster_group], metadata
 
-        # Generate embeddings for each file
-        file_paths = list(files.keys())
-        file_contents = [files[fp] for fp in file_paths]
+        # Generate embeddings for each file with language and path metadata.
+        file_paths = list(files)
+        file_contents = self._prepare_files_for_embedding(
+            files, file_paths, file_languages
+        )
 
         logger.debug(f"Generating embeddings for {len(file_contents)} files")
         embeddings = await self._embedding_provider.embed_batch(file_contents)
@@ -115,19 +164,19 @@ class ClusteringService:
             cluster_to_files.setdefault(int(cluster_id), []).append(file_path)
 
         cluster_groups: list[ClusterGroup] = []
-        for cluster_id in sorted(cluster_to_files.keys()):
+        for cluster_id in sorted(cluster_to_files):
             cluster_file_paths = cluster_to_files[cluster_id]
-            cluster_files_content = {fp: files[fp] for fp in cluster_file_paths}
             cluster_tokens = sum(
-                self._llm_provider.estimate_tokens(content)
-                for content in cluster_files_content.values()
+                self._llm_provider.estimate_tokens(files[file_path])
+                for file_path in cluster_file_paths
             )
 
-            cluster_group = ClusterGroup(
+            cluster_group = self._create_cluster_group(
                 cluster_id=cluster_id,
                 file_paths=cluster_file_paths,
-                files_content=cluster_files_content,
+                files=files,
                 total_tokens=cluster_tokens,
+                file_languages=file_languages,
             )
             cluster_groups.append(cluster_group)
 
@@ -155,6 +204,7 @@ class ClusteringService:
         self,
         files: dict[str, str],
         min_cluster_size: int = 2,
+        file_languages: dict[str, str] | None = None,
     ) -> tuple[list[ClusterGroup], dict[str, int]]:
         """Cluster files using HDBSCAN for natural semantic grouping.
 
@@ -165,6 +215,8 @@ class ClusteringService:
         Args:
             files: Dictionary mapping file_path -> file_content
             min_cluster_size: Minimum size for HDBSCAN clusters (default: 2)
+            file_languages: Indexed language by file path. Overrides extension inference
+                in embedding headers and is retained by returned cluster groups.
 
         Returns:
             Tuple of (cluster_groups, metadata) where metadata contains:
@@ -180,6 +232,7 @@ class ClusteringService:
         """
         if not files:
             raise ValueError("Cannot cluster empty files dictionary")
+        file_languages = file_languages or {}
 
         # Calculate total tokens
         total_tokens = sum(
@@ -191,11 +244,12 @@ class ClusteringService:
         # Special case: single file
         if len(files) == 1:
             logger.info("Single file - will produce single cluster")
-            cluster_group = ClusterGroup(
+            cluster_group = self._create_cluster_group(
                 cluster_id=0,
-                file_paths=list(files.keys()),
-                files_content=files,
+                file_paths=list(files),
+                files=files,
                 total_tokens=total_tokens,
+                file_languages=file_languages,
             )
             metadata = {
                 "num_clusters": 1,
@@ -207,9 +261,11 @@ class ClusteringService:
             }
             return [cluster_group], metadata
 
-        # Generate embeddings for each file
-        file_paths = list(files.keys())
-        file_contents = [files[fp] for fp in file_paths]
+        # Generate embeddings for each file with language and path metadata.
+        file_paths = list(files)
+        file_contents = self._prepare_files_for_embedding(
+            files, file_paths, file_languages
+        )
 
         logger.debug(f"Generating embeddings for {len(file_contents)} files")
         embeddings = await self._embedding_provider.embed_batch(file_contents)
@@ -251,19 +307,19 @@ class ClusteringService:
             cluster_to_files.setdefault(int(cluster_id), []).append(file_path)
 
         cluster_groups: list[ClusterGroup] = []
-        for cluster_id in sorted(cluster_to_files.keys()):
+        for cluster_id in sorted(cluster_to_files):
             cluster_file_paths = cluster_to_files[cluster_id]
-            cluster_files_content = {fp: files[fp] for fp in cluster_file_paths}
             cluster_tokens = sum(
-                self._llm_provider.estimate_tokens(content)
-                for content in cluster_files_content.values()
+                self._llm_provider.estimate_tokens(files[file_path])
+                for file_path in cluster_file_paths
             )
 
-            cluster_group = ClusterGroup(
+            cluster_group = self._create_cluster_group(
                 cluster_id=cluster_id,
                 file_paths=cluster_file_paths,
-                files_content=cluster_files_content,
+                files=files,
                 total_tokens=cluster_tokens,
+                file_languages=file_languages,
             )
             cluster_groups.append(cluster_group)
 
@@ -346,6 +402,7 @@ class ClusteringService:
         min_cluster_size: int = 2,
         min_tokens_per_cluster: int = 15_000,
         max_tokens_per_cluster: int = 50_000,
+        file_languages: dict[str, str] | None = None,
     ) -> tuple[list[ClusterGroup], dict[str, int]]:
         """Cluster files using HDBSCAN with token bounds enforcement.
 
@@ -358,6 +415,8 @@ class ClusteringService:
             min_cluster_size: Minimum size for HDBSCAN clusters (default: 2)
             min_tokens_per_cluster: Minimum tokens per cluster (default: 15,000)
             max_tokens_per_cluster: Maximum tokens per cluster (default: 50,000)
+            file_languages: Indexed language by file path. Overrides extension inference
+                in embedding headers and is retained by returned cluster groups.
 
         Returns:
             Tuple of (cluster_groups, metadata) where metadata contains:
@@ -380,6 +439,7 @@ class ClusteringService:
         """
         if not files:
             raise ValueError("Cannot cluster empty files dictionary")
+        file_languages = file_languages or {}
 
         # Calculate total tokens and per-file tokens
         file_tokens: dict[str, int] = {
@@ -396,11 +456,12 @@ class ClusteringService:
         # Special case: single file
         if len(files) == 1:
             logger.info("Single file - will produce single cluster")
-            cluster_group = ClusterGroup(
+            cluster_group = self._create_cluster_group(
                 cluster_id=0,
-                file_paths=list(files.keys()),
-                files_content=files,
+                file_paths=list(files),
+                files=files,
                 total_tokens=total_tokens,
+                file_languages=file_languages,
             )
             metadata = {
                 "num_clusters": 1,
@@ -414,9 +475,11 @@ class ClusteringService:
             }
             return [cluster_group], metadata
 
-        # Generate embeddings for each file (once, reused for all operations)
-        file_paths = list(files.keys())
-        file_contents = [files[fp] for fp in file_paths]
+        # Generate embeddings once for all clustering operations.
+        file_paths = list(files)
+        file_contents = self._prepare_files_for_embedding(
+            files, file_paths, file_languages
+        )
 
         logger.debug(f"Generating embeddings for {len(file_contents)} files")
         embeddings = await self._embedding_provider.embed_batch(file_contents)
@@ -641,16 +704,18 @@ class ClusteringService:
 
         # Phase 3: Renumber clusters sequentially
         final_cluster_groups: list[ClusterGroup] = []
-        for new_id, old_id in enumerate(sorted(cluster_to_files.keys())):
+        for new_id, old_id in enumerate(sorted(cluster_to_files)):
             cluster_file_paths = cluster_to_files[old_id]
-            cluster_files_content = {fp: files[fp] for fp in cluster_file_paths}
-            cluster_tokens = sum(file_tokens[fp] for fp in cluster_file_paths)
+            cluster_tokens = sum(
+                file_tokens[file_path] for file_path in cluster_file_paths
+            )
 
-            cluster_group = ClusterGroup(
+            cluster_group = self._create_cluster_group(
                 cluster_id=new_id,
                 file_paths=cluster_file_paths,
-                files_content=cluster_files_content,
+                files=files,
                 total_tokens=cluster_tokens,
+                file_languages=file_languages,
             )
             final_cluster_groups.append(cluster_group)
 

--- a/chunkhound/services/research/shared/evidence_ledger/clustered_extractor.py
+++ b/chunkhound/services/research/shared/evidence_ledger/clustered_extractor.py
@@ -57,6 +57,7 @@ async def extract_facts_with_clustering(
     max_concurrency: int = 4,
     min_tokens_per_cluster: int = MIN_TOKENS_PER_CLUSTER,
     max_tokens_per_cluster: int = MAX_TOKENS_PER_CLUSTER,
+    file_languages: dict[str, str] | None = None,
 ) -> ClusteredExtractionResult:
     """Extract facts from files using HDBSCAN bounded clustering.
 
@@ -76,6 +77,8 @@ async def extract_facts_with_clustering(
         max_concurrency: Maximum parallel LLM calls
         min_tokens_per_cluster: Minimum tokens per cluster (HDBSCAN bound)
         max_tokens_per_cluster: Maximum tokens per cluster (HDBSCAN bound)
+        file_languages: Indexed language by file path. Overrides extension inference
+            in clustering embeddings and is retained by returned cluster groups.
 
     Returns:
         ClusteredExtractionResult with:
@@ -100,6 +103,7 @@ async def extract_facts_with_clustering(
         files,
         min_tokens_per_cluster=min_tokens_per_cluster,
         max_tokens_per_cluster=max_tokens_per_cluster,
+        file_languages=file_languages,
     )
 
     logger.info(

--- a/chunkhound/services/research/v1/pluggable_research_service.py
+++ b/chunkhound/services/research/v1/pluggable_research_service.py
@@ -265,6 +265,12 @@ class PluggableResearchService(ProgressEmitterMixin):
         ) = await self._synthesis_engine._manage_token_budget_for_synthesis(
             aggregated["chunks"], aggregated["files"], query, synthesis_budgets
         )
+        file_languages = {
+            file_path: language
+            for chunk in prioritized_chunks
+            if (file_path := chunk.get("file_path")) in budgeted_files
+            and isinstance(language := chunk.get("language"), str)
+        }
 
         # Emit synthesizing event
         await self._emit_event(
@@ -288,6 +294,7 @@ class PluggableResearchService(ProgressEmitterMixin):
             root_query=query,
             llm_provider=self._llm_manager.get_utility_provider(),
             embedding_provider=self._embedding_manager.get_provider(),
+            file_languages=file_languages,
         )
         cluster_groups = extraction_result.cluster_groups
         cluster_metadata = extraction_result.cluster_metadata
@@ -313,6 +320,7 @@ class PluggableResearchService(ProgressEmitterMixin):
                 files=budgeted_files,
                 context=context,
                 synthesis_budgets=synthesis_budgets,
+                file_languages=file_languages,
                 constants_context=constants_context,
                 facts_context=facts_context,
             )

--- a/chunkhound/services/research/v1/pluggable_research_service.py
+++ b/chunkhound/services/research/v1/pluggable_research_service.py
@@ -352,9 +352,11 @@ class PluggableResearchService(ProgressEmitterMixin):
                 async with semaphore:
                     # Get cluster-specific facts context
                     cluster_files = set(cluster.file_paths)
-                    cluster_facts_context = evidence_ledger.get_facts_map_prompt_context(
-                        cluster_files,
-                        cluster_id=cluster.cluster_id,
+                    cluster_facts_context = (
+                        evidence_ledger.get_facts_map_prompt_context(
+                            cluster_files,
+                            cluster_id=cluster.cluster_id,
+                        )
                     )
                     return await self._synthesis_engine._map_synthesis_on_cluster(
                         cluster,
@@ -683,10 +685,8 @@ class PluggableResearchService(ProgressEmitterMixin):
                         end_line = chunk.get("end_line", 1)
 
                         # Use smart boundary detection to expand to complete functions/classes
-                        expanded_start, expanded_end = (
-                            expand_to_natural_boundaries(
-                                lines, start_line, end_line, chunk, file_path
-                            )
+                        expanded_start, expanded_end = expand_to_natural_boundaries(
+                            lines, start_line, end_line, chunk, file_path
                         )
 
                         # Skip chunks with invalid boundary expansion

--- a/chunkhound/services/research/v1/synthesis_engine.py
+++ b/chunkhound/services/research/v1/synthesis_engine.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from loguru import logger
 
+from chunkhound.core.types.common import Language
 from chunkhound.database_factory import DatabaseServices
 from chunkhound.llm_manager import LLMManager
 from chunkhound.services import prompts
@@ -74,6 +75,14 @@ class SynthesisEngine:
         self._db_services = database_services
         self._parent = parent_service
 
+    @staticmethod
+    def _format_source_section(
+        file_path: str, file_content: str, language: str | None
+    ) -> str:
+        """Format a source section with indexed language when available."""
+        language = language or Language.from_file_extension(file_path).value
+        return f"### [{language}] {file_path}\n{'=' * 80}\n{file_content}\n{'=' * 80}"
+
     async def _manage_token_budget_for_synthesis(
         self,
         chunks: list[dict[str, Any]],
@@ -121,6 +130,7 @@ class SynthesisEngine:
         files: dict[str, str],
         context: Any,
         synthesis_budgets: dict[str, int],
+        file_languages: dict[str, str] | None = None,
         constants_context: str = "",
         facts_context: str = "",
     ) -> str:
@@ -141,6 +151,8 @@ class SynthesisEngine:
             files: Budgeted file contents (subset within token limits)
             context: Research context
             synthesis_budgets: Dynamic budgets based on repository size
+            file_languages: Indexed language by file path. Overrides extension inference
+                in source headers.
             constants_context: Constants ledger context for LLM prompts
             facts_context: Facts ledger context for LLM prompts
 
@@ -218,7 +230,9 @@ class SynthesisEngine:
                 file_content = content
 
             source_sections.append(
-                f"### {file_path}\n{'=' * 80}\n{file_content}\n{'=' * 80}"
+                self._format_source_section(
+                    file_path, file_content, (file_languages or {}).get(file_path)
+                )
             )
 
         source_context = "\n\n".join(source_sections)
@@ -379,7 +393,9 @@ class SynthesisEngine:
                 file_content = content
 
             source_sections.append(
-                f"### {file_path}\n{'=' * 80}\n{file_content}\n{'=' * 80}"
+                self._format_source_section(
+                    file_path, file_content, cluster.file_languages.get(file_path)
+                )
             )
 
         source_context = "\n\n".join(source_sections)

--- a/tests/services/test_clustering_service.py
+++ b/tests/services/test_clustering_service.py
@@ -25,7 +25,9 @@ class TestKMeansClustering:
 
     @pytest.fixture
     def clustering_service(
-        self, fake_llm_provider: FakeLLMProvider, fake_embedding_provider: FakeEmbeddingProvider
+        self,
+        fake_llm_provider: FakeLLMProvider,
+        fake_embedding_provider: FakeEmbeddingProvider,
     ) -> ClusteringService:
         """Create clustering service with fake providers."""
         return ClusteringService(
@@ -174,7 +176,9 @@ class TestKMeansClustering:
 
         # Average should be reasonable
         expected_avg = metadata["total_tokens"] / len(clusters)
-        assert abs(metadata["avg_tokens_per_cluster"] - expected_avg) <= 1  # Allow rounding error
+        assert (
+            abs(metadata["avg_tokens_per_cluster"] - expected_avg) <= 1
+        )  # Allow rounding error
 
     @pytest.mark.asyncio
     async def test_budget_tracking_with_multiple_clusters(
@@ -253,7 +257,9 @@ class TestHDBSCANClustering:
 
     @pytest.fixture
     def clustering_service(
-        self, fake_llm_provider: FakeLLMProvider, fake_embedding_provider: FakeEmbeddingProvider
+        self,
+        fake_llm_provider: FakeLLMProvider,
+        fake_embedding_provider: FakeEmbeddingProvider,
     ) -> ClusteringService:
         """Create clustering service with fake providers."""
         return ClusteringService(
@@ -415,7 +421,9 @@ class TestClusterFilesHDBSCANBounded:
 
     @pytest.fixture
     def clustering_service(
-        self, fake_llm_provider: FakeLLMProvider, fake_embedding_provider: FakeEmbeddingProvider
+        self,
+        fake_llm_provider: FakeLLMProvider,
+        fake_embedding_provider: FakeEmbeddingProvider,
     ) -> ClusteringService:
         """Create clustering service with fake providers."""
         return ClusteringService(
@@ -455,7 +463,11 @@ class TestClusterFilesHDBSCANBounded:
         files = {}
         for i in range(6):
             # Each file has distinctly different content for k-means to separate
-            unique_content = f"unique_module_{i}_" + ("a" * i * 1000) + self._make_content_with_tokens(19_900)
+            unique_content = (
+                f"unique_module_{i}_"
+                + ("a" * i * 1000)
+                + self._make_content_with_tokens(19_900)
+            )
             files[f"large{i}.py"] = unique_content
 
         clusters, metadata = await clustering_service.cluster_files_hdbscan_bounded(
@@ -502,7 +514,9 @@ class TestClusterFilesHDBSCANBounded:
         files = {}
         for i in range(6):
             # Each file has unique content to create distinct embeddings
-            unique_content = f"unique_module_{i}_" + self._make_content_with_tokens(4_990)
+            unique_content = f"unique_module_{i}_" + self._make_content_with_tokens(
+                4_990
+            )
             files[f"small_{i}.py"] = unique_content
 
         clusters, metadata = await clustering_service.cluster_files_hdbscan_bounded(
@@ -538,9 +552,7 @@ class TestClusterFilesHDBSCANBounded:
         """Test that clusters already within bounds are not modified."""
         # Create files with ~25k tokens each (within 15k-50k bounds)
         medium_content = self._make_content_with_tokens(25_000)
-        files = {
-            f"medium{i}.py": medium_content for i in range(2)
-        }
+        files = {f"medium{i}.py": medium_content for i in range(2)}
 
         clusters, metadata = await clustering_service.cluster_files_hdbscan_bounded(
             files,
@@ -618,7 +630,7 @@ class TestClusterFilesHDBSCANBounded:
         """Test that returned metadata accurately reflects operations performed."""
         # Create mix of file sizes to trigger both splits and merges
         large_content = self._make_content_with_tokens(60_000)  # Will need split
-        small_content = self._make_content_with_tokens(5_000)   # Will need merge
+        small_content = self._make_content_with_tokens(5_000)  # Will need merge
 
         files = {
             "large.py": large_content,
@@ -679,9 +691,9 @@ class TestClusterFilesHDBSCANBounded:
         """Test that all input files appear in output after splits and merges."""
         # Mix of sizes to trigger various operations
         files = {
-            "huge.py": self._make_content_with_tokens(80_000),   # Split needed
-            "medium.py": self._make_content_with_tokens(30_000), # OK
-            "small.py": self._make_content_with_tokens(5_000),   # Merge needed
+            "huge.py": self._make_content_with_tokens(80_000),  # Split needed
+            "medium.py": self._make_content_with_tokens(30_000),  # OK
+            "small.py": self._make_content_with_tokens(5_000),  # Merge needed
         }
 
         clusters, metadata = await clustering_service.cluster_files_hdbscan_bounded(
@@ -821,8 +833,12 @@ class TestClusterFilesHDBSCANBounded:
         # Use unique content so k-means can distinguish them
         files = {
             "tiny.py": self._make_unique_content_with_tokens(2_000, seed="tiny"),
-            "nearmax1.py": self._make_unique_content_with_tokens(49_000, seed="nearmax1"),
-            "nearmax2.py": self._make_unique_content_with_tokens(49_000, seed="nearmax2"),
+            "nearmax1.py": self._make_unique_content_with_tokens(
+                49_000, seed="nearmax1"
+            ),
+            "nearmax2.py": self._make_unique_content_with_tokens(
+                49_000, seed="nearmax2"
+            ),
         }
 
         clusters, metadata = await clustering_service.cluster_files_hdbscan_bounded(
@@ -841,3 +857,81 @@ class TestClusterFilesHDBSCANBounded:
         assert "num_unmergeable" in metadata
         # The tiny cluster cannot merge anywhere (would exceed 50k)
         assert metadata["num_unmergeable"] >= 1
+
+
+class CapturingEmbeddingProvider(FakeEmbeddingProvider):
+    """Capture the provider payload sent by clustering."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.captured_texts: list[str] = []
+
+    async def embed_batch(self, texts, batch_size=None):
+        self.captured_texts.extend(texts)
+        return await super().embed_batch(texts, batch_size)
+
+
+class TestLanguageMetadataInEmbeddings:
+    """Clustering must send each file's indexed language with its source."""
+
+    @pytest.fixture
+    def fake_llm_provider(self) -> FakeLLMProvider:
+        return FakeLLMProvider(model="fake-gpt")
+
+    @pytest.fixture
+    def capturing_provider(self) -> CapturingEmbeddingProvider:
+        return CapturingEmbeddingProvider(model="fake-embed")
+
+    @pytest.fixture
+    def clustering_service(
+        self,
+        fake_llm_provider: FakeLLMProvider,
+        capturing_provider: CapturingEmbeddingProvider,
+    ) -> ClusteringService:
+        return ClusteringService(capturing_provider, fake_llm_provider)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("method_name", "kwargs"),
+        [
+            ("cluster_files", {"n_clusters": 2}),
+            ("cluster_files_hdbscan", {}),
+            ("cluster_files_hdbscan_bounded", {}),
+        ],
+    )
+    async def test_embedding_payload_preserves_indexed_language(
+        self,
+        clustering_service: ClusteringService,
+        capturing_provider: CapturingEmbeddingProvider,
+        method_name: str,
+        kwargs: dict[str, int],
+    ) -> None:
+        files = {
+            "Sources/Widget.m": "@implementation Widget\n@end",
+            "docs/guide.md": "# Guide",
+        }
+        file_languages = {"Sources/Widget.m": "objc", "docs/guide.md": "markdown"}
+
+        await getattr(clustering_service, method_name)(
+            files, file_languages=file_languages, **kwargs
+        )
+
+        assert capturing_provider.captured_texts == [
+            "# Sources/Widget.m (objc)\n@implementation Widget\n@end",
+            "# docs/guide.md (markdown)\n# Guide",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_embedding_payload_falls_back_to_extension_language(
+        self,
+        clustering_service: ClusteringService,
+        capturing_provider: CapturingEmbeddingProvider,
+    ) -> None:
+        files = {"Sources/Widget.m": "@implementation Widget\n@end", "notes.txt": "x"}
+
+        await clustering_service.cluster_files(files, n_clusters=2)
+
+        assert capturing_provider.captured_texts == [
+            "# Sources/Widget.m (matlab)\n@implementation Widget\n@end",
+            "# notes.txt (text)\nx",
+        ]

--- a/tests/unit/research/test_synthesis_engine_fallback.py
+++ b/tests/unit/research/test_synthesis_engine_fallback.py
@@ -1,5 +1,7 @@
 """Synthesis engine fallback behavior when rerank results are invalid."""
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 from chunkhound.interfaces.embedding_provider import RerankResult
@@ -7,12 +9,25 @@ from chunkhound.llm_manager import LLMManager
 from chunkhound.services.clustering_service import ClusterGroup
 from chunkhound.services.research import SynthesisEngine
 from chunkhound.services.research.shared.citation_manager import CitationManager
+from chunkhound.services.research.v1.pluggable_research_service import (
+    PluggableResearchService,
+)
 from tests.fixtures.fake_providers import FakeEmbeddingProvider, FakeLLMProvider
 
 
 class _OutOfBoundsEmbeddingProvider(FakeEmbeddingProvider):
     async def rerank(self, query: str, documents: list[str], top_k=None):  # noqa: ANN001
         return [RerankResult(index=len(documents) + 5, score=1.0)]
+
+
+class _CapturingEmbeddingProvider(FakeEmbeddingProvider):
+    def __init__(self):
+        super().__init__()
+        self.texts: list[str] = []
+
+    async def embed_batch(self, texts: list[str], batch_size: int | None = None):
+        self.texts.extend(texts)
+        return await super().embed_batch(texts, batch_size)
 
 
 class _FakeEmbeddingManager:
@@ -157,3 +172,135 @@ async def test_map_synthesis_uses_output_budget_for_cluster_allocation(
     call = fake_provider.calls[0]
     assert call["max_completion_tokens"] == 6000
     assert "Target output: ~6,000 tokens" in call["system"]
+
+
+def _source_header(file_path: str, language: str, content: str) -> str:
+    return f"### [{language}] {file_path}\n{'=' * 80}\n{content}\n{'=' * 80}"
+
+
+@pytest.mark.asyncio
+async def test_map_synthesis_preserves_cluster_language_in_source_headers(
+    capturing_llm_manager,
+):
+    llm_manager, fake_provider = capturing_llm_manager
+    engine = SynthesisEngine(
+        llm_manager, object(), _FakeParent(FakeEmbeddingProvider())
+    )
+    source = "@implementation Widget\n@end"
+    cluster = ClusterGroup(
+        cluster_id=0,
+        file_paths=["Sources/Widget.m"],
+        files_content={"Sources/Widget.m": source},
+        total_tokens=20_000,
+        file_languages={"Sources/Widget.m": "objc"},
+    )
+    chunks = [
+        {
+            "file_path": "Sources/Widget.m",
+            "content": source,
+            "start_line": 1,
+            "end_line": 2,
+        }
+    ]
+
+    await engine._map_synthesis_on_cluster(
+        cluster, "widget", chunks, {"output_tokens": 30_000}, 100_000
+    )
+
+    prompt = fake_provider.calls[0]["prompt"]
+    assert (
+        _source_header("Sources/Widget.m", "objc", f"# Lines 1-2\n{source}") in prompt
+    )
+
+
+@pytest.mark.asyncio
+async def test_research_flow_preserves_indexed_language_in_embeddings_and_prompt(
+    capturing_llm_manager, monkeypatch
+):
+    llm_manager, fake_provider = capturing_llm_manager
+    embedding_provider = _CapturingEmbeddingProvider()
+    embedding_manager = _FakeEmbeddingManager(embedding_provider)
+    exploration_strategy = MagicMock()
+    exploration_strategy.name = "test"
+    source = "@implementation Widget\n@end"
+    chunks = [
+        {
+            "chunk_id": 1,
+            "file_path": "Sources/Widget.m",
+            "content": source,
+            "language": "objc",
+            "start_line": 1,
+            "end_line": 2,
+        },
+        {
+            "chunk_id": 2,
+            "file_path": "Sources/Helper.py",
+            "content": "def helper(): pass",
+            "language": "python",
+            "start_line": 1,
+            "end_line": 1,
+        },
+    ]
+    files = {chunk["file_path"]: chunk["content"] for chunk in chunks}
+    exploration_strategy.explore = AsyncMock(return_value=(chunks, {}, files))
+    service = PluggableResearchService(
+        database_services=MagicMock(),
+        embedding_manager=embedding_manager,
+        llm_manager=llm_manager,
+        exploration_strategy=exploration_strategy,
+    )
+    monkeypatch.setattr(service, "_unified_search", AsyncMock(return_value=chunks))
+    monkeypatch.setattr(
+        service._synthesis_engine,
+        "_manage_token_budget_for_synthesis",
+        AsyncMock(
+            return_value=(
+                chunks,
+                files,
+                {"files_selected": 2, "total_tokens": 10, "chunks_count": 2},
+            )
+        ),
+    )
+
+    await service.deep_research("How does Widget work?")
+
+    assert (
+        "# Sources/Widget.m (objc)\n@implementation Widget\n@end"
+        in embedding_provider.texts
+    )
+    prompts = [call["prompt"] for call in fake_provider.calls]
+    assert any("### [objc] Sources/Widget.m" in prompt for prompt in prompts)
+    assert not any("### [matlab] Sources/Widget.m" in prompt for prompt in prompts)
+
+
+@pytest.mark.asyncio
+async def test_single_pass_synthesis_falls_back_to_extension_language(
+    capturing_llm_manager,
+):
+    llm_manager, fake_provider = capturing_llm_manager
+    engine = SynthesisEngine(
+        llm_manager, object(), _FakeParent(FakeEmbeddingProvider())
+    )
+    source = "@implementation Widget\n@end"
+    files = {"Sources/Widget.m": source}
+    chunks = [
+        {
+            "file_path": "Sources/Widget.m",
+            "content": source,
+            "start_line": 1,
+            "end_line": 2,
+        }
+    ]
+
+    await engine._single_pass_synthesis(
+        "widget",
+        chunks,
+        files,
+        None,
+        {"input_tokens": 50_000, "output_tokens": 5_000},
+    )
+
+    prompt = fake_provider.calls[0]["prompt"]
+    assert (
+        _source_header("Sources/Widget.m", "matlab", f"# Lines 1-2\n{source}") in prompt
+    )

--- a/tests/unit/research/test_synthesis_engine_fallback.py
+++ b/tests/unit/research/test_synthesis_engine_fallback.py
@@ -12,7 +12,7 @@ from chunkhound.services.research.v1.pluggable_research_service import (
     PluggableResearchService,
 )
 from tests.fixtures.fake_providers import FakeEmbeddingProvider, FakeLLMProvider
-from tests.unit.research.conftest import FakeParent
+from tests.unit.research.conftest import FakeEmbeddingManager, FakeParent
 
 
 class _OutOfBoundsEmbeddingProvider(FakeEmbeddingProvider):

--- a/tests/unit/research/test_synthesis_engine_fallback.py
+++ b/tests/unit/research/test_synthesis_engine_fallback.py
@@ -6,7 +6,7 @@ import pytest
 
 from chunkhound.interfaces.embedding_provider import RerankResult
 from chunkhound.llm_manager import LLMManager
-from chunkhound.services.clustering_service import ClusterGroup
+from chunkhound.services.clustering_service import ClusterGroup, ClusteringService
 from chunkhound.services.research import SynthesisEngine
 from chunkhound.services.research.shared.citation_manager import CitationManager
 from chunkhound.services.research.v1.pluggable_research_service import (
@@ -174,43 +174,63 @@ async def test_map_synthesis_uses_output_budget_for_cluster_allocation(
     assert "Target output: ~6,000 tokens" in call["system"]
 
 
+_WIDGET_SOURCE = "@implementation Widget\n@end"
+_WIDGET_FILE = {"Sources/Widget.m": _WIDGET_SOURCE}
+_WIDGET_FILES = {**_WIDGET_FILE, "Sources/Helper.py": "def helper(): pass"}
+_WIDGET_CHUNKS = [
+    {
+        "file_path": "Sources/Widget.m",
+        "content": _WIDGET_SOURCE,
+        "start_line": 1,
+        "end_line": 2,
+    }
+]
+_WIDGET_LANGUAGE = {"Sources/Widget.m": "objc"}
+_WIDGET_LANGUAGES = {**_WIDGET_LANGUAGE, "Sources/Helper.py": "python"}
+
+
 def _source_header(file_path: str, language: str, content: str) -> str:
     return f"### [{language}] {file_path}\n{'=' * 80}\n{content}\n{'=' * 80}"
 
 
+async def _cluster_widget_source():
+    clusterer = ClusteringService(FakeEmbeddingProvider(), FakeLLMProvider())
+    clusters, _ = await clusterer.cluster_files_hdbscan_bounded(
+        _WIDGET_FILES,
+        min_tokens_per_cluster=1,
+        max_tokens_per_cluster=50_000,
+        file_languages=_WIDGET_LANGUAGES,
+    )
+    return next(
+        cluster for cluster in clusters if "Sources/Widget.m" in cluster.file_paths
+    )
+
+
 @pytest.mark.asyncio
-async def test_map_synthesis_preserves_cluster_language_in_source_headers(
+async def test_map_synthesis_uses_indexed_language_over_extension_fallback(
     capturing_llm_manager,
 ):
     llm_manager, fake_provider = capturing_llm_manager
     engine = SynthesisEngine(
         llm_manager, object(), _FakeParent(FakeEmbeddingProvider())
     )
-    source = "@implementation Widget\n@end"
-    cluster = ClusterGroup(
-        cluster_id=0,
-        file_paths=["Sources/Widget.m"],
-        files_content={"Sources/Widget.m": source},
-        total_tokens=20_000,
-        file_languages={"Sources/Widget.m": "objc"},
-    )
-    chunks = [
-        {
-            "file_path": "Sources/Widget.m",
-            "content": source,
-            "start_line": 1,
-            "end_line": 2,
-        }
-    ]
+    cluster = await _cluster_widget_source()
 
     await engine._map_synthesis_on_cluster(
-        cluster, "widget", chunks, {"output_tokens": 30_000}, 100_000
+        cluster,
+        "widget",
+        _WIDGET_CHUNKS,
+        {"output_tokens": 30_000},
+        100_000,
     )
 
+    assert len(fake_provider.calls) == 1
     prompt = fake_provider.calls[0]["prompt"]
     assert (
-        _source_header("Sources/Widget.m", "objc", f"# Lines 1-2\n{source}") in prompt
+        _source_header("Sources/Widget.m", "objc", f"# Lines 1-2\n{_WIDGET_SOURCE}")
+        in prompt
     )
+    assert "### [matlab] Sources/Widget.m" not in prompt
 
 
 @pytest.mark.asyncio
@@ -274,33 +294,38 @@ async def test_research_flow_preserves_indexed_language_in_embeddings_and_prompt
 
 
 @pytest.mark.asyncio
-async def test_single_pass_synthesis_falls_back_to_extension_language(
+@pytest.mark.parametrize(
+    ("file_languages", "expected_language"),
+    [
+        pytest.param(None, "matlab", id="extension-fallback"),
+        pytest.param(_WIDGET_LANGUAGE, "objc", id="indexed-language"),
+    ],
+)
+async def test_single_pass_synthesis_resolves_source_language(
     capturing_llm_manager,
+    file_languages,
+    expected_language,
 ):
     llm_manager, fake_provider = capturing_llm_manager
     engine = SynthesisEngine(
         llm_manager, object(), _FakeParent(FakeEmbeddingProvider())
     )
-    source = "@implementation Widget\n@end"
-    files = {"Sources/Widget.m": source}
-    chunks = [
-        {
-            "file_path": "Sources/Widget.m",
-            "content": source,
-            "start_line": 1,
-            "end_line": 2,
-        }
-    ]
-
     await engine._single_pass_synthesis(
         "widget",
-        chunks,
-        files,
+        _WIDGET_CHUNKS,
+        _WIDGET_FILE,
         None,
         {"input_tokens": 50_000, "output_tokens": 5_000},
+        file_languages=file_languages,
     )
 
+    assert len(fake_provider.calls) == 1
     prompt = fake_provider.calls[0]["prompt"]
     assert (
-        _source_header("Sources/Widget.m", "matlab", f"# Lines 1-2\n{source}") in prompt
+        _source_header(
+            "Sources/Widget.m", expected_language, f"# Lines 1-2\n{_WIDGET_SOURCE}"
+        )
+        in prompt
     )
+    if file_languages:
+        assert "### [matlab] Sources/Widget.m" not in prompt


### PR DESCRIPTION
**Note**: This PR was generated by an AI agent. If you'd like to talk with other humans, drop by our Discord!

---

## Language Metadata Propagation through the Research Pipeline

### Problem
The deep research pipeline had no mechanism to pass indexed language metadata (e.g., "objc", "python") from chunk ingestion through to clustering and LLM synthesis. Both the embedding stage (clustering quality) and the prompt stage (code comprehension) relied solely on file extension heuristics, which are ambiguous for files like `.m` (Objective-C vs MATLAB) and miss the rich language data already available in indexed chunks.

### Changes

**`chunkhound/services/clustering_service.py`**
- **+`ClusterGroup.file_languages`** — New field on the dataclass (`default_factory=dict`, backward compatible)
- **+`_create_cluster_group()`** — Factory method replacing 6 inline `ClusterGroup(...)` calls; ensures consistent `file_languages` propagation
- **+`_prepare_files_for_embedding()`** — Formats embedding strings as `# file_path (language)\ncontent` instead of bare content
- **~`cluster_files()`**, **~`cluster_files_hdbscan()`**, **~`cluster_files_hdbscan_bounded()`** — All three accept `file_languages: dict[str, str] | None = None` (backward compatible)

**`chunkhound/services/research/v1/pluggable_research_service.py`**
- **+`file_languages` dict** — Built from enriched chunks after token budget management
- **~`extract_facts_with_clustering()` call** — Now receives `file_languages`
- **~`_single_pass_synthesis()` call** — Now receives `file_languages`
- **(Style)** Multi-line function call formatting brought inline with project conventions

**`chunkhound/services/research/shared/evidence_ledger/clustered_extractor.py`**
- **~`extract_facts_with_clustering()`** — New `file_languages` parameter, passed through to clustering service

**`chunkhound/services/research/v1/synthesis_engine.py`**
- **+`_format_source_section()`** — Formats prompt sections as `### [language] file_path\n======\ncontent\n======` instead of bare `### file_path`
- **~Single-pass synthesis** — Reads language from `file_languages` dict
- **~Map-reduce synthesis** — Reads language from `cluster.file_languages`

### What was removed
- ~Inline `ClusterGroup(...)` construction at 6 locations (replaced by factory)
- ~Inline `file_path` header formatting at 2 locations (replaced by `_format_source_section`)
- ~Redundant `cluster_files_content` interim dicts (simplified to direct `files[file_path]` access)

### Breaking changes
**None.** All new parameters are `Optional` with `None` default. `ClusterGroup.file_languages` uses `field(default_factory=dict)`. Existing code instantiating `ClusterGroup` without the new field continues working.

### Value
- **Clustering quality**: Language-annotated embeddings prevent cross-language semantic confusion (Python and JS with similar structure won't cluster together)
- **LLM code comprehension**: Explicit `[lang]` headers in prompts signal how to parse syntax — especially valuable for polyglot repositories
- **Backward compatible**: Existing indexed repos fall back to extension inference seamlessly
- **Self-contained clusters**: `ClusterGroup.file_languages` enables parallel map-reduce tasks to operate without a global dependency
- **Maintainability**: `_create_cluster_group` factory eliminates the "forget to propagate metadata" failure mode

---

Attached is an agent optimized description of the changes in this PR - [AGENT_REVIEW.md](https://github.com/user-attachments/files/30383616/AGENT_REVIEW.md)
