### PR TITLE
fix(parsers): import pymupdf instead of fitz to keep MCP stdout clean (#393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Configurable via `fetchurl.rerank_threshold_tokens` (default 15000), `fetchurl.truncate_tokens` (default 15000), and `fetchurl.max_retries` (default 3), or their `CHUNKHOUND_FETCHURL_*` env-var equivalents.
   - Uses the same zendriver + system Chrome transport as `websearch`, with `urllib` fallback.
 
+### Fixed
+- **PyMuPDF `fitz` import deprecation warning on stdout** — PDF parsing now imports `pymupdf` instead of the legacy `fitz` alias, which since PyMuPDF 1.28.2 prints a deprecation warning to stdout and corrupts MCP stdio clients (e.g. CURe preflight). Adds a regression test asserting parser imports write nothing to stdout.
+
 ## [5.2.0] - 2026-07-12
 
 ### Breaking Changes

--- a/chunkhound/parsers/mappings/pdf.py
+++ b/chunkhound/parsers/mappings/pdf.py
@@ -25,7 +25,7 @@ from chunkhound.parsers.mappings.base import BaseMapping
 from chunkhound.parsers.universal_engine import UniversalConcept
 
 try:
-    import fitz  # type: ignore  # PyMuPDF
+    import pymupdf as fitz  # type: ignore  # PyMuPDF
 
     PYMUPDF_AVAILABLE = True
 except ImportError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ pandas>=2.3.0
 psutil>=7.1.0
 watchdog>=6.0.0
 readchar>=4.2.0
-pymupdf>=1.26.0
+pymupdf>=1.27.0
 
 # Tree-sitter language support
 tree-sitter-hcl>=1.2.0

--- a/tests/test_parser_mappings_import.py
+++ b/tests/test_parser_mappings_import.py
@@ -1,0 +1,20 @@
+"""Import invariants for parser mappings."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_import_writes_nothing_to_stdout() -> None:
+    """Parser imports must not corrupt stdout-based protocols such as MCP."""
+    completed = subprocess.run(
+        [sys.executable, "-c", "import chunkhound.parsers.mappings"],
+        cwd=Path(__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == ""

--- a/tests/test_pdf_indexing_integration.py
+++ b/tests/test_pdf_indexing_integration.py
@@ -19,7 +19,7 @@ from chunkhound.core.models.chunk import Chunk
 
 # Import conditional PyMuPDF test skip
 try:
-    import fitz  # PyMuPDF
+    import pymupdf as fitz  # PyMuPDF
     PYMUPDF_AVAILABLE = True
 except ImportError:
     PYMUPDF_AVAILABLE = False


### PR DESCRIPTION
Closes #393

## Problem
PyMuPDF 1.28.2 (published 2026-08-06) prints a deprecation warning to **stdout** when the legacy `fitz` module is imported:

```text
warning: The `fitz` API is deprecated and will be removed in future. Use `import pymupdf` instead.
```

ChunkHound's PDF mapping imports `fitz` at module level (`chunkhound/parsers/mappings/__init__.py` imports it eagerly), so any MCP stdio session loading chunkhound corrupts the JSON-RPC stdout stream. Strict clients fail, e.g. CURe's helper preflight: *"unexpected chunkhound mcp stdout: warning: The 'fitz' API is deprecated…"*.

The warning is a direct `print()` from PyMuPDF's fitz shim — not a `warnings.warn()` — so the existing stdout-hygiene in `chunkhound/mcp_server/stdio.py` (swig filter, `logging.disable`, loguru silencing) cannot suppress it. The only real fix is to stop importing `fitz`.

## Changes
- `chunkhound/parsers/mappings/pdf.py`: `import fitz` → `import pymupdf as fitz` (drop-in; both `fitz.open(...)` call sites unchanged, availability guard unchanged).
- `tests/test_pdf_indexing_integration.py`: same swap in the PyMuPDF skip guard.
- `tests/test_parser_mappings_import.py` (new): subprocess regression test asserting `import chunkhound.parsers.mappings` writes nothing to stdout.
- `requirements.txt`: align `pymupdf` lower bound with pyproject.toml (`>=1.27.0`).
- `CHANGELOG.md`: Unreleased → Fixed entry.

## Verification
- `pytest tests/test_parser_mappings_import.py tests/test_pdf_indexing_integration.py` → 6 passed.
- Scratch venv with pymupdf==1.28.2:
  - `import fitz` → warning printed to stdout (repro).
  - `import pymupdf` → clean.
  - `import chunkhound.parsers.mappings` with the fix → empty stdout.
- No remaining `import fitz` in source/tests.

Happy to retest against any changes.