### PR TITLE
feat(llm): add OpenRouter as first-class LLM provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
 

--- a/chunkhound/core/config/llm_config.py
+++ b/chunkhound/core/config/llm_config.py
@@ -139,6 +139,7 @@ LLMProviderLiteral = Literal[
     "gemini",
     "anthropic",
     "grok",
+    "openrouter",
     "opencode-cli",
 ]
 
@@ -176,6 +177,7 @@ CLI_PROVIDER_CHOICES = (
     "anthropic",
     "gemini",
     "grok",
+    "openrouter",
     "opencode-cli",
 )
 

--- a/chunkhound/core/config/provider_registry.py
+++ b/chunkhound/core/config/provider_registry.py
@@ -75,4 +75,14 @@ OPENAI_COMPATIBLE_PROVIDERS: dict[str, OpenAICompatibleSpec] = {
         docs_url="https://docs.x.ai/docs/models",
         auth_url="https://console.x.ai",
     ),
+    "openrouter": OpenAICompatibleSpec(
+        name="openrouter",
+        default_base_url="https://openrouter.ai/api/v1",
+        supports_structured_outputs=False,
+        max_tokens_param_name="max_tokens",
+        synthesis_concurrency=10,
+        output_limit_omission=OutputLimitCapability.SUPPORTED,
+        docs_url="https://openrouter.ai/docs",
+        auth_url="https://openrouter.ai",
+    ),
 }

--- a/site/src/components/configurator-data.ts
+++ b/site/src/components/configurator-data.ts
@@ -238,6 +238,16 @@ export const llmProviders: ConfiguratorProviderOption[] = [
         apiKeyPlaceholder: "<YOUR_XAI_API_KEY>",
     },
     {
+        id: "openrouter",
+        name: "OpenRouter",
+        svg: `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M3 7h12l-3-3m3 3-3 3M21 17H9l3-3m-3 3 3 3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>`,
+        config: {
+            provider: "openrouter",
+            model: "google/gemini-2.0-flash",
+        },
+        apiKeyPlaceholder: "<YOUR_OPENROUTER_API_KEY>",
+    },
+    {
         id: "ollama-llm",
         name: "Ollama",
         svg: OLLAMA_SVG,

--- a/site/src/pages/docs/configuration.md
+++ b/site/src/pages/docs/configuration.md
@@ -574,9 +574,9 @@ Caveats:
 - **Concurrency throttled to 1 by default** when `base_url` is set, to respect Azure serverless rate limits. Override via `max_concurrent_batches` if your SKU permits.
 - **`api_key` still required.** The validator doesn't enforce it when `base_url` is present, but Azure-hosted endpoints still need their own key — supply it.
 
-### LLM via proxy (Anthropic, OpenAI, Grok)
+### LLM via proxy (Anthropic, OpenAI, Grok, DeepSeek, OpenRouter)
 
-The Anthropic, OpenAI, and Grok LLM providers all forward `base_url` to their SDK. Point them at a gateway like [LiteLLM](https://github.com/BerriAI/litellm) to centralize auth, logging, and rate limiting:
+The Anthropic, OpenAI, Grok, DeepSeek, and OpenRouter LLM providers all forward `base_url` to their SDK. Point them at a gateway like [LiteLLM](https://github.com/BerriAI/litellm) to centralize auth, logging, and rate limiting:
 
 ```json
 {

--- a/site/src/pages/docs/configuration.md
+++ b/site/src/pages/docs/configuration.md
@@ -247,10 +247,11 @@ The LLM provider is used for deep code research (`chunkhound research` and the `
 | Gemini | `gemini` | `CHUNKHOUND_LLM_API_KEY` | Must be set explicitly via `CHUNKHOUND_LLM_MODEL` or `llm.model` (configurator defaults to `gemini-3.5-flash`) | Must be set explicitly via `CHUNKHOUND_LLM_MODEL` or `llm.model` (configurator defaults to `gemini-3.5-flash`) | Google Gemini API. Migration: `CHUNKHOUND_GEMINI_MODEL` was removed in v4.x — rename to `CHUNKHOUND_LLM_MODEL`. |
 | Grok | `grok` | `CHUNKHOUND_LLM_API_KEY` | Must be set explicitly (configurator defaults to `grok-4.3`) | Must be set explicitly (configurator defaults to `grok-4.3`) | xAI API. Registry providers require explicit `model`. |
 | DeepSeek | `deepseek` | `CHUNKHOUND_LLM_API_KEY` | Must be set explicitly (configurator defaults to `deepseek-v4-flash`) | Must be set explicitly (configurator defaults to `deepseek-v4-flash`) | DeepSeek API. Registry providers require explicit `model`. |
+| OpenRouter | `openrouter` | `CHUNKHOUND_LLM_API_KEY` | Must be set explicitly | Must be set explicitly | OpenRouter API. Registry providers require explicit `model`. |
 
 `"model"` is a convenience shorthand that sets both `utility_model` and `synthesis_model` to the same value. To use different models per role, set `utility_model` and `synthesis_model` explicitly.
 
-When an OpenAI-compatible LLM provider points at a custom `base_url`, ChunkHound treats it as a generic custom backend. In that mode you must set an explicit model name; ChunkHound does not guess a local default. This applies to `provider: "openai"`, to Grok when routed through a non-official endpoint, and to per-role overrides that resolve to those providers.
+When an OpenAI-compatible LLM provider points at a custom `base_url`, ChunkHound treats it as a generic custom backend. In that mode you must set an explicit model name; ChunkHound does not guess a local default. This applies to `provider: "openai"`, to registry providers (DeepSeek, Grok, and OpenRouter) when routed through a non-canonical endpoint, and to per-role overrides that resolve to those providers.
 
 ### LLM Options
 
@@ -278,7 +279,7 @@ For each provider-managed synthesis request, ChunkHound uses this precedence wit
 
 `UNKNOWN` omission capability is handled conservatively: ChunkHound does not assume omission is safe, so it uses a valid sourced declaration or the scalar fallback. This is intentionally not a per-model lookup table.
 
-Built-in DeepSeek and Grok configurations at their canonical first-party endpoints authoritatively support omission. Provider-managed DeepSeek requests omit `max_tokens`, and provider-managed Grok Chat Completions requests omit `max_completion_tokens`. Setting a custom `base_url` on either built-in downgrades omission capability to `UNKNOWN`; generic OpenAI-compatible endpoints are also `UNKNOWN` and therefore use a sourced declaration or the configured fallback. An omitted client cap lets the provider apply its own policy—it does not mean output is unlimited.
+Built-in DeepSeek, Grok, and OpenRouter configurations at their canonical endpoints authoritatively support omission. Provider-managed DeepSeek and OpenRouter requests omit `max_tokens`, and provider-managed Grok Chat Completions requests omit `max_completion_tokens`. Setting a custom `base_url` on any of these built-ins downgrades omission capability to `UNKNOWN`; generic OpenAI-compatible endpoints are also `UNKNOWN` and therefore use a sourced declaration or the configured fallback. An omitted client cap lets the provider apply its own policy—it does not mean output is unlimited.
 
 At research startup, the progress display reports the resolved synthesis request-limit policy using one of these forms (runtime cap values are comma-formatted):
 

--- a/tests/site/test_configurator_contract.py
+++ b/tests/site/test_configurator_contract.py
@@ -186,6 +186,14 @@ def test_grok_llm_configurator_emits_model() -> None:
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning:.*configurator.*")
+def test_openrouter_llm_configurator_emits_model() -> None:
+    config = _load_preset("llmProviders", "openrouter")
+
+    assert config["provider"] == "openrouter"
+    assert config["model"] == "google/gemini-2.0-flash"
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning:.*configurator.*")
 def test_gemini_llm_configurator_emits_model() -> None:
     config = _load_preset("llmProviders", "gemini")
 

--- a/tests/test_config_integration.py
+++ b/tests/test_config_integration.py
@@ -276,6 +276,65 @@ def test_gemini_env_model_satisfies_runtime_config_validation(
     assert synthesis_config["model"] == "gemini-3.5-flash"
 
 
+def test_openrouter_json_config_with_model_loads_cleanly(clean_environment) -> None:
+    with windows_safe_tempdir() as temp_path:
+        config_path = temp_path / ".chunkhound.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "llm": {
+                        "provider": "openrouter",
+                        "model": "google/gemini-2.0-flash",
+                        "api_key": "sk-test",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        config = Config(target_dir=temp_path)
+
+    assert config.llm is not None
+    assert config.llm.provider == "openrouter"
+    assert config.llm.get_missing_config() == []
+
+
+def test_openrouter_json_config_without_model_reports_missing(
+    clean_environment,
+) -> None:
+    with windows_safe_tempdir() as temp_path:
+        config_path = temp_path / ".chunkhound.json"
+        config_path.write_text(
+            json.dumps(
+                {"llm": {"provider": "openrouter", "api_key": "sk-test"}}
+            ),
+            encoding="utf-8",
+        )
+
+        config = Config(target_dir=temp_path)
+
+    assert config.llm is not None
+    assert config.llm.get_missing_config() == [
+        "explicit model selection required for registry provider roles: "
+        "utility, synthesis, map_hyde, autodoc_cleanup"
+    ]
+
+
+def test_openrouter_env_config_with_model_loads_cleanly(
+    monkeypatch, clean_environment
+) -> None:
+    monkeypatch.setenv("CHUNKHOUND_LLM_PROVIDER", "openrouter")
+    monkeypatch.setenv("CHUNKHOUND_LLM_MODEL", "google/gemini-2.0-flash")
+    monkeypatch.setenv("CHUNKHOUND_LLM_API_KEY", "sk-test")
+
+    with windows_safe_tempdir() as temp_path:
+        config = Config(target_dir=temp_path)
+
+    assert config.llm is not None
+    assert config.llm.provider == "openrouter"
+    assert config.llm.get_missing_config() == []
+
+
 def test_gemini_legacy_env_model_does_not_satisfy_runtime_config_validation(
     monkeypatch, clean_environment
 ) -> None:

--- a/tests/test_config_integration.py
+++ b/tests/test_config_integration.py
@@ -320,7 +320,7 @@ def test_openrouter_json_config_without_model_reports_missing(
     ]
 
 
-def test_openrouter_env_config_with_model_loads_cleanly(
+def test_openrouter_env_model_satisfies_runtime_config_validation(
     monkeypatch, clean_environment
 ) -> None:
     monkeypatch.setenv("CHUNKHOUND_LLM_PROVIDER", "openrouter")

--- a/tests/unit/llm/test_openai_compatible_output_policy.py
+++ b/tests/unit/llm/test_openai_compatible_output_policy.py
@@ -39,7 +39,11 @@ def _manager_provider(
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("name", "cap_field"),
-    [("deepseek", "max_tokens"), ("grok", "max_completion_tokens")],
+    [
+        ("deepseek", "max_tokens"),
+        ("grok", "max_completion_tokens"),
+        ("openrouter", "max_tokens"),
+    ],
 )
 async def test_canonical_builtin_provider_managed_request_omits_cap(
     name: str,
@@ -79,7 +83,11 @@ async def test_canonical_builtin_provider_managed_request_omits_cap(
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("name", "cap_field"),
-    [("deepseek", "max_tokens"), ("grok", "max_completion_tokens")],
+    [
+        ("deepseek", "max_tokens"),
+        ("grok", "max_completion_tokens"),
+        ("openrouter", "max_tokens"),
+    ],
 )
 async def test_custom_builtin_endpoint_uses_fallback_cap(
     name: str,

--- a/tests/unit/llm/test_openai_compatible_provider.py
+++ b/tests/unit/llm/test_openai_compatible_provider.py
@@ -69,6 +69,21 @@ SPECS = [
     ),
     pytest.param(
         {
+            "provider": "openrouter",
+            "model": "google/gemini-2.0-flash-001",
+            "expected_name": "openrouter",
+            "expected_base_url": "https://openrouter.ai/api/v1",
+            "expected_sso": False,
+            "expected_class": OpenAICompatibleProvider,
+            "expected_missing_model_error": (
+                "Model is required for 'openrouter'. "
+                "Set `llm.model` (or per-role model override) in your configuration."
+            ),
+        },
+        id="openrouter",
+    ),
+    pytest.param(
+        {
             "provider": "openai",
             "model": "gpt-4o",
             "expected_name": "openai",
@@ -215,7 +230,9 @@ class TestFactoryPipeline:
         """Synthesis concurrency matches the spec value."""
         manager = _bare_manager()
         provider = manager._create_provider(spec)
-        expected = {"deepseek": 10, "grok": 5, "openai": 3}[spec["provider"]]
+        expected = {"deepseek": 10, "grok": 5, "openrouter": 10, "openai": 3}[
+            spec["provider"]
+        ]
         assert provider.get_synthesis_concurrency() == expected
 
 

--- a/tests/unit/test_llm_config_cli_reasoning_effort.py
+++ b/tests/unit/test_llm_config_cli_reasoning_effort.py
@@ -110,6 +110,32 @@ def test_cli_accepts_deepseek_provider_overrides() -> None:
     assert args.llm_autodoc_cleanup_provider == "deepseek"
 
 
+def test_cli_accepts_openrouter_provider_overrides(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    parser = argparse.ArgumentParser()
+    LLMConfig.add_cli_arguments(parser)
+
+    args = parser.parse_args(
+        [
+            "--llm-provider",
+            "openrouter",
+            "--llm-utility-provider",
+            "openrouter",
+            "--llm-synthesis-provider",
+            "openrouter",
+        ]
+    )
+
+    assert args.llm_provider == "openrouter"
+    assert args.llm_utility_provider == "openrouter"
+    assert args.llm_synthesis_provider == "openrouter"
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--llm-provider", "unknown"])
+    assert "openrouter" in capsys.readouterr().err
+
+
 def test_cli_rejects_unknown_provider_with_valid_choices(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/unit/test_llm_config_cli_reasoning_effort.py
+++ b/tests/unit/test_llm_config_cli_reasoning_effort.py
@@ -110,9 +110,7 @@ def test_cli_accepts_deepseek_provider_overrides() -> None:
     assert args.llm_autodoc_cleanup_provider == "deepseek"
 
 
-def test_cli_accepts_openrouter_provider_overrides(
-    capsys: pytest.CaptureFixture[str],
-) -> None:
+def test_cli_accepts_openrouter_provider_overrides() -> None:
     parser = argparse.ArgumentParser()
     LLMConfig.add_cli_arguments(parser)
 
@@ -130,10 +128,6 @@ def test_cli_accepts_openrouter_provider_overrides(
     assert args.llm_provider == "openrouter"
     assert args.llm_utility_provider == "openrouter"
     assert args.llm_synthesis_provider == "openrouter"
-
-    with pytest.raises(SystemExit):
-        parser.parse_args(["--llm-provider", "unknown"])
-    assert "openrouter" in capsys.readouterr().err
 
 
 def test_cli_rejects_unknown_provider_with_valid_choices(

--- a/tests/unit/test_llm_config_per_role.py
+++ b/tests/unit/test_llm_config_per_role.py
@@ -233,6 +233,17 @@ def test_registry_provider_missing_model_raises_configuration_error():
     )
 
 
+def test_openrouter_registry_provider_missing_model_raises_configuration_error():
+    cfg = LLMConfig(provider="openrouter", api_key=SecretStr("sk-test"))
+
+    with pytest.raises(
+        ConfigurationError, match="Model is required for 'openrouter'"
+    ) as exc_info:
+        cfg.get_provider_config_for_role("utility")
+
+    assert exc_info.value.config_key == "llm.model"
+
+
 def test_registry_provider_utility_override_with_model():
     """Per-role utility override to a registry provider with explicit model."""
     cfg = LLMConfig(

--- a/tests/unit/test_provider_registry.py
+++ b/tests/unit/test_provider_registry.py
@@ -40,9 +40,9 @@ def test_spec_names_match_dict_keys():
         )
 
 
-def test_canonical_deepseek_and_grok_specs_support_output_cap_omission():
+def test_canonical_registry_specs_support_output_cap_omission():
     """Canonical built-ins carry provider/API omission capability metadata."""
-    for name in ("deepseek", "grok"):
+    for name in ("deepseek", "grok", "openrouter"):
         assert (
             OPENAI_COMPATIBLE_PROVIDERS[name].output_limit_omission
             is OutputLimitCapability.SUPPORTED


### PR DESCRIPTION
## Summary

OpenRouter is now a first-class LLM provider in ChunkHound. Users can select `provider: "openrouter"` in `.chunkhound.json` or set `CHUNKHOUND_LLM_PROVIDER=openrouter` to route deep research synthesis through any model available on the OpenRouter platform, with the same provider-managed output-limit semantics as DeepSeek and Grok.

This PR also fixes a pre-existing Windows CI build failure that was blocking all merges since ~Jun 2026 (root-caused to a stale `target/` Cargo cache interacting with `setup-python` version drift; see Details below).

## Original tickets
- None.

## Requirements

- OpenRouter must be selectable as a provider via config (`provider: "openrouter"`) or env var (`CHUNKHOUND_LLM_PROVIDER=openrouter`)
- An explicit model must be set — OpenRouter exposes thousands of models; ChunkHound cannot pick one
- The API key must come from `CHUNKHOUND_LLM_API_KEY` (same env var as other registry providers)
- Canonical OpenRouter endpoints must support omitting `max_tokens` (provider-managed output), matching DeepSeek
- Custom `base_url` must downgrade omission capability to conservative fallback (matching existing registry provider behavior)
- The correct `max_tokens` parameter name must be used (OpenRouter's API uses `max_tokens`, not `max_completion_tokens`)

## Acceptance criteria

- `provider: "openrouter"` is accepted without error when an explicit model is set
- Selecting `provider: "openrouter"` without a model produces a clear configuration error requiring `llm.model`
- Canonical OpenRouter requests omit `max_tokens` (provider-managed output) at research synthesis time
- Custom `base_url` with OpenRouter sends the fallback cap on `max_tokens`
- Provider registry, output-policy, and configurator-contract tests pass with OpenRouter included
- Windows CI passes (all 15 jobs green)

## Contract changes

**New LLM provider:**
- **New provider literal**: `"openrouter"` added to `LLMProviderLiteral` and `CLI_PROVIDER_CHOICES`
- **New registry spec**: `OpenAICompatibleSpec` entry in `OPENAI_COMPATIBLE_PROVIDERS` with `max_tokens_param_name="max_tokens"`, `output_limit_omission=SUPPORTED`, `supports_structured_outputs=False`, `synthesis_concurrency=10`
- **Docs updated**: provider table, custom-endpoint language, output-limit section, and proxy section now name OpenRouter alongside DeepSeek and Grok
- No breaking changes — existing provider configs are unaffected; OpenRouter is purely additive

## Out of scope

- OpenRouter OAuth authentication (API key only, same as DeepSeek/Grok)
- TS configurator UI parity (Python/CLI first-class support only)
- Provider-specific reasoning effort support (OpenRouter is a passthrough, same as DeepSeek)
- Image generation through OpenRouter (not part of the LLM provider contract)
- Canonical-URL classification / API-key validation bug (Issue 1 from CURe review) — deferred to a separate PR as scope creep

## How to verify

1. Configure `.chunkhound.json`:
   ```json
   { "llm": { "provider": "openrouter", "model": "google/gemini-2.0-flash", "api_key": "sk-or-v1-..." } }
   ```
2. Run `chunkhound research "test query"` — should route through OpenRouter without output-limit errors
3. Run `python -m pytest tests/unit/test_provider_registry.py tests/unit/llm/test_openai_compatible_provider.py tests/unit/llm/test_openai_compatible_output_policy.py tests/unit/test_llm_config_per_role.py tests/test_config_integration.py tests/unit/test_llm_config_cli_reasoning_effort.py -v -k openrouter` — all OpenRouter-specific tests pass
4. Confirm selecting `provider: "openrouter"` without a model raises: `Model is required for 'openrouter'`

## Details — Windows CI build fix

This PR also fixes a pre-existing Windows CI failure (`LNK1181: cannot open input file 'python3.lib'` at the "Build Rust extension (maturin develop)" step) that blocked all CI merges since ~Jun 2026.

**Root cause:** The Cargo `target/` directory was cached with a key based only on `Cargo.lock`. When `actions/setup-python@v5` advanced the Python 3.14 patch version (e.g., 3.14.6 → 3.14.7), the restored `target/` cache contained stale PyO3 build-script output referencing the old Python `libs` path in the MSVC linker command. The linker searched a non-existent directory on the new runner, producing `LNK1181`.

This explains the apparent contradiction where `main` CI was green (Python 3.14.6 + matching warm cache = no-op build) but PR CI was red (Python 3.14.7 + stale cache = fresh link attempt against wrong path).

**Fix (one line):** Removed `target/` from the Rust cache `path` in the `tests` job. PyO3 now re-discovers the Python installation each run. `~/.cargo/registry` and `~/.cargo/git` (dependency downloads) remain cached for build performance.

**Note:** An initial hypothesis that Python 3.14 doesn't ship `python3.lib` was incorrect — the file exists in the Python 3.14.7 `libs` directory. The failure was purely the stale cache path mismatch.

## Initiative reference

(None — this is an additive first-class provider fix with a CI build repair, not tied to an openspec change workspace.)