### PR TITLE
fix(embeddings): match a third OpenAI token-limit error phrasing

### DIFF
--- a/chunkhound/providers/embeddings/openai_provider.py
+++ b/chunkhound/providers/embeddings/openai_provider.py
@@ -1172,12 +1172,19 @@ class OpenAIEmbeddingProvider:
                     # Handle token limit exceeded errors
                     error_message = str(rate_error)
                     if (
-                        "maximum context length" in error_message
-                        and "tokens" in error_message
-                    ) or (
-                        "tokens" in error_message
-                        and "max" in error_message
-                        and "per request" in error_message
+                        (
+                            "maximum context length" in error_message
+                            and "tokens" in error_message
+                        )
+                        or (
+                            "tokens" in error_message
+                            and "max" in error_message
+                            and "per request" in error_message
+                        )
+                        or (
+                            "input length exceeds" in error_message
+                            and "context length" in error_message
+                        )
                     ):
                         total_tokens = self.estimate_batch_tokens(texts)
                         token_limit = (

--- a/tests/unit/test_openai_provider_token_limit.py
+++ b/tests/unit/test_openai_provider_token_limit.py
@@ -1,0 +1,62 @@
+"""Tests for the OpenAI embedding provider's token-limit-error classifier.
+
+Covers the phrase-matching condition in _embed_batch_internal that decides
+whether a BadRequestError should route through handle_token_limit_error's
+split-and-retry path, or propagate as a hard failure.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.unit.provider_test_helpers import _bare_provider, _ok_response
+
+
+class TestTokenLimitClassifier:
+    @pytest.mark.asyncio
+    async def test_input_length_exceeds_context_length_triggers_split_retry(self):
+        """The provider's own reported error phrasing ('input length exceeds
+        the context length') was not covered by either existing condition and
+        propagated as a hard failure instead of triggering split-and-retry.
+        """
+        provider, fake_openai, mod = _bare_provider(retry_attempts=2, retry_delay=0.0)
+
+        call_count = 0
+
+        async def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise fake_openai.BadRequestError(
+                    "Error code: 400 - {'error': {'message': 'the input length "
+                    "exceeds the context length', 'type': 'api_error', "
+                    "'param': None, 'code': None}}"
+                )
+            return _ok_response()
+
+        provider._client = MagicMock()
+        provider._client.embeddings.create = side_effect
+
+        with patch.object(mod, "openai", fake_openai):
+            result = await provider._embed_batch_internal(["hello", "world"])
+
+        assert len(result) == 2
+        # 1 failed call on the original batch + one successful call per split.
+        assert call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_unrelated_bad_request_still_propagates(self):
+        """A BadRequestError that is not a token-limit error must still raise,
+        never silently routed into the split-retry path.
+        """
+        provider, fake_openai, mod = _bare_provider(retry_attempts=2, retry_delay=0.0)
+
+        async def always_fail(*args, **kwargs):
+            raise fake_openai.BadRequestError("invalid api key provided")
+
+        provider._client = MagicMock()
+        provider._client.embeddings.create = always_fail
+
+        with patch.object(mod, "openai", fake_openai):
+            with pytest.raises(fake_openai.BadRequestError):
+                await provider._embed_batch_internal(["hello"])


### PR DESCRIPTION
`_embed_batch_internal`'s token-limit classifier only recognizes two phrasings from the OpenAI API: `"maximum context length"` + `"tokens"`, or `"tokens"` + `"max"` + `"per request"`. The reported error, `the input length exceeds the context length`, matches neither, so it falls through to `raise` instead of routing through the existing split-and-retry logic in `handle_token_limit_error`, and the whole batch fails outright.

This adds a third condition matching `"input length exceeds"` + `"context length"`, following the same style as the two existing ones.

Verification:
- New test (`tests/unit/test_openai_provider_token_limit.py`) reproduces the reported message against a mocked `BadRequestError`: fails on `main` (error propagates), passes on this branch (batch splits and completes). A second test pins that an unrelated `BadRequestError` still raises.
- Full `tests/unit/` suite (1799 tests) passes unchanged.
- `ruff check` / `ruff format --check` clean on the changed lines; `mypy` clean on the changed file.
- I did not build the Rust extension or run the Windows/macOS legs; this change is pure Python and doesn't touch that surface.
