### PR TITLE
feat(config): add OrcaRouter as an OpenAI-compatible LLM provider

### DIFF
--- a/chunkhound/core/config/llm_config.py
+++ b/chunkhound/core/config/llm_config.py
@@ -140,6 +140,7 @@ LLMProviderLiteral = Literal[
     "anthropic",
     "grok",
     "openrouter",
+    "orcarouter",
     "opencode-cli",
 ]
 
@@ -178,6 +179,7 @@ CLI_PROVIDER_CHOICES = (
     "gemini",
     "grok",
     "openrouter",
+    "orcarouter",
     "opencode-cli",
 )
 

--- a/chunkhound/core/config/provider_registry.py
+++ b/chunkhound/core/config/provider_registry.py
@@ -85,4 +85,14 @@ OPENAI_COMPATIBLE_PROVIDERS: dict[str, OpenAICompatibleSpec] = {
         docs_url="https://openrouter.ai/docs",
         auth_url="https://openrouter.ai",
     ),
+    "orcarouter": OpenAICompatibleSpec(
+        name="orcarouter",
+        default_base_url="https://api.orcarouter.ai/v1",
+        supports_structured_outputs=False,
+        max_tokens_param_name="max_tokens",
+        synthesis_concurrency=10,
+        output_limit_omission=OutputLimitCapability.SUPPORTED,
+        docs_url="https://docs.orcarouter.ai",
+        auth_url="https://www.orcarouter.ai",
+    ),
 }

--- a/site/src/components/configurator-data.ts
+++ b/site/src/components/configurator-data.ts
@@ -248,6 +248,16 @@ export const llmProviders: ConfiguratorProviderOption[] = [
         apiKeyPlaceholder: "<YOUR_OPENROUTER_API_KEY>",
     },
     {
+        id: "orcarouter",
+        name: "OrcaRouter",
+        svg: `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M4 6h9a3 3 0 0 1 3 3v6a3 3 0 0 0 3 3h1M4 12h15M4 18h5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>`,
+        config: {
+            provider: "orcarouter",
+            model: "anthropic/claude-sonnet-5",
+        },
+        apiKeyPlaceholder: "<YOUR_ORCAROUTER_API_KEY>",
+    },
+    {
         id: "ollama-llm",
         name: "Ollama",
         svg: OLLAMA_SVG,

--- a/site/src/pages/docs/configuration.md
+++ b/site/src/pages/docs/configuration.md
@@ -248,10 +248,11 @@ The LLM provider is used for deep code research (`chunkhound research` and the `
 | Grok | `grok` | `CHUNKHOUND_LLM_API_KEY` | Must be set explicitly (configurator defaults to `grok-4.3`) | Must be set explicitly (configurator defaults to `grok-4.3`) | xAI API. Registry providers require explicit `model`. |
 | DeepSeek | `deepseek` | `CHUNKHOUND_LLM_API_KEY` | Must be set explicitly (configurator defaults to `deepseek-v4-flash`) | Must be set explicitly (configurator defaults to `deepseek-v4-flash`) | DeepSeek API. Registry providers require explicit `model`. |
 | OpenRouter | `openrouter` | `CHUNKHOUND_LLM_API_KEY` | Must be set explicitly | Must be set explicitly | OpenRouter API. Registry providers require explicit `model`. |
+| OrcaRouter | `orcarouter` | `CHUNKHOUND_LLM_API_KEY` | Must be set explicitly | Must be set explicitly | OrcaRouter API. Registry providers require explicit `model`. |
 
 `"model"` is a convenience shorthand that sets both `utility_model` and `synthesis_model` to the same value. To use different models per role, set `utility_model` and `synthesis_model` explicitly.
 
-When an OpenAI-compatible LLM provider points at a custom `base_url`, ChunkHound treats it as a generic custom backend. In that mode you must set an explicit model name; ChunkHound does not guess a local default. This applies to `provider: "openai"`, to registry providers (DeepSeek, Grok, and OpenRouter) when routed through a non-canonical endpoint, and to per-role overrides that resolve to those providers.
+When an OpenAI-compatible LLM provider points at a custom `base_url`, ChunkHound treats it as a generic custom backend. In that mode you must set an explicit model name; ChunkHound does not guess a local default. This applies to `provider: "openai"`, to registry providers (DeepSeek, Grok, OpenRouter, and OrcaRouter) when routed through a non-canonical endpoint, and to per-role overrides that resolve to those providers.
 
 ### LLM Options
 
@@ -574,9 +575,9 @@ Caveats:
 - **Concurrency throttled to 1 by default** when `base_url` is set, to respect Azure serverless rate limits. Override via `max_concurrent_batches` if your SKU permits.
 - **`api_key` still required.** The validator doesn't enforce it when `base_url` is present, but Azure-hosted endpoints still need their own key — supply it.
 
-### LLM via proxy (Anthropic, OpenAI, Grok, DeepSeek, OpenRouter)
+### LLM via proxy (Anthropic, OpenAI, Grok, DeepSeek, OpenRouter, OrcaRouter)
 
-The Anthropic, OpenAI, Grok, DeepSeek, and OpenRouter LLM providers all forward `base_url` to their SDK. Point them at a gateway like [LiteLLM](https://github.com/BerriAI/litellm) to centralize auth, logging, and rate limiting:
+The Anthropic, OpenAI, Grok, DeepSeek, OpenRouter, and OrcaRouter LLM providers all forward `base_url` to their SDK. Point them at a gateway like [LiteLLM](https://github.com/BerriAI/litellm) or [OrcaRouter](https://www.orcarouter.ai) to centralize auth, logging, and rate limiting:
 
 ```json
 {

--- a/tests/site/test_configurator_contract.py
+++ b/tests/site/test_configurator_contract.py
@@ -194,6 +194,14 @@ def test_openrouter_llm_configurator_emits_model() -> None:
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning:.*configurator.*")
+def test_orcarouter_llm_configurator_emits_model() -> None:
+    config = _load_preset("llmProviders", "orcarouter")
+
+    assert config["provider"] == "orcarouter"
+    assert config["model"] == "anthropic/claude-sonnet-5"
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning:.*configurator.*")
 def test_gemini_llm_configurator_emits_model() -> None:
     config = _load_preset("llmProviders", "gemini")
 

--- a/tests/unit/llm/test_openai_compatible_output_policy.py
+++ b/tests/unit/llm/test_openai_compatible_output_policy.py
@@ -43,6 +43,7 @@ def _manager_provider(
         ("deepseek", "max_tokens"),
         ("grok", "max_completion_tokens"),
         ("openrouter", "max_tokens"),
+        ("orcarouter", "max_tokens"),
     ],
 )
 async def test_canonical_builtin_provider_managed_request_omits_cap(
@@ -87,6 +88,7 @@ async def test_canonical_builtin_provider_managed_request_omits_cap(
         ("deepseek", "max_tokens"),
         ("grok", "max_completion_tokens"),
         ("openrouter", "max_tokens"),
+        ("orcarouter", "max_tokens"),
     ],
 )
 async def test_custom_builtin_endpoint_uses_fallback_cap(

--- a/tests/unit/llm/test_openai_compatible_provider.py
+++ b/tests/unit/llm/test_openai_compatible_provider.py
@@ -84,6 +84,21 @@ SPECS = [
     ),
     pytest.param(
         {
+            "provider": "orcarouter",
+            "model": "anthropic/claude-sonnet-5",
+            "expected_name": "orcarouter",
+            "expected_base_url": "https://api.orcarouter.ai/v1",
+            "expected_sso": False,
+            "expected_class": OpenAICompatibleProvider,
+            "expected_missing_model_error": (
+                "Model is required for 'orcarouter'. "
+                "Set `llm.model` (or per-role model override) in your configuration."
+            ),
+        },
+        id="orcarouter",
+    ),
+    pytest.param(
+        {
             "provider": "openai",
             "model": "gpt-4o",
             "expected_name": "openai",
@@ -230,9 +245,9 @@ class TestFactoryPipeline:
         """Synthesis concurrency matches the spec value."""
         manager = _bare_manager()
         provider = manager._create_provider(spec)
-        expected = {"deepseek": 10, "grok": 5, "openrouter": 10, "openai": 3}[
-            spec["provider"]
-        ]
+        expected = {
+            "deepseek": 10, "grok": 5, "openrouter": 10, "orcarouter": 10, "openai": 3
+        }[spec["provider"]]
         assert provider.get_synthesis_concurrency() == expected
 
 

--- a/tests/unit/test_provider_registry.py
+++ b/tests/unit/test_provider_registry.py
@@ -42,7 +42,7 @@ def test_spec_names_match_dict_keys():
 
 def test_canonical_registry_specs_support_output_cap_omission():
     """Canonical built-ins carry provider/API omission capability metadata."""
-    for name in ("deepseek", "grok", "openrouter"):
+    for name in ("deepseek", "grok", "openrouter", "orcarouter"):
         assert (
             OPENAI_COMPATIBLE_PROVIDERS[name].output_limit_omission
             is OutputLimitCapability.SUPPORTED


### PR DESCRIPTION
## What

Adds **OrcaRouter** as a named OpenAI-compatible LLM provider in the data-driven provider registry, mirroring the existing `openrouter` entry. OrcaRouter is an Anthropic-compatible gateway whose OpenAI-compatible endpoint (`https://api.orcarouter.ai/v1`) passes through to Claude models, so it drops into the shared `OpenAICompatibleProvider` path with no protocol special-casing.

### Changes

- **`chunkhound/core/config/provider_registry.py`**: `orcarouter` spec in `OPENAI_COMPATIBLE_PROVIDERS` (canonical `https://api.orcarouter.ai/v1`, `max_tokens` output-cap param, output-cap omission supported, `docs_url`/`auth_url`)
- **`chunkhound/core/config/llm_config.py`**: `orcarouter` added to `LLMProviderLiteral` and `CLI_PROVIDER_CHOICES` (no reasoning-effort support — matches OpenRouter)
- **`site/src/components/configurator-data.ts`**: `orcarouter` card in the `llmProviders` picker (default model `anthropic/claude-sonnet-5`)
- **`site/src/pages/docs/configuration.md`**: provider table row + proxy-section mention
- **tests**: parametrized provider-registry spec coverage, `test_openai_compatible_provider.py` SPECS + synthesis-concurrency map, output-policy `max_tokens` cases, and a site configurator contract test

## Why

OpenRouter is a first-class named provider in ChunkHound's registry; OrcaRouter offers the same universal-gateway convenience with a simpler, fully Anthropic-compatible surface. Users who want to route research through [OrcaRouter](https://www.orcarouter.ai) can now pick `provider: orcarouter` instead of hand-rolling a custom OpenAI-compatible `base_url`.

## Notes

- Endpoint probed live: `GET https://api.orcarouter.ai/v1/models` returns namespaced `anthropic/*` ids (`anthropic/claude-sonnet-5`, `anthropic/claude-haiku-4.5`, …); `POST /v1/chat/completions` with `anthropic/claude-sonnet-5` returns valid completions both with and without `max_tokens`.
- OrcaRouter's OpenAI-compatible path does not accept OpenAI-style `json_schema` `response_format` (Anthropic schema strictness leaks through the translation layer), so `supports_structured_outputs` stays `False` — same as the OpenRouter entry.
- Registry providers require an explicit `model`; for OrcaRouter use a namespaced id like `anthropic/claude-sonnet-5`.
- It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

---

I'm an engineer on the OrcaRouter team.
