### PR TITLE
fix(mcp): log when the MCP server's resolved database is missing

### DIFF
--- a/chunkhound/mcp_server/base.py
+++ b/chunkhound/mcp_server/base.py
@@ -400,6 +400,24 @@ class MCPServerBase(ABC):
                 if not self.config.database.read_only:
                     db_path.parent.mkdir(parents=True, exist_ok=True)
 
+                # Logged before create_services() connects and creates an empty
+                # DB at the resolved path, so that case (legacy install, --db
+                # pointed at the wrong directory) stays distinguishable from it.
+                if str(db_path) != ":memory:":
+                    try:
+                        resolved_db_path = self.config.database.get_db_path()
+                        if not resolved_db_path.exists():
+                            self.debug_log(
+                                f"No existing index found at {resolved_db_path} "
+                                f"(configured database.path={db_path}); a fresh "
+                                "one will be created as files are scanned.",
+                                always=True,
+                            )
+                    except Exception as error:
+                        self.debug_log(
+                            f"Index-presence check skipped: {error}", always=True
+                        )
+
                 # Initialize embedding manager
                 self.embedding_manager = EmbeddingManager()
 

--- a/tests/test_mcp_initialization_invariant.py
+++ b/tests/test_mcp_initialization_invariant.py
@@ -262,6 +262,69 @@ class TestNonBlockingInitialization:
                     await server.cleanup()
 
 
+class TestMissingIndexVisibility:
+    """Verify a missing resolved database file is logged, not silently masked."""
+
+    @pytest.mark.asyncio
+    async def test_logs_when_resolved_db_path_is_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config = MagicMock()
+        config.database.path = str(tmp_path / ".chunkhound")
+        config.database.get_db_path.return_value = tmp_path / "elsewhere" / "chunks.db"
+        config.embedding = None
+        config.llm = None
+        config.target_dir = tmp_path
+
+        debug_file = tmp_path / "debug.log"
+        monkeypatch.setenv("CHUNKHOUND_DEBUG_FILE", str(debug_file))
+
+        with patch("chunkhound.mcp_server.base.create_services") as mock_create:
+            mock_services = MagicMock()
+            mock_services.provider.is_connected = False
+            mock_create.return_value = mock_services
+
+            with patch("chunkhound.mcp_server.base.EmbeddingManager"):
+                server = ConcreteMCPServer(config=config)
+                await server.initialize()
+                await server.cleanup()
+
+        logged = debug_file.read_text()
+        assert "No existing index found" in logged
+        assert str(tmp_path / "elsewhere" / "chunks.db") in logged
+
+    @pytest.mark.asyncio
+    async def test_silent_when_resolved_db_path_exists(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        existing_db = tmp_path / "chunks.db"
+        existing_db.write_bytes(b"")
+
+        config = MagicMock()
+        config.database.path = str(tmp_path / ".chunkhound")
+        config.database.get_db_path.return_value = existing_db
+        config.embedding = None
+        config.llm = None
+        config.target_dir = tmp_path
+
+        debug_file = tmp_path / "debug.log"
+        monkeypatch.setenv("CHUNKHOUND_DEBUG_FILE", str(debug_file))
+
+        with patch("chunkhound.mcp_server.base.create_services") as mock_create:
+            mock_services = MagicMock()
+            mock_services.provider.is_connected = False
+            mock_create.return_value = mock_services
+
+            with patch("chunkhound.mcp_server.base.EmbeddingManager"):
+                server = ConcreteMCPServer(config=config)
+                await server.initialize()
+                await server.cleanup()
+
+        assert not debug_file.exists() or "No existing index found" not in (
+            debug_file.read_text()
+        )
+
+
 class TestCleanup:
     """Verify cleanup invariants for connected providers."""
 


### PR DESCRIPTION
## Root cause

`get_db_path()` applies the provider's real file/directory resolution (legacy flat-file installs, or `--db` pointed at a directory whose actual index lives elsewhere), and that can diverge from the raw `database.path` value. Nothing on the MCP startup path (`mcp_server/base.py`) checked for this: `create_services()` connects eagerly (despite its "lazy connect" comment) and DuckDB auto-creates an empty database with a fresh schema at whatever path it resolves to. A stale `--db` then looks identical to a project that has simply never been indexed: every search tool returns 0 results with no signal anywhere an operator could see.

This is the MCP half of #226. The CLI half (`chunkhound search`/`research`/`code_mapper`) already has a hard `FileNotFoundError` via `verify_database_exists()`; that guard isn't in the MCP path, and shouldn't be applied verbatim there since a fresh, never-indexed project is a normal MCP entry point, not an error. PR #245 covers the other, disjoint half of #226 (`core/config/database_config.py`), so this is `Refs #226` rather than `Fixes #226`.

## Fix

Log the `get_db_path()`-resolved path before `create_services()` runs, when it does not already exist on disk. Purely diagnostic: startup behavior is unchanged either way, so a legitimate fresh project still indexes normally. The message goes through `debug_log(..., always=True)`, the same MCP-safe file sink (`CHUNKHOUND_DEBUG_FILE`) other startup diagnostics in this class already use, so it never touches stdout/JSON-RPC.

## Verification

- New regression test (`tests/test_mcp_initialization_invariant.py::TestMissingIndexVisibility`): fails on `main` (no log line, `FileNotFoundError` reading the debug file) and passes on this branch, for both the missing-path and already-exists cases.
- Live repro against the exact `--db` shape from #226 (point at the `.chunkhound` directory of a repo indexed by an older layout): before this change, an MCP session started clean with zero diagnostic anywhere; after, the debug log records `No existing index found at .../chunks.db`.
- `tests/test_mcp_initialization_invariant.py` (15), the other MCP test files that exercise `base.py` (118), and `tests/test_smoke.py` (25) all pass. `ruff check`/`ruff format --check`/`mypy` on the changed files show no new findings versus `main` (the one existing `mypy`/`ruff` finding in this file is pre-existing and untouched by this diff).
- Not checked: behavior when the resolved path is a LanceDB directory rather than a DuckDB file (no LanceDB-configured repro was set up this pass); the code path is provider-agnostic (`get_db_path()` handles both), but only the DuckDB case was exercised end to end.