### PR TITLE
fix(fetchurl): support raw Markdown content types

### DIFF
--- a/chunkhound/utils/websearch_core.py
+++ b/chunkhound/utils/websearch_core.py
@@ -9,6 +9,7 @@ sites depend on this neutral module instead of each other.
 from __future__ import annotations
 
 import asyncio
+import base64
 import hashlib
 import html
 import html.parser
@@ -546,7 +547,7 @@ async def _fetch_page(browser: zd.Browser, url: str) -> tuple[str, bytes, str]:
         # is known.
         nav_loader_id: cdp.network.LoaderId | None = None
         candidates: list[cdp.network.ResponseReceived] = []
-        main_response: asyncio.Future[cdp.network.Response] = (
+        main_response: asyncio.Future[cdp.network.ResponseReceived] = (
             asyncio.get_running_loop().create_future()
         )
 
@@ -563,7 +564,7 @@ async def _fetch_page(browser: zd.Browser, url: str) -> tuple[str, bytes, str]:
                 candidates.append(event)
                 return
             if event.loader_id == nav_loader_id:
-                main_response.set_result(event.response)
+                main_response.set_result(event)
 
         # Register the handler BEFORE Network.enable. Events that fire
         # during the enable round-trip would otherwise land before the
@@ -590,10 +591,11 @@ async def _fetch_page(browser: zd.Browser, url: str) -> tuple[str, bytes, str]:
         # loader_id; the ResponseReceived event does).
         for ev in candidates:
             if ev.loader_id == nav_loader_id and not main_response.done():
-                main_response.set_result(ev.response)
+                main_response.set_result(ev)
                 break
 
-        response = await asyncio.wait_for(main_response, timeout=30)
+        response_event = await asyncio.wait_for(main_response, timeout=30)
+        response = response_event.response
         ct = _normalize_ct(
             response.headers.get("content-type")
             or response.headers.get("Content-Type")
@@ -646,6 +648,17 @@ async def _fetch_page(browser: zd.Browser, url: str) -> tuple[str, bytes, str]:
                 _fetch_url, pdf_url, extra, False  # follow_redirects=False
             )
             return "application/pdf", body, "utf-8"
+
+        if ct in {"text/plain", "text/markdown"}:
+            await asyncio.wait_for(tab.wait(), timeout=30)
+            body, base64_encoded = await asyncio.wait_for(
+                tab.send(
+                    cdp.network.get_response_body(request_id=response_event.request_id)
+                ),
+                timeout=30,
+            )
+            body = base64.b64decode(body) if base64_encoded else body.encode("utf-8")
+            return ct, body, response.charset or "utf-8"
 
         if ct != "text/html":
             raise ValueError(f"Unsupported content-type: {ct!r}")
@@ -700,10 +713,14 @@ async def fetch_url_to_content(
             source_metadata["title"] = _extract_html_title(
                 body.decode(charset, errors="replace")
             )
-    elif ct == "text/html":
+    elif ct in {"text/html", "text/plain", "text/markdown"}:
         html_text = body.decode(charset, errors="replace")
-        source_metadata["title"] = _extract_html_title(html_text)
-        kind, content = ".md", _html_to_markdown(html_text)
+        if ct == "text/html":
+            source_metadata["title"] = _extract_html_title(html_text)
+            content = _html_to_markdown(html_text)
+        else:
+            content = html_text
+        kind = ".md"
     else:
         raise ValueError(f"Unsupported content-type: {ct!r}")
     # Auth walls and error pages often render to whitespace-only markdown —

--- a/chunkhound/utils/websearch_core.py
+++ b/chunkhound/utils/websearch_core.py
@@ -24,7 +24,7 @@ import urllib.request
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import IO, TYPE_CHECKING
+from typing import IO, TYPE_CHECKING, Any, cast
 
 from loguru import logger
 
@@ -651,14 +651,26 @@ async def _fetch_page(browser: zd.Browser, url: str) -> tuple[str, bytes, str]:
 
         if ct in {"text/plain", "text/markdown"}:
             await asyncio.wait_for(tab.wait(), timeout=30)
-            body, base64_encoded = await asyncio.wait_for(
-                tab.send(
-                    cdp.network.get_response_body(request_id=response_event.request_id)
+            body_text, base64_encoded = cast(
+                tuple[str, bool],
+                await asyncio.wait_for(
+                    tab.send(
+                        cast(
+                            Any,
+                            cdp.network.get_response_body(
+                                request_id=response_event.request_id
+                            ),
+                        )
+                    ),
+                    timeout=30,
                 ),
-                timeout=30,
             )
-            body = base64.b64decode(body) if base64_encoded else body.encode("utf-8")
-            return ct, body, response.charset or "utf-8"
+            body_bytes = (
+                base64.b64decode(body_text)
+                if base64_encoded
+                else body_text.encode("utf-8")
+            )
+            return ct, body_bytes, "utf-8"
 
         if ct != "text/html":
             raise ValueError(f"Unsupported content-type: {ct!r}")

--- a/chunkhound/utils/websearch_core.py
+++ b/chunkhound/utils/websearch_core.py
@@ -24,13 +24,12 @@ import urllib.request
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, cast
+from typing import IO, TYPE_CHECKING, Any
 
 from loguru import logger
 
 if TYPE_CHECKING:
     from http.client import HTTPMessage
-    from typing import Any
 
     import zendriver as zd
 
@@ -651,19 +650,13 @@ async def _fetch_page(browser: zd.Browser, url: str) -> tuple[str, bytes, str]:
 
         if ct in {"text/plain", "text/markdown"}:
             await asyncio.wait_for(tab.wait(), timeout=30)
-            body_text, base64_encoded = cast(
-                tuple[str, bool],
-                await asyncio.wait_for(
-                    tab.send(
-                        cast(
-                            Any,
-                            cdp.network.get_response_body(
-                                request_id=response_event.request_id
-                            ),
-                        )
-                    ),
-                    timeout=30,
+            body_text, base64_encoded = await asyncio.wait_for(
+                tab.send(
+                    cdp.network.get_response_body(
+                        request_id=response_event.request_id
+                    )
                 ),
+                timeout=30,
             )
             body_bytes = (
                 base64.b64decode(body_text)

--- a/tests/integration/test_websearch_fetch_page.py
+++ b/tests/integration/test_websearch_fetch_page.py
@@ -136,6 +136,20 @@ async def test_fetch_page_html_branch(
     assert final == baseline
 
 
+async def test_fetch_page_plain_text_branch(
+    chrome_browser: zd.Browser,
+    local_fetch_page_server: tuple[str, list[str]],
+) -> None:
+    """Plain-text responses use the raw CDP body instead of rendered DOM."""
+    base, _ = local_fetch_page_server
+
+    ct, body, charset = await _fetch_page(chrome_browser, f"{base}/plain")
+
+    assert ct == "text/plain"
+    assert body == b"# Raw Markdown\n\nserved as plain text\n"
+    assert charset == "utf-8"
+
+
 async def test_fetch_page_pdf_branch(
     chrome_browser: zd.Browser,
     local_fetch_page_server: tuple[str, list[str]],
@@ -202,6 +216,14 @@ def local_fetch_page_server() -> Iterator[tuple[str, list[str]]]:
                 self.send_header("Content-Length", str(len(_MINIMAL_HTML)))
                 self.end_headers()
                 self.wfile.write(_MINIMAL_HTML)
+                return
+            if self.path == "/plain":
+                body = b"# Raw Markdown\n\nserved as plain text\n"
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
                 return
             if self.path == "/pdf":
                 self.send_response(200)

--- a/tests/test_websearch_content_types.py
+++ b/tests/test_websearch_content_types.py
@@ -88,8 +88,6 @@ async def test_fetch_page_reads_raw_text_from_pinned_cdp_response_shape(
     event = SimpleNamespace(
         loader_id="loader", request_id="request", response=response
     )
-    body_result = ("# Raw Markdown\n", False)
-
     class Tab:
         def __init__(self) -> None:
             self.handler = None

--- a/tests/test_websearch_content_types.py
+++ b/tests/test_websearch_content_types.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import sys
+from types import ModuleType, SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
-from chunkhound.utils.websearch_core import fetch_url_to_content
+from chunkhound.utils.websearch_core import _fetch_page, fetch_url_to_content
 
 
 @pytest.mark.asyncio
@@ -27,3 +29,76 @@ async def test_raw_markdown_content_types_are_returned_without_html_rendering(
     assert kind == ".md"
     assert content == body.decode("utf-8")
     assert metadata == {"title": None}
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_reads_raw_text_from_pinned_cdp_response_shape() -> None:
+    class _ResponseReceived:
+        pass
+
+    class Network:
+        ResponseReceived = _ResponseReceived
+
+        @staticmethod
+        def enable() -> str:
+            return "enable"
+
+        @staticmethod
+        def get_response_body(*, request_id: str) -> tuple[str, str]:
+            return ("body", request_id)
+
+    class Page:
+        @staticmethod
+        def navigate(*, url: str) -> tuple[str, str, None]:
+            return ("frame", "loader", None)
+
+    cdp = SimpleNamespace(network=Network, page=Page)
+    zendriver = ModuleType("zendriver")
+    zendriver.cdp = cdp
+
+    response = SimpleNamespace(
+        headers={"content-type": "text/plain; charset=utf-8"},
+        url="https://example.test/raw.md",
+        charset="utf-8",
+    )
+    event = SimpleNamespace(
+        loader_id="loader", request_id="request", response=response
+    )
+    body_result = ("# Raw Markdown\n", False)
+
+    class Tab:
+        def __init__(self) -> None:
+            self.handler = None
+
+        def add_handler(self, event_type, handler) -> None:
+            assert event_type is _ResponseReceived
+            self.handler = handler
+
+        async def send(self, command):
+            if command == "enable":
+                return None
+            if command == ("frame", "loader", None):
+                assert self.handler is not None
+                await self.handler(event)
+                return command
+            assert command == ("body", "request")
+            return body_result
+
+        async def wait(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    tab = Tab()
+
+    class Browser:
+        async def get(self, url: str, *, new_tab: bool):
+            assert url == "about:blank"
+            assert new_tab
+            return tab
+
+    with patch.dict(sys.modules, {"zendriver": zendriver}):
+        result = await _fetch_page(Browser(), "https://example.test/raw.md")
+
+    assert result == ("text/plain", b"# Raw Markdown\n", "utf-8")

--- a/tests/test_websearch_content_types.py
+++ b/tests/test_websearch_content_types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import sys
 from types import ModuleType, SimpleNamespace
 from unittest.mock import patch
@@ -32,25 +33,48 @@ async def test_raw_markdown_content_types_are_returned_without_html_rendering(
 
 
 @pytest.mark.asyncio
-async def test_fetch_page_reads_raw_text_from_pinned_cdp_response_shape() -> None:
+@pytest.mark.parametrize(
+    ("body_result", "expected_body"),
+    [
+        (("# Raw Markdown\n", False), b"# Raw Markdown\n"),
+        (
+            (base64.b64encode(b"# Raw Markdown\n").decode("ascii"), True),
+            b"# Raw Markdown\n",
+        ),
+    ],
+    ids=["plain-body", "base64-body"],
+)
+async def test_fetch_page_reads_raw_text_from_pinned_cdp_response_shape(
+    body_result: tuple[str, bool], expected_body: bytes
+) -> None:
     class _ResponseReceived:
         pass
+
+    class _Command:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    enable_command = _Command("enable")
+    navigate_command = _Command("navigate")
+    body_command = _Command("get_response_body")
 
     class Network:
         ResponseReceived = _ResponseReceived
 
         @staticmethod
-        def enable() -> str:
-            return "enable"
+        def enable() -> _Command:
+            return enable_command
 
         @staticmethod
-        def get_response_body(*, request_id: str) -> tuple[str, str]:
-            return ("body", request_id)
+        def get_response_body(*, request_id: str) -> _Command:
+            assert request_id == "request"
+            return body_command
 
     class Page:
         @staticmethod
-        def navigate(*, url: str) -> tuple[str, str, None]:
-            return ("frame", "loader", None)
+        def navigate(*, url: str) -> _Command:
+            assert url == "https://example.test/raw.md"
+            return navigate_command
 
     cdp = SimpleNamespace(network=Network, page=Page)
     zendriver = ModuleType("zendriver")
@@ -75,14 +99,15 @@ async def test_fetch_page_reads_raw_text_from_pinned_cdp_response_shape() -> Non
             self.handler = handler
 
         async def send(self, command):
-            if command == "enable":
+            if command is enable_command:
                 return None
-            if command == ("frame", "loader", None):
+            if command is navigate_command:
                 assert self.handler is not None
                 await self.handler(event)
-                return command
-            assert command == ("body", "request")
-            return body_result
+                return ("frame", "loader", None)
+            if command is body_command:
+                return body_result
+            raise AssertionError(f"Unexpected command: {command!r}")
 
         async def wait(self) -> None:
             return None
@@ -98,7 +123,11 @@ async def test_fetch_page_reads_raw_text_from_pinned_cdp_response_shape() -> Non
             assert new_tab
             return tab
 
-    with patch.dict(sys.modules, {"zendriver": zendriver}):
-        result = await _fetch_page(Browser(), "https://example.test/raw.md")
+    with patch.object(
+        Network, "get_response_body", return_value=body_command
+    ) as get_body:
+        with patch.dict(sys.modules, {"zendriver": zendriver}):
+            result = await _fetch_page(Browser(), "https://example.test/raw.md")
 
-    assert result == ("text/plain", b"# Raw Markdown\n", "utf-8")
+    get_body.assert_called_once_with(request_id="request")
+    assert result == ("text/plain", expected_body, "utf-8")

--- a/tests/test_websearch_content_types.py
+++ b/tests/test_websearch_content_types.py
@@ -1,0 +1,29 @@
+"""Contract tests for raw Markdown content types in fetchurl."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from chunkhound.utils.websearch_core import fetch_url_to_content
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("content_type", ["text/plain", "text/markdown"])
+async def test_raw_markdown_content_types_are_returned_without_html_rendering(
+    content_type: str,
+) -> None:
+    body = b"# Raw Markdown\n\n**body**\n"
+
+    with patch(
+        "chunkhound.utils.websearch_core._fetch_url",
+        return_value=(content_type, body, "utf-8"),
+    ):
+        kind, content, metadata = await fetch_url_to_content(
+            "https://example.test/raw.md", browser=None
+        )
+
+    assert kind == ".md"
+    assert content == body.decode("utf-8")
+    assert metadata == {"title": None}


### PR DESCRIPTION
## Summary

Fixes #399.

`fetchurl` rejected raw Markdown and plain-text responses because both fetch paths only accepted `text/html` and `application/pdf`. This made raw GitHub Markdown URLs fail with `Unsupported content-type: 'text/plain'`.

The fix:

- accepts `text/plain` and `text/markdown` in the urllib fallback and preserves their decoded body as Markdown;
- uses `Network.getResponseBody` in the CDP path, preserving the original response instead of Chrome's generated `<pre>` DOM;
- handles the exact `(body, base64_encoded)` return shape from the pinned `zendriver==0.15.3` API;
- adds unit coverage for both raw MIME types, a pinned-CDP response-shape regression, and a local HTTP CDP integration route.

## Validation

- `ruff check chunkhound/utils/websearch_core.py tests/test_websearch_content_types.py tests/integration/test_websearch_fetch_page.py` — passed
- `git diff --check` — passed
- focused raw-content tests — 3 passed
- CDP integration tests — 4 skipped because this Windows host's Chrome executable cannot be resolved/launched by `_resolve_chrome_path`
- `mypy chunkhound/utils/websearch_core.py` — repository baseline/environment errors remain; the changed CDP lines are clean after adapting the pinned API. The full dependency environment could not be completed because the locked `pyarrow` download stalled; no production dependency was changed.

The unit test exercises the production `_fetch_page` path with a deterministic fake CDP transport, so the browser-launch limitation does not hide the response-shape regression.
